### PR TITLE
fix(daemon): owner-route W5 contention paths

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,16 +4,16 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 997 sites
-- Synchronous `withWriteTx()` sites: 66
-- Synchronous `withReadDb()` sites: 107
-- Async-named parent DB sites: 308
+- Exact ledger inventory: 985 sites
+- Synchronous `withWriteTx()` sites: 65
+- Synchronous `withReadDb()` sites: 106
+- Async-named parent DB sites: 298
 - Synchronous filesystem/process sites: 516
-- Compile-visible legacy DB sites remaining: 173
-  - `withWriteTx`: 66
-  - `withReadDb`: 107
+- Compile-visible legacy DB sites remaining: 171
+  - `withWriteTx`: 65
+  - `withReadDb`: 106
 
-The 997-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 66 synchronous writes, 107 synchronous reads, and 308 async-named parent DB sites are the complete database-call inventory; 173 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 985-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 65 synchronous writes, 106 synchronous reads, and 298 async-named parent DB sites are the complete database-call inventory; 171 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## A3 Slice 2 migration notes
 
@@ -30,4 +30,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 173 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 66 write and 107 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 171 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 65 write and 106 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -36,6 +36,8 @@ import {
 } from "./continuity-state";
 import { listAgentPresence } from "./cross-agent";
 import { getDbAccessor } from "./db-accessor";
+import { getDbOwner } from "./db-owner-runtime";
+import { ownerReadOne } from "./db-owner-sql";
 import { fetchEmbedding } from "./embedding-fetch";
 import {
 	DEFAULT_SESSION_START_MAX_INJECT_TOKENS,
@@ -74,9 +76,9 @@ import {
 import { recordFeedbackTelemetry } from "./pipeline/aspect-feedback";
 import {
 	invalidateTraversalCache,
-	resolveFocalEntities,
+	resolveFocalEntitiesViaOwner,
 	setTraversalStatus,
-	traverseKnowledgeGraph,
+	traverseKnowledgeGraphViaOwner,
 } from "./pipeline/graph-traversal";
 import { estimateTokens } from "./pipeline/tokenizer";
 import { getDefaultPluginHost } from "./plugins/index";
@@ -499,32 +501,31 @@ async function getSessionGapSummary(): Promise<string | undefined> {
 	if (!existsSync(getMemoryDbPath())) return undefined;
 
 	try {
-		return await getDbAccessor().withReadDbAsync(
-			async (db) => {
-				// The completion marker covers explicit ends and daemon recovery/TTL
-				// boundaries; all are settled session activity for this brief.
-				const lastSession = db.prepare("SELECT MAX(completed_at) as last_end FROM session_transcripts").get() as
-					| { last_end: string | null }
-					| undefined;
-
-				if (!lastSession?.last_end) return undefined;
-
-				const lastEnd = lastSession.last_end;
-
-				// Count new memories since last session
-				const memCount = db
-					.prepare("SELECT COUNT(*) as cnt FROM memories WHERE created_at > ? AND is_deleted = 0")
-					.get(lastEnd) as { cnt: number };
-
-				// Count sessions since last session
-				const sessionCount = db
-					.prepare("SELECT COUNT(*) as cnt FROM session_transcripts WHERE completed_at > ?")
-					.get(lastEnd) as { cnt: number };
-
-				return `[since last session: ${memCount.cnt} new memories, ${sessionCount.cnt} sessions captured]`;
+		const row = await ownerReadOne<{
+			readonly last_end: string | null;
+			readonly memory_count: number;
+			readonly session_count: number;
+		}>(
+			await getDbOwner(),
+			`WITH last_session AS (
+				SELECT MAX(completed_at) AS last_end FROM session_transcripts
+			)
+			SELECT
+				last_end,
+				(SELECT COUNT(*) FROM memories WHERE created_at > last_end AND is_deleted = 0) AS memory_count,
+				(SELECT COUNT(*) FROM session_transcripts WHERE completed_at > last_end) AS session_count
+			FROM last_session`,
+			[],
+			{
+				operation: "session-start.session-gap-summary",
+				lane: "read",
+				workloadClass: "foreground",
+				deadlineMs: 5_000,
+				estimatedWorkUnits: 3,
 			},
-			{ siteToken: "hooks.ts:502" },
 		);
+		if (!row?.last_end) return undefined;
+		return `[since last session: ${row.memory_count} new memories, ${row.session_count} sessions captured]`;
 	} catch {
 		return undefined;
 	}
@@ -636,7 +637,7 @@ async function getRecentMemories(
 					}),
 				);
 			},
-			{ siteToken: "hooks.ts:605" },
+			{ siteToken: "hooks.ts:606" },
 		);
 
 		return rows.map((r) => ({
@@ -828,7 +829,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 					});
 					return parent ? assembleInheritedContextBlock(db, parent, subagentCfg) : null;
 				},
-				{ siteToken: "hooks.ts:816" },
+				{ siteToken: "hooks.ts:817" },
 			);
 			inheritedSection = block ?? "";
 		} catch (error) {
@@ -891,23 +892,19 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	if (traversalEnabled) {
 		const _traversalStart = Date.now();
 		try {
-			const focal = await getDbAccessor().withReadDbAsync(
-				async (db) =>
-					resolveFocalEntities(db, traversalAgentId, {
-						project: req.project,
-						sessionKey: req.sessionKey,
-					}),
-				{ siteToken: "hooks.ts:894" },
-			);
+			const owner = await getDbOwner();
+			const focal = await resolveFocalEntitiesViaOwner(owner, traversalAgentId, {
+				project: req.project,
+				sessionKey: req.sessionKey,
+			});
 			traversalFocalSource = focal.source;
 			traversalEntities = focal.entityIds.length;
 			traversalEntityNames = focal.entityNames;
 
 			if (focal.entityIds.length > 0) {
-				const traversalResult = await traverseKnowledgeGraph(
+				const traversalResult = await traverseKnowledgeGraphViaOwner(
 					focal.entityIds,
-					(readFn) =>
-						getDbAccessor().withReadDbAsync(readFn, { siteToken: "hooks.ts:910", operation: "hooks.graph-traversal" }),
+					owner,
 					traversalAgentId,
 					traversalRuntimeCfg,
 				);
@@ -1111,7 +1108,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 				};
 			}),
 	];
-	recordSessionCandidates(req.sessionKey, candidatesForRecording, injectedSet, agentId);
+	await recordSessionCandidates(req.sessionKey, candidatesForRecording, injectedSet, agentId);
 
 	// Format the dynamic context separately from the deterministic system
 	// prefix. The aggregate `inject` field below remains for legacy clients.

--- a/platform/daemon/src/pipeline/graph-traversal.test.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.test.ts
@@ -8,7 +8,14 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { ReadDb } from "../db-accessor";
-import { invalidateTraversalCache, traverseKnowledgeGraph } from "./graph-traversal";
+import type { DbOwnerClient } from "../db-owner-client";
+import type { DbOwnerRequest } from "../db-owner-protocol";
+import {
+	invalidateTraversalCache,
+	resolveFocalEntitiesViaOwner,
+	traverseKnowledgeGraph,
+	traverseKnowledgeGraphViaOwner,
+} from "./graph-traversal";
 
 const CONFIG = {
 	maxAspectsPerEntity: 10,
@@ -54,6 +61,25 @@ function seedGraph(db: Database): void {
 		('a3', 'm-other', 'other', 'active', 'fact', 'other fact', 0.95)`);
 	db.exec(`INSERT INTO entity_dependencies VALUES ('d1', 'e1', 'e2', 'default', 0.9, 0.8)`);
 	db.exec(`INSERT INTO memory_entity_mentions VALUES ('m1', 'e1', 0.9)`);
+}
+
+function createTestOwner(db: Database, operations: string[]): DbOwnerClient {
+	return {
+		submit<Result>(request: DbOwnerRequest, options: { readonly operation: string }) {
+			if (request.kind !== "query") throw new Error("test owner only supports query requests");
+			operations.push(options.operation);
+			const params = request.statement.params ?? [];
+			if (params.some((param) => typeof param === "object")) throw new Error("unexpected test owner byte parameter");
+			const statement = db.prepare(request.statement.sql);
+			const value =
+				request.statement.result === "get"
+					? statement.get(...params)
+					: request.statement.result === "all"
+						? statement.all(...params)
+						: statement.run(...params);
+			return { result: Promise.resolve(value as Result) } as never;
+		},
+	} as unknown as DbOwnerClient;
 }
 
 describe("traverseKnowledgeGraph event-loop yields (#1118)", () => {
@@ -163,5 +189,25 @@ describe("traverseKnowledgeGraph event-loop yields (#1118)", () => {
 		expect(result.memoryIds.size).toBe(0);
 		expect(result.constraints).toEqual([]);
 		expect(activeReads).toBe(0);
+	});
+
+	test("routes focal resolution and traversal through the DB owner adapter", async () => {
+		const operations: string[] = [];
+		const owner = createTestOwner(db, operations);
+		const focal = await resolveFocalEntitiesViaOwner(owner, "default", {
+			checkpointEntityIds: ["e1"],
+			includePinned: false,
+		});
+		const result = await traverseKnowledgeGraphViaOwner(focal.entityIds, owner, "default", CONFIG);
+
+		expect(focal).toEqual({
+			entityIds: ["e1"],
+			entityNames: ["Alpha"],
+			pinnedEntityIds: [],
+			source: "checkpoint",
+		});
+		expect(result.memoryIds.has("m1")).toBe(true);
+		expect(result.memoryIds.has("m3")).toBe(true);
+		expect(operations.every((operation) => operation.startsWith("session-start.graph-"))).toBe(true);
 	});
 });

--- a/platform/daemon/src/pipeline/graph-traversal.test.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.test.ts
@@ -30,7 +30,7 @@ const CONFIG = {
 
 function seedGraph(db: Database): void {
 	db.exec(`
-		CREATE TABLE entities (id TEXT PRIMARY KEY, name TEXT, agent_id TEXT);
+	CREATE TABLE entities (id TEXT PRIMARY KEY, name TEXT, agent_id TEXT, canonical_name TEXT, mentions INTEGER DEFAULT 0);
 		CREATE TABLE entity_aspects (id TEXT PRIMARY KEY, entity_id TEXT, agent_id TEXT, weight REAL, canonical_name TEXT);
 		CREATE TABLE entity_attributes (aspect_id TEXT, memory_id TEXT, agent_id TEXT, status TEXT, kind TEXT, content TEXT, importance REAL);
 		CREATE TABLE entity_dependencies (id TEXT PRIMARY KEY, source_entity_id TEXT, target_entity_id TEXT, agent_id TEXT, confidence REAL, strength REAL);
@@ -41,7 +41,10 @@ function seedGraph(db: Database): void {
 		CREATE INDEX idx_entity_dependencies_source ON entity_dependencies (source_entity_id);
 	`);
 	db.exec(
-		`INSERT INTO entities VALUES ('e1', 'Alpha', 'default'), ('e2', 'Beta', 'default'), ('e3', 'Other', 'other')`,
+		`INSERT INTO entities (id, name, agent_id, canonical_name, mentions) VALUES
+			('e1', 'Alpha', 'default', 'alpha', 2),
+			('e2', 'Beta', 'default', 'beta', 1),
+			('e3', 'Other', 'other', 'other', 1)`,
 	);
 	db.exec(
 		`INSERT INTO entity_aspects VALUES
@@ -209,5 +212,34 @@ describe("traverseKnowledgeGraph event-loop yields (#1118)", () => {
 		expect(result.memoryIds.has("m1")).toBe(true);
 		expect(result.memoryIds.has("m3")).toBe(true);
 		expect(operations.every((operation) => operation.startsWith("session-start.graph-"))).toBe(true);
+	});
+
+	test("falls back to LIKE when the owner FTS index has no matching row", async () => {
+		db.exec("CREATE VIRTUAL TABLE entities_fts USING fts5(name)");
+		const owner = createTestOwner(db, []);
+
+		const focal = await resolveFocalEntitiesViaOwner(owner, "default", {
+			queryTokens: ["alpha"],
+			includePinned: false,
+		});
+
+		expect(focal).toEqual({
+			entityIds: ["e1"],
+			entityNames: ["Alpha"],
+			pinnedEntityIds: [],
+			source: "query",
+		});
+	});
+
+	test("does not disclose a cross-agent checkpoint entity name", async () => {
+		const owner = createTestOwner(db, []);
+
+		const focal = await resolveFocalEntitiesViaOwner(owner, "default", {
+			checkpointEntityIds: ["e3"],
+			includePinned: false,
+		});
+
+		expect(focal.entityIds).toEqual(["e3"]);
+		expect(focal.entityNames).toEqual([]);
 	});
 });

--- a/platform/daemon/src/pipeline/graph-traversal.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.ts
@@ -1,5 +1,7 @@
 import { yieldEvery } from "../async-yield";
 import type { ReadDb } from "../db-accessor";
+import type { DbOwnerClient } from "../db-owner-client";
+import { ownerReadAll } from "../db-owner-sql";
 
 /**
  * Yield cadence for long row loops inside the traversal. Row work is cheap
@@ -68,10 +70,42 @@ export interface TraversalConfig {
  * callers that already own a bounded read scope.
  */
 type ReadDbSource = ReadDb | (<T>(fn: (db: ReadDb) => T) => T) | (<T>(fn: (db: ReadDb) => T) => Promise<T>);
+type ReadAll = <Row extends object>(
+	sql: string,
+	params: readonly unknown[],
+	operation: string,
+	estimatedWorkUnits: number,
+) => Promise<ReadonlyArray<Row>>;
 
 async function withReadDbAsync<T>(source: ReadDbSource, fn: (db: ReadDb) => T): Promise<T> {
 	if (typeof source !== "function") return fn(source);
 	return await source(fn);
+}
+
+function readAllFromSource(source: ReadDbSource): ReadAll {
+	return async <Row extends object>(
+		sql: string,
+		params: readonly unknown[],
+		_operation: string,
+		_estimatedWorkUnits: number,
+	): Promise<ReadonlyArray<Row>> =>
+		await withReadDbAsync(source, (db) => db.prepare(sql).all(...params) as ReadonlyArray<Row>);
+}
+
+function readAllFromOwner(owner: DbOwnerClient): ReadAll {
+	return async <Row extends object>(
+		sql: string,
+		params: readonly unknown[],
+		operation: string,
+		estimatedWorkUnits: number,
+	): Promise<ReadonlyArray<Row>> =>
+		await ownerReadAll<Row>(owner, sql, params, {
+			operation,
+			lane: "read",
+			workloadClass: "foreground",
+			deadlineMs: 5_000,
+			estimatedWorkUnits: Math.max(1, Math.min(1_200, estimatedWorkUnits)),
+		});
 }
 
 export interface FocalEntityResult {
@@ -313,7 +347,7 @@ export function resolveFocalEntities(
 			source = "session_key";
 		}
 
-		const entityIds = sanitizeEntityIds([...pinnedEntityIds, ...resolvedEntityIds]);
+		const entityIds = sanitizeEntityIds([...pinnedEntityIds, ...resolvedEntityIds]).slice(0, 200);
 		return {
 			entityIds,
 			entityNames: getEntityNames(db, entityIds),
@@ -330,9 +364,140 @@ export function resolveFocalEntities(
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Shared path helpers (used by both old and batched traversal paths)
-// ---------------------------------------------------------------------------
+/** Resolve focal entities through the serialized DB owner. */
+export async function resolveFocalEntitiesViaOwner(
+	owner: DbOwnerClient,
+	agentId: string,
+	signals: {
+		project?: string;
+		sessionKey?: string;
+		checkpointEntityIds?: string[];
+		queryTokens?: string[];
+		includePinned?: boolean;
+	},
+): Promise<FocalEntityResult> {
+	const readAll = readAllFromOwner(owner);
+	try {
+		const tableRows = await readAll<{ readonly name: string }>(
+			`SELECT name FROM sqlite_master
+			 WHERE type = 'table'
+			   AND name IN ('entities', 'entity_aspects', 'entity_attributes', 'entity_dependencies')`,
+			[],
+			"session-start.graph-focal.table-check",
+			4,
+		);
+		const tableNames = new Set(tableRows.map((row) => row.name));
+		if (
+			["entities", "entity_aspects", "entity_attributes", "entity_dependencies"].some((name) => !tableNames.has(name))
+		) {
+			return { entityIds: [], entityNames: [], pinnedEntityIds: [], source: "query" };
+		}
+
+		const pinnedEntityIds =
+			signals.includePinned === false
+				? []
+				: (
+						await readAll<{ readonly id: string }>(
+							`SELECT id FROM entities
+							 WHERE agent_id = ?
+							   AND pinned = 1
+							 ORDER BY pinned_at DESC, updated_at DESC
+			 LIMIT 200`,
+							[agentId],
+							"session-start.graph-focal.pinned",
+							200,
+						)
+					).map((row) => row.id);
+		let resolvedEntityIds: string[] = [];
+		let source: FocalEntityResult["source"] = signals.project ? "project" : "query";
+
+		if (signals.checkpointEntityIds && signals.checkpointEntityIds.length > 0) {
+			resolvedEntityIds = sanitizeEntityIds(signals.checkpointEntityIds);
+			source = "checkpoint";
+		} else if (signals.project) {
+			const tokens = extractProjectTokens(signals.project);
+			if (tokens.length > 0) {
+				const clauses = tokens.map(() => "(canonical_name LIKE ? OR name LIKE ?)").join(" OR ");
+				const args: string[] = [];
+				for (const token of tokens) {
+					const pattern = `%${token}%`;
+					args.push(pattern, pattern);
+				}
+				const projectRows = await readAll<{ readonly id: string }>(
+					`SELECT id FROM entities
+					 WHERE agent_id = ?
+					   AND entity_type = 'project'
+					   AND (${clauses})
+					 ORDER BY mentions DESC
+					 LIMIT 5`,
+					[agentId, ...args],
+					"session-start.graph-focal.project",
+					Math.max(1, tokens.length * 5),
+				);
+				resolvedEntityIds = sanitizeEntityIds(projectRows.map((row) => row.id));
+			}
+		}
+
+		if (resolvedEntityIds.length === 0 && signals.queryTokens && signals.queryTokens.length > 0) {
+			const tokens = sanitizeQueryTokens(signals.queryTokens);
+			if (tokens.length > 0) {
+				try {
+					const queryRows = await readAll<{ readonly id: string }>(
+						`SELECT e.id FROM entities_fts
+						 CROSS JOIN entities e ON e.rowid = entities_fts.rowid
+						 WHERE entities_fts MATCH ?
+						   AND e.agent_id = ?
+						 ORDER BY rank
+						 LIMIT 20`,
+						[tokens.join(" OR "), agentId],
+						"session-start.graph-focal.query-fts",
+						20,
+					);
+					resolvedEntityIds = sanitizeEntityIds(queryRows.map((row) => row.id));
+				} catch {
+					const clauses = tokens.map(() => "(canonical_name LIKE ? OR name LIKE ?)").join(" OR ");
+					const args: string[] = [];
+					for (const token of tokens) {
+						const pattern = `%${token}%`;
+						args.push(pattern, pattern);
+					}
+					const queryRows = await readAll<{ readonly id: string }>(
+						`SELECT id FROM entities
+						 WHERE agent_id = ?
+						   AND (${clauses})
+						 ORDER BY mentions DESC
+						 LIMIT 20`,
+						[agentId, ...args],
+						"session-start.graph-focal.query-like",
+						20,
+					);
+					resolvedEntityIds = sanitizeEntityIds(queryRows.map((row) => row.id));
+				}
+				if (resolvedEntityIds.length > 0) source = "query";
+			}
+		}
+
+		if (resolvedEntityIds.length === 0 && signals.sessionKey) source = "session_key";
+		const entityIds = sanitizeEntityIds([...pinnedEntityIds, ...resolvedEntityIds]).slice(0, 200);
+		const entityNameRows =
+			entityIds.length === 0
+				? []
+				: await readAll<{ readonly id: string; readonly name: string }>(
+						`SELECT id, name FROM entities WHERE id IN (${entityIds.map(() => "?").join(", ")})`,
+						entityIds,
+						"session-start.graph-focal.names",
+						entityIds.length,
+					);
+		const nameById = new Map(entityNameRows.map((row) => [row.id, row.name]));
+		const entityNames = entityIds.flatMap((id) => {
+			const name = nameById.get(id);
+			return typeof name === "string" && name.length > 0 ? [name] : [];
+		});
+		return { entityIds, entityNames, pinnedEntityIds, source };
+	} catch {
+		return { entityIds: [], entityNames: [], pinnedEntityIds: [], source: "query" };
+	}
+}
 
 function toPathStatic(
 	entityId: string,
@@ -373,7 +538,7 @@ function pathSize(path: TraversalPath): number {
  * long row loops (#1118) — query shapes and result identity are unchanged.
  */
 async function batchCollectForEntities(
-	db: ReadDbSource,
+	readAll: ReadAll,
 	entityIds: ReadonlyArray<string>,
 	agentId: string,
 	config: TraversalConfig,
@@ -403,29 +568,26 @@ async function batchCollectForEntities(
 	const entityPh = entityIds.map(() => "?").join(", ");
 
 	// --- 1. Batch constraints for all entities ---
-	const constraintRows = await withReadDbAsync(
-		db,
-		(readDb) =>
-			readDb
-				.prepare(
-					`SELECT asp.entity_id, e.name as entity_name, ea.content, ea.importance
-				 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
-				 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
-				   ON ea.aspect_id = asp.id
-				 JOIN entities e ON e.id = asp.entity_id
-				 WHERE asp.entity_id IN (${entityPh})
-				   AND asp.agent_id = ?
-				   AND ea.agent_id = ?
-				   AND ea.kind = 'constraint'
-				   AND ea.status = 'active'
-				 ORDER BY ea.importance DESC`,
-				)
-				.all(...entityIds, agentId, agentId) as Array<{
-				entity_id: string;
-				entity_name: string;
-				content: string;
-				importance: number;
-			}>,
+	const constraintRows = await readAll<{
+		entity_id: string;
+		entity_name: string;
+		content: string;
+		importance: number;
+	}>(
+		`SELECT asp.entity_id, e.name as entity_name, ea.content, ea.importance
+		 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
+		 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
+		   ON ea.aspect_id = asp.id
+		 JOIN entities e ON e.id = asp.entity_id
+		 WHERE asp.entity_id IN (${entityPh})
+		   AND asp.agent_id = ?
+		   AND ea.agent_id = ?
+		   AND ea.kind = 'constraint'
+		   AND ea.status = 'active'
+		 ORDER BY ea.importance DESC`,
+		[...entityIds, agentId, agentId],
+		"session-start.graph-traversal.constraints",
+		Math.max(1, entityIds.length * config.maxAttributesPerAspect),
 	);
 
 	for (const row of constraintRows) {
@@ -458,13 +620,11 @@ async function batchCollectForEntities(
 		aspectArgs = [...entityIds, agentId];
 	}
 
-	const allAspectRows = await withReadDbAsync(
-		db,
-		(readDb) =>
-			readDb.prepare(aspectQuery).all(...aspectArgs) as Array<{
-				id: string;
-				entity_id: string;
-			}>,
+	const allAspectRows = await readAll<{ id: string; entity_id: string }>(
+		aspectQuery,
+		aspectArgs,
+		"session-start.graph-traversal.aspects",
+		Math.max(1, entityIds.length * config.maxAspectsPerEntity),
 	);
 
 	// Apply maxAspectsPerEntity budget by grouping and slicing
@@ -505,44 +665,42 @@ async function batchCollectForEntities(
 		if (config.scope !== undefined) {
 			const scopeClause = config.scope === null ? "AND m.scope IS NULL" : "AND m.scope = ?";
 			const scopeArgs: unknown[] = config.scope === null ? [] : [config.scope];
-			attributeRows = await withReadDbAsync(
-				db,
-				(readDb) =>
-					readDb
-						.prepare(
-							`SELECT ea.memory_id, ea.importance, ea.aspect_id
-						 FROM entity_attributes ea INDEXED BY idx_entity_attributes_aspect
-						 JOIN memories m ON m.id = ea.memory_id
-						 WHERE ea.aspect_id IN (${aspectPh})
-						   AND ea.agent_id = ?
-						   AND ea.status = 'active'
-						   AND m.is_deleted = 0 ${scopeClause}
-						 ORDER BY ea.importance DESC`,
-						)
-						.all(...budgetedAspectIds, agentId, ...scopeArgs) as Array<{
-						memory_id: string | null;
-						importance: number;
-						aspect_id: string;
-					}>,
-			);
+			attributeRows = [
+				...(await readAll<{
+					memory_id: string | null;
+					importance: number;
+					aspect_id: string;
+				}>(
+					`SELECT ea.memory_id, ea.importance, ea.aspect_id
+				 FROM entity_attributes ea INDEXED BY idx_entity_attributes_aspect
+				 JOIN memories m ON m.id = ea.memory_id
+				 WHERE ea.aspect_id IN (${aspectPh})
+				   AND ea.agent_id = ?
+				   AND ea.status = 'active'
+				   AND m.is_deleted = 0 ${scopeClause}
+				 ORDER BY ea.importance DESC`,
+					[...budgetedAspectIds, agentId, ...scopeArgs],
+					"session-start.graph-traversal.attributes",
+					Math.max(1, budgetedAspectIds.length * config.maxAttributesPerAspect),
+				)),
+			];
 		} else {
-			attributeRows = await withReadDbAsync(
-				db,
-				(readDb) =>
-					readDb
-						.prepare(
-							`SELECT memory_id, importance, aspect_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
-						 WHERE aspect_id IN (${aspectPh})
-						   AND agent_id = ?
-						   AND status = 'active'
-						 ORDER BY importance DESC`,
-						)
-						.all(...budgetedAspectIds, agentId) as Array<{
-						memory_id: string | null;
-						importance: number;
-						aspect_id: string;
-					}>,
-			);
+			attributeRows = [
+				...(await readAll<{
+					memory_id: string | null;
+					importance: number;
+					aspect_id: string;
+				}>(
+					`SELECT memory_id, importance, aspect_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
+				 WHERE aspect_id IN (${aspectPh})
+				   AND agent_id = ?
+				   AND status = 'active'
+				 ORDER BY importance DESC`,
+					[...budgetedAspectIds, agentId],
+					"session-start.graph-traversal.attributes",
+					Math.max(1, budgetedAspectIds.length * config.maxAttributesPerAspect),
+				)),
+			];
 		}
 
 		// Apply maxAttributesPerAspect budget and collect memories
@@ -578,45 +736,43 @@ async function batchCollectForEntities(
 		if (config.scope !== undefined) {
 			const scopeClause = config.scope === null ? "AND m.scope IS NULL" : "AND m.scope = ?";
 			const scopeArgs: unknown[] = config.scope === null ? [] : [config.scope];
-			mentionRows = await withReadDbAsync(
-				db,
-				(readDb) =>
-					readDb
-						.prepare(
-							`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
-						 FROM memory_entity_mentions mem
-						 JOIN memories m ON m.id = mem.memory_id
-						 WHERE mem.entity_id IN (${entityPh})
-						   AND m.is_deleted = 0 ${scopeClause}
-						 ORDER BY mem.confidence DESC, m.importance DESC
-						 LIMIT ?`,
-						)
-						.all(...entityIds, ...scopeArgs, mentionBudget) as Array<{
-						memory_id: string;
-						importance: number;
-						entity_id: string;
-					}>,
-			);
+			mentionRows = [
+				...(await readAll<{
+					memory_id: string;
+					importance: number;
+					entity_id: string;
+				}>(
+					`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
+				 FROM memory_entity_mentions mem
+				 JOIN memories m ON m.id = mem.memory_id
+				 WHERE mem.entity_id IN (${entityPh})
+				   AND m.is_deleted = 0 ${scopeClause}
+				 ORDER BY mem.confidence DESC, m.importance DESC
+				 LIMIT ?`,
+					[...entityIds, ...scopeArgs, mentionBudget],
+					"session-start.graph-traversal.mentions",
+					mentionBudget,
+				)),
+			];
 		} else {
-			mentionRows = await withReadDbAsync(
-				db,
-				(readDb) =>
-					readDb
-						.prepare(
-							`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
-						 FROM memory_entity_mentions mem
-						 JOIN memories m ON m.id = mem.memory_id
-						 WHERE mem.entity_id IN (${entityPh})
-						   AND m.is_deleted = 0
-						 ORDER BY mem.confidence DESC, m.importance DESC
-						 LIMIT ?`,
-						)
-						.all(...entityIds, mentionBudget) as Array<{
-						memory_id: string;
-						importance: number;
-						entity_id: string;
-					}>,
-			);
+			mentionRows = [
+				...(await readAll<{
+					memory_id: string;
+					importance: number;
+					entity_id: string;
+				}>(
+					`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
+				 FROM memory_entity_mentions mem
+				 JOIN memories m ON m.id = mem.memory_id
+				 WHERE mem.entity_id IN (${entityPh})
+				   AND m.is_deleted = 0
+				 ORDER BY mem.confidence DESC, m.importance DESC
+				 LIMIT ?`,
+					[...entityIds, mentionBudget],
+					"session-start.graph-traversal.mentions",
+					mentionBudget,
+				)),
+			];
 		}
 
 		for (const row of mentionRows) {
@@ -643,9 +799,9 @@ async function batchCollectForEntities(
  * query stages so concurrent session starts interleave instead of
  * serializing on ~1.7s of uninterrupted main-thread work (large graphs).
  */
-export async function traverseKnowledgeGraph(
+async function traverseKnowledgeGraphWithReadAll(
 	focalEntityIds: ReadonlyArray<string>,
-	db: ReadDbSource,
+	readAll: ReadAll,
 	agentId: string,
 	config: TraversalConfig,
 ): Promise<TraversalResult> {
@@ -661,7 +817,20 @@ export async function traverseKnowledgeGraph(
 	};
 
 	try {
-		if (!(await withReadDbAsync(db, hasTraversalTables))) return empty;
+		const tableRows = await readAll<{ readonly name: string }>(
+			`SELECT name FROM sqlite_master
+			 WHERE type = 'table'
+			   AND name IN ('entities', 'entity_aspects', 'entity_attributes', 'entity_dependencies')`,
+			[],
+			"session-start.graph-traversal.table-check",
+			4,
+		);
+		const tableNames = new Set(tableRows.map((row) => row.name));
+		if (
+			tableRows.length < 4 ||
+			!["entities", "entity_aspects", "entity_attributes", "entity_dependencies"].every((name) => tableNames.has(name))
+		)
+			return empty;
 
 		const focalIds = sanitizeEntityIds(focalEntityIds);
 		if (focalIds.length === 0) return empty;
@@ -672,7 +841,7 @@ export async function traverseKnowledgeGraph(
 		const budget = config.maxTraversalPaths;
 
 		// --- Phase 1: Batch-collect for focal entities ---
-		const phase1 = await batchCollectForEntities(db, focalIds, agentId, config, budget);
+		const phase1 = await batchCollectForEntities(readAll, focalIds, agentId, config, budget);
 		let timedOut = Date.now() > deadline;
 
 		await stageYield();
@@ -680,27 +849,24 @@ export async function traverseKnowledgeGraph(
 		// --- Phase 2: Dependency expansion + batch collect for hops ---
 		if (!timedOut && phase1.memoryIds.size < budget) {
 			const focalPh = focalIds.map(() => "?").join(", ");
-			const dependencyRows = await withReadDbAsync(
-				db,
-				(readDb) =>
-					readDb
-						.prepare(
-							`SELECT id, source_entity_id, target_entity_id FROM entity_dependencies
-						 INDEXED BY idx_entity_dependencies_source
-						 WHERE agent_id = ?
-						   AND source_entity_id IN (${focalPh})
-						   AND (COALESCE(confidence, 0.7) * strength) >= ?
-						   AND COALESCE(confidence, 0.7) >= ?
-						 ORDER BY (COALESCE(confidence, 0.7) * strength) DESC
-						 LIMIT ?`,
-						)
-						.all(
-							agentId,
-							...focalIds,
-							config.minDependencyStrength,
-							config.minConfidence,
-							config.maxBranching * focalIds.length,
-						) as Array<{ id: string; source_entity_id: string; target_entity_id: string }>,
+			const dependencyRows = await readAll<{ id: string; source_entity_id: string; target_entity_id: string }>(
+				`SELECT id, source_entity_id, target_entity_id FROM entity_dependencies
+				 INDEXED BY idx_entity_dependencies_source
+				 WHERE agent_id = ?
+				   AND source_entity_id IN (${focalPh})
+				   AND (COALESCE(confidence, 0.7) * strength) >= ?
+				   AND COALESCE(confidence, 0.7) >= ?
+				 ORDER BY (COALESCE(confidence, 0.7) * strength) DESC
+				 LIMIT ?`,
+				[
+					agentId,
+					...focalIds,
+					config.minDependencyStrength,
+					config.minConfidence,
+					config.maxBranching * focalIds.length,
+				],
+				"session-start.graph-traversal.dependencies",
+				Math.max(1, config.maxBranching * focalIds.length),
 			);
 
 			// Filter to hop targets not already visited
@@ -710,7 +876,7 @@ export async function traverseKnowledgeGraph(
 
 			if (hopTargetIds.length > 0) {
 				const remainingBudget = budget - phase1.memoryIds.size;
-				const phase2 = await batchCollectForEntities(db, hopTargetIds, agentId, config, remainingBudget);
+				const phase2 = await batchCollectForEntities(readAll, hopTargetIds, agentId, config, remainingBudget);
 
 				// Merge phase2 results into phase1
 				for (const mid of phase2.memoryIds) {
@@ -798,4 +964,23 @@ export async function traverseKnowledgeGraph(
 	} catch {
 		return empty;
 	}
+}
+
+export async function traverseKnowledgeGraph(
+	focalEntityIds: ReadonlyArray<string>,
+	db: ReadDbSource,
+	agentId: string,
+	config: TraversalConfig,
+): Promise<TraversalResult> {
+	return await traverseKnowledgeGraphWithReadAll(focalEntityIds, readAllFromSource(db), agentId, config);
+}
+
+/** Traverse graph data through the serialized DB owner, outside the parent DB seam. */
+export async function traverseKnowledgeGraphViaOwner(
+	focalEntityIds: ReadonlyArray<string>,
+	owner: DbOwnerClient,
+	agentId: string,
+	config: TraversalConfig,
+): Promise<TraversalResult> {
+	return await traverseKnowledgeGraphWithReadAll(focalEntityIds, readAllFromOwner(owner), agentId, config);
 }

--- a/platform/daemon/src/pipeline/graph-traversal.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.ts
@@ -279,23 +279,32 @@ function resolveByQueryTokens(db: ReadDb, agentId: string, queryTokens: Readonly
 		// FTS table doesn't exist — fall through to LIKE
 	}
 
-	// LIKE fallback for pre-migration databases
+	return resolveByQueryTokensLike(db, agentId, tokens);
+}
+
+function buildQueryTokenLikeStatement(tokens: ReadonlyArray<string>): {
+	readonly sql: string;
+	readonly params: string[];
+} {
 	const clauses = tokens.map(() => "(canonical_name LIKE ? OR name LIKE ?)").join(" OR ");
 	const args: string[] = [];
 	for (const token of tokens) {
 		const pattern = `%${token}%`;
 		args.push(pattern, pattern);
 	}
-
-	const rows = db
-		.prepare(
-			`SELECT id FROM entities
+	return {
+		sql: `SELECT id FROM entities
 			 WHERE agent_id = ?
 			   AND (${clauses})
 			 ORDER BY mentions DESC
 			 LIMIT 20`,
-		)
-		.all(agentId, ...args) as Array<{ id: string }>;
+		params: args,
+	};
+}
+
+function resolveByQueryTokensLike(db: ReadDb, agentId: string, tokens: ReadonlyArray<string>): string[] {
+	const query = buildQueryTokenLikeStatement(tokens);
+	const rows = db.prepare(query.sql).all(agentId, ...query.params) as Array<{ id: string }>;
 	return sanitizeEntityIds(rows.map((row) => row.id));
 }
 
@@ -441,6 +450,7 @@ export async function resolveFocalEntitiesViaOwner(
 		if (resolvedEntityIds.length === 0 && signals.queryTokens && signals.queryTokens.length > 0) {
 			const tokens = sanitizeQueryTokens(signals.queryTokens);
 			if (tokens.length > 0) {
+				let queryIds: string[] = [];
 				try {
 					const queryRows = await readAll<{ readonly id: string }>(
 						`SELECT e.id FROM entities_fts
@@ -453,26 +463,21 @@ export async function resolveFocalEntitiesViaOwner(
 						"session-start.graph-focal.query-fts",
 						20,
 					);
-					resolvedEntityIds = sanitizeEntityIds(queryRows.map((row) => row.id));
+					queryIds = sanitizeEntityIds(queryRows.map((row) => row.id));
 				} catch {
-					const clauses = tokens.map(() => "(canonical_name LIKE ? OR name LIKE ?)").join(" OR ");
-					const args: string[] = [];
-					for (const token of tokens) {
-						const pattern = `%${token}%`;
-						args.push(pattern, pattern);
-					}
-					const queryRows = await readAll<{ readonly id: string }>(
-						`SELECT id FROM entities
-						 WHERE agent_id = ?
-						   AND (${clauses})
-						 ORDER BY mentions DESC
-						 LIMIT 20`,
-						[agentId, ...args],
+					// FTS is optional on pre-migration databases.
+				}
+				if (queryIds.length === 0) {
+					const likeStatement = buildQueryTokenLikeStatement(tokens);
+					const likeRows = await readAll<{ readonly id: string }>(
+						likeStatement.sql,
+						[agentId, ...likeStatement.params],
 						"session-start.graph-focal.query-like",
 						20,
 					);
-					resolvedEntityIds = sanitizeEntityIds(queryRows.map((row) => row.id));
+					queryIds = sanitizeEntityIds(likeRows.map((row) => row.id));
 				}
+				resolvedEntityIds = queryIds;
 				if (resolvedEntityIds.length > 0) source = "query";
 			}
 		}
@@ -483,8 +488,10 @@ export async function resolveFocalEntitiesViaOwner(
 			entityIds.length === 0
 				? []
 				: await readAll<{ readonly id: string; readonly name: string }>(
-						`SELECT id, name FROM entities WHERE id IN (${entityIds.map(() => "?").join(", ")})`,
-						entityIds,
+						`SELECT id, name FROM entities
+						 WHERE agent_id = ?
+						   AND id IN (${entityIds.map(() => "?").join(", ")})`,
+						[agentId, ...entityIds],
 						"session-start.graph-focal.names",
 						entityIds.length,
 					);

--- a/platform/daemon/src/pipeline/reflection-worker.test.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.test.ts
@@ -93,15 +93,16 @@ function seedReflection(
 	return id;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+	await closeDbAccessor();
 	dir = join(tmpdir(), `signet-reflection-worker-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(join(dir, "memory"), { recursive: true });
 	process.env.SIGNET_PATH = dir;
 	initDbAccessor(join(dir, "memory", "memories.db"));
 });
 
-afterEach(() => {
-	closeDbAccessor();
+afterEach(async () => {
+	await closeDbAccessor();
 	if (previousSignetPath === undefined) {
 		process.env.SIGNET_PATH = undefined;
 	} else {
@@ -484,5 +485,32 @@ describe("reflection worker", () => {
 			{ agent_id: "agent-c", memory_ids: JSON.stringify([memoryId]) },
 		]);
 		expect(existsSync(join(dir, ".daemon", "last-reflection.agent-c.json"))).toBe(true);
+	});
+
+	it("routes active-agent discovery through the DB owner, not parent read seams", async () => {
+		const accessor = getDbAccessor() as unknown as {
+			withReadDb: (...args: never[]) => unknown;
+			withReadDbAsync: (...args: never[]) => Promise<unknown>;
+		};
+		const originalWithReadDb = accessor.withReadDb;
+		const originalWithReadDbAsync = accessor.withReadDbAsync;
+		accessor.withReadDb = () => {
+			throw new Error("reflection worker crossed the parent sync read seam");
+		};
+		accessor.withReadDbAsync = async () => {
+			throw new Error("reflection worker crossed the parent async read seam");
+		};
+		const worker = startReflectionWorker(config, {
+			getDbAccessor,
+			getInferenceProvider: () => provider("SUMMARY: Should not run."),
+			logger,
+		});
+		try {
+			await worker.triggerNow();
+		} finally {
+			worker.stop();
+			accessor.withReadDb = originalWithReadDb;
+			accessor.withReadDbAsync = originalWithReadDbAsync;
+		}
 	});
 });

--- a/platform/daemon/src/pipeline/reflection-worker.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.ts
@@ -3,6 +3,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type PipelineReflectionsConfig, resolveDefaultBasePath, scanMemoryContent } from "@signet/core";
 import { getDbAccessor } from "../db-accessor";
+import { getDbOwner } from "../db-owner-runtime";
+import { ownerReadAll } from "../db-owner-sql";
 import { getInferenceProvider } from "../llm";
 import { logger } from "../logger";
 import { isMemoryContentContextEligible } from "../memory-content-safety";
@@ -393,7 +395,7 @@ export function collectReflectionContext(
 				tags: r.tags ?? "",
 				createdAt: r.created_at,
 			}));
-	}, "pipeline/reflection-worker.ts:366");
+	}, "pipeline/reflection-worker.ts:368");
 
 	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 	const existingReflections = dbAccessor.withReadDb((db: import("../db-accessor").ReadDb) => {
@@ -411,7 +413,7 @@ export function collectReflectionContext(
 					(row.question === null || scanMemoryContent(row.question).contextEligible),
 			)
 			.map((r) => ({ id: r.id, question: r.question, summary: r.summary, createdAt: r.created_at }));
-	}, "pipeline/reflection-worker.ts:399");
+	}, "pipeline/reflection-worker.ts:401");
 
 	return { memories, summaries: [], transcripts: [], graphFacts: [], existingReflections };
 }
@@ -483,7 +485,7 @@ export async function generateDailyBriefInsights(
 				);
 			if (result.changes > 0) ids.push(id);
 		}
-	}, "pipeline/reflection-worker.ts:461");
+	}, "pipeline/reflection-worker.ts:463");
 
 	return ids;
 }
@@ -520,25 +522,27 @@ export function startReflectionWorker(
 		}
 	}
 
-	function listActiveAgentIds(): string[] {
-		const rows: Array<{ agent_id: string | null }> = deps
-			.getDbAccessor()
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			.withReadDb((db: import("../db-accessor").ReadDb) => {
-				return db
-					.prepare(
-						`SELECT DISTINCT agent_id FROM memories
-					 WHERE is_deleted = 0`,
-					)
-					.all() as { agent_id: string | null }[];
-			}, "pipeline/reflection-worker.ts:527");
+	async function listActiveAgentIds(): Promise<string[]> {
+		const rows = await ownerReadAll<{ readonly agent_id: string | null }>(
+			await getDbOwner(),
+			`SELECT DISTINCT agent_id FROM memories
+			 WHERE is_deleted = 0`,
+			[],
+			{
+				operation: "pipeline.reflection-worker.list-active-agent-ids",
+				lane: "read",
+				workloadClass: "foreground",
+				deadlineMs: 5_000,
+				estimatedWorkUnits: 100,
+			},
+		);
 		const agentIds = rows.map((row) => row.agent_id).filter((agentId): agentId is string => !!agentId);
 		return agentIds.length > 0 ? agentIds : ["default"];
 	}
 
 	async function runDueAgents(): Promise<void> {
 		const date = todayDateInTimeZone(config.timezone);
-		for (const agentId of listActiveAgentIds()) {
+		for (const agentId of await listActiveAgentIds()) {
 			const lastDate = readLastReflectionTime(agentId);
 			if (lastDate !== date && nextReflectionDelayMs(config.schedule, config.timezone, lastDate) === POLL_INTERVAL_MS) {
 				await runReflection(agentId);
@@ -546,12 +550,25 @@ export function startReflectionWorker(
 		}
 	}
 
-	function nextWorkerDelayMs(): number {
+	async function nextWorkerDelayMs(): Promise<number> {
+		const agentIds = await listActiveAgentIds();
 		return Math.min(
-			...listActiveAgentIds().map((agentId) =>
+			...agentIds.map((agentId) =>
 				nextReflectionDelayMs(config.schedule, config.timezone, readLastReflectionTime(agentId)),
 			),
 		);
+	}
+
+	async function scheduleNextTick(): Promise<void> {
+		try {
+			const delayMs = await nextWorkerDelayMs();
+			if (!stopped) timer = setTimeout(() => void tick(), delayMs);
+		} catch (e) {
+			deps.logger.warn("reflections", "Scheduling failed; using polling interval", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+			if (!stopped) timer = setTimeout(() => void tick(), POLL_INTERVAL_MS);
+		}
 	}
 
 	async function tick(): Promise<void> {
@@ -561,16 +578,14 @@ export function startReflectionWorker(
 			await runDueAgents();
 		} finally {
 			generating = false;
-			if (!stopped) {
-				timer = setTimeout(tick, nextWorkerDelayMs());
-			}
+			if (!stopped) void scheduleNextTick();
 		}
 	}
 
 	function start(): void {
 		if (running) return;
 		running = true;
-		timer = setTimeout(tick, nextWorkerDelayMs());
+		void scheduleNextTick();
 	}
 
 	function stop(): void {

--- a/platform/daemon/src/session-memories.test.ts
+++ b/platform/daemon/src/session-memories.test.ts
@@ -16,7 +16,7 @@ import { join } from "node:path";
 const TEST_DIR = join(tmpdir(), `signet-session-mem-test-${Date.now()}`);
 process.env.SIGNET_PATH = TEST_DIR;
 
-const { initDbAccessor, closeDbAccessor } = await import("./db-accessor");
+const { initDbAccessor, closeDbAccessor, getDbAccessor } = await import("./db-accessor");
 const { recordSessionCandidates, trackFtsHits, parseFeedback, recordAgentFeedbackInner } = await import(
 	"./session-memories"
 );
@@ -29,7 +29,7 @@ function ensureDir(path: string): void {
 	mkdirSync(path, { recursive: true });
 }
 
-function setupDb(): Database {
+async function setupDb(): Promise<Database> {
 	const dbPath = join(TEST_DIR, "memory", "memories.db");
 	ensureDir(join(TEST_DIR, "memory"));
 	if (existsSync(dbPath)) rmSync(dbPath);
@@ -49,7 +49,7 @@ function setupDb(): Database {
 	stmt.run("mem-bbb-222", "Project uses TypeScript", now, now);
 	stmt.run("mem-ccc-333", "Bun is the package manager", now, now);
 
-	closeDbAccessor();
+	await closeDbAccessor();
 	initDbAccessor(dbPath);
 
 	return db;
@@ -104,15 +104,15 @@ function getSessionMemoryRows(
 
 let db: Database;
 
-beforeEach(() => {
+beforeEach(async () => {
 	if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
 	ensureDir(TEST_DIR);
-	db = setupDb();
+	db = await setupDb();
 });
 
-afterEach(() => {
+afterEach(async () => {
 	db.close();
-	closeDbAccessor();
+	await closeDbAccessor();
 	if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -121,7 +121,7 @@ afterEach(() => {
 // ============================================================================
 
 describe("recordSessionCandidates", () => {
-	it("inserts candidate rows with correct was_injected flags", () => {
+	it("inserts candidate rows with correct was_injected flags", async () => {
 		const candidates = [
 			{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const },
 			{ id: "mem-bbb-222", effScore: 0.7, source: "effective" as const },
@@ -129,7 +129,7 @@ describe("recordSessionCandidates", () => {
 		];
 		const injectedIds = new Set(["mem-aaa-111", "mem-bbb-222"]);
 
-		recordSessionCandidates("session-001", candidates, injectedIds);
+		await recordSessionCandidates("session-001", candidates, injectedIds);
 
 		const testDb = openTestDb();
 		const rows = getSessionMemoryRows(testDb, "session-001");
@@ -144,13 +144,43 @@ describe("recordSessionCandidates", () => {
 		expect(notInjected[0].memory_id).toBe("mem-ccc-333");
 	});
 
-	it("sets rank in order", () => {
+	it("routes the batched write through the DB owner, not parent write seams", async () => {
+		const accessor = getDbAccessor() as unknown as {
+			withWriteTx: (...args: never[]) => unknown;
+			withWriteTxAsync: (...args: never[]) => Promise<unknown>;
+		};
+		const originalWithWriteTx = accessor.withWriteTx;
+		const originalWithWriteTxAsync = accessor.withWriteTxAsync;
+		accessor.withWriteTx = () => {
+			throw new Error("session candidates crossed the parent sync write seam");
+		};
+		accessor.withWriteTxAsync = async () => {
+			throw new Error("session candidates crossed the parent async write seam");
+		};
+		try {
+			await recordSessionCandidates(
+				"session-owner-001",
+				[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
+				new Set(["mem-aaa-111"]),
+			);
+
+			const testDb = openTestDb();
+			const rows = getSessionMemoryRows(testDb, "session-owner-001");
+			testDb.close();
+			expect(rows.map((row) => row.memory_id)).toEqual(["mem-aaa-111"]);
+		} finally {
+			accessor.withWriteTx = originalWithWriteTx;
+			accessor.withWriteTxAsync = originalWithWriteTxAsync;
+		}
+	});
+
+	it("sets rank in order", async () => {
 		const candidates = [
 			{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const },
 			{ id: "mem-bbb-222", effScore: 0.7, source: "effective" as const },
 		];
 
-		recordSessionCandidates("session-002", candidates, new Set(["mem-aaa-111"]));
+		await recordSessionCandidates("session-002", candidates, new Set(["mem-aaa-111"]));
 
 		const testDb = openTestDb();
 		const rows = getSessionMemoryRows(testDb, "session-002");
@@ -160,10 +190,10 @@ describe("recordSessionCandidates", () => {
 		expect(rows[1].rank).toBe(1);
 	});
 
-	it("stores effective_score and final_score", () => {
+	it("stores effective_score and final_score", async () => {
 		const candidates = [{ id: "mem-aaa-111", effScore: 0.85, source: "effective" as const }];
 
-		recordSessionCandidates("session-003", candidates, new Set(["mem-aaa-111"]));
+		await recordSessionCandidates("session-003", candidates, new Set(["mem-aaa-111"]));
 
 		const testDb = openTestDb();
 		const rows = getSessionMemoryRows(testDb, "session-003");
@@ -173,7 +203,7 @@ describe("recordSessionCandidates", () => {
 		expect(rows[0].final_score).toBeCloseTo(0.85, 2);
 	});
 
-	it("stores path_json when provided", () => {
+	it("stores path_json when provided", async () => {
 		const candidates = [
 			{
 				id: "mem-aaa-111",
@@ -187,7 +217,7 @@ describe("recordSessionCandidates", () => {
 			},
 		];
 
-		recordSessionCandidates("session-path-001", candidates, new Set(["mem-aaa-111"]));
+		await recordSessionCandidates("session-path-001", candidates, new Set(["mem-aaa-111"]));
 
 		const testDb = openTestDb();
 		const rows = getSessionMemoryRows(testDb, "session-path-001");
@@ -197,10 +227,10 @@ describe("recordSessionCandidates", () => {
 		expect(rows[0].path_json).toContain("entity_ids");
 	});
 
-	it("stores provided agent_id", () => {
+	it("stores provided agent_id", async () => {
 		const candidates = [{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }];
 
-		recordSessionCandidates("session-agent-001", candidates, new Set(["mem-aaa-111"]), "agent-a");
+		await recordSessionCandidates("session-agent-001", candidates, new Set(["mem-aaa-111"]), "agent-a");
 
 		const testDb = openTestDb();
 		const rows = getSessionMemoryRows(testDb, "session-agent-001");
@@ -210,11 +240,11 @@ describe("recordSessionCandidates", () => {
 		expect(rows[0].agent_id).toBe("agent-a");
 	});
 
-	it("is idempotent (INSERT OR IGNORE on duplicate session+memory)", () => {
+	it("is idempotent (INSERT OR IGNORE on duplicate session+memory)", async () => {
 		const candidates = [{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }];
 
-		recordSessionCandidates("session-004", candidates, new Set(["mem-aaa-111"]));
-		recordSessionCandidates("session-004", candidates, new Set(["mem-aaa-111"]));
+		await recordSessionCandidates("session-004", candidates, new Set(["mem-aaa-111"]));
+		await recordSessionCandidates("session-004", candidates, new Set(["mem-aaa-111"]));
 
 		const testDb = openTestDb();
 		const rows = getSessionMemoryRows(testDb, "session-004");
@@ -223,10 +253,10 @@ describe("recordSessionCandidates", () => {
 		expect(rows.length).toBe(1);
 	});
 
-	it("bails on undefined sessionKey", () => {
+	it("bails on undefined sessionKey", async () => {
 		const candidates = [{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }];
 
-		recordSessionCandidates(undefined, candidates, new Set(["mem-aaa-111"]));
+		await recordSessionCandidates(undefined, candidates, new Set(["mem-aaa-111"]));
 
 		const testDb = openTestDb();
 		const count = testDb.prepare("SELECT COUNT(*) as cnt FROM session_memories").get() as { cnt: number };
@@ -235,8 +265,8 @@ describe("recordSessionCandidates", () => {
 		expect(count.cnt).toBe(0);
 	});
 
-	it("bails on empty candidates array", () => {
-		recordSessionCandidates("session-005", [], new Set());
+	it("bails on empty candidates array", async () => {
+		await recordSessionCandidates("session-005", [], new Set());
 
 		const testDb = openTestDb();
 		const count = testDb.prepare("SELECT COUNT(*) as cnt FROM session_memories").get() as { cnt: number };
@@ -245,10 +275,10 @@ describe("recordSessionCandidates", () => {
 		expect(count.cnt).toBe(0);
 	});
 
-	it("sets source field correctly", () => {
+	it("sets source field correctly", async () => {
 		const candidates = [{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }];
 
-		recordSessionCandidates("session-006", candidates, new Set(["mem-aaa-111"]));
+		await recordSessionCandidates("session-006", candidates, new Set(["mem-aaa-111"]));
 
 		const testDb = openTestDb();
 		const rows = getSessionMemoryRows(testDb, "session-006");
@@ -263,8 +293,8 @@ describe("recordSessionCandidates", () => {
 // ============================================================================
 
 describe("trackFtsHits", () => {
-	it("increments fts_hit_count for existing candidate rows", () => {
-		recordSessionCandidates(
+	it("increments fts_hit_count for existing candidate rows", async () => {
+		await recordSessionCandidates(
 			"session-fts-1",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -281,8 +311,8 @@ describe("trackFtsHits", () => {
 		expect(rows[0].source).toBe("effective");
 	});
 
-	it("increments multiple times", () => {
-		recordSessionCandidates(
+	it("increments multiple times", async () => {
+		await recordSessionCandidates(
 			"session-fts-2",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -299,14 +329,14 @@ describe("trackFtsHits", () => {
 		expect(rows[0].fts_hit_count).toBe(3);
 	});
 
-	it("tracks fts hits per agent for same session+memory", () => {
-		recordSessionCandidates(
+	it("tracks fts hits per agent for same session+memory", async () => {
+		await recordSessionCandidates(
 			"session-fts-agent",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
 			"agent-a",
 		);
-		recordSessionCandidates(
+		await recordSessionCandidates(
 			"session-fts-agent",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -348,7 +378,7 @@ describe("trackFtsHits", () => {
 		expect(rows[0].fts_hit_count).toBe(1);
 	});
 
-	it("bails on undefined sessionKey", () => {
+	it("bails on undefined sessionKey", async () => {
 		trackFtsHits(undefined, ["mem-aaa-111"]);
 
 		const testDb = openTestDb();
@@ -368,8 +398,8 @@ describe("trackFtsHits", () => {
 		expect(count.cnt).toBe(0);
 	});
 
-	it("handles mix of existing and new memory IDs", () => {
-		recordSessionCandidates(
+	it("handles mix of existing and new memory IDs", async () => {
+		await recordSessionCandidates(
 			"session-fts-5",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -472,8 +502,8 @@ function getFeedbackColumns(
 }
 
 describe("recordAgentFeedbackInner", () => {
-	it("sets score on first feedback (NULL -> score)", () => {
-		recordSessionCandidates(
+	it("sets score on first feedback (NULL -> score)", async () => {
+		await recordSessionCandidates(
 			"session-fb-1",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -490,8 +520,8 @@ describe("recordAgentFeedbackInner", () => {
 		expect(result?.agent_feedback_count).toBe(1);
 	});
 
-	it("computes running mean on second feedback", () => {
-		recordSessionCandidates(
+	it("computes running mean on second feedback", async () => {
+		await recordSessionCandidates(
 			"session-fb-2",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -509,8 +539,8 @@ describe("recordAgentFeedbackInner", () => {
 		expect(result?.agent_feedback_count).toBe(2);
 	});
 
-	it("multiple feedbacks converge to the mean", () => {
-		recordSessionCandidates(
+	it("multiple feedbacks converge to the mean", async () => {
+		await recordSessionCandidates(
 			"session-fb-3",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -530,8 +560,8 @@ describe("recordAgentFeedbackInner", () => {
 		expect(result?.agent_feedback_count).toBe(5);
 	});
 
-	it("handles multiple memories in one feedback call", () => {
-		recordSessionCandidates(
+	it("handles multiple memories in one feedback call", async () => {
+		await recordSessionCandidates(
 			"session-fb-4",
 			[
 				{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const },
@@ -554,8 +584,8 @@ describe("recordAgentFeedbackInner", () => {
 		expect(b?.agent_relevance_score).toBeCloseTo(-0.5, 6);
 	});
 
-	it("ignores feedback for non-existent session memories", () => {
-		recordSessionCandidates(
+	it("ignores feedback for non-existent session memories", async () => {
+		await recordSessionCandidates(
 			"session-fb-5",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -576,13 +606,13 @@ describe("recordAgentFeedbackInner", () => {
 		expect(ghost).toBeFalsy();
 	});
 
-	it("feedback for wrong session does not affect other sessions", () => {
-		recordSessionCandidates(
+	it("feedback for wrong session does not affect other sessions", async () => {
+		await recordSessionCandidates(
 			"session-fb-6a",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
 		);
-		recordSessionCandidates(
+		await recordSessionCandidates(
 			"session-fb-6b",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -599,14 +629,14 @@ describe("recordAgentFeedbackInner", () => {
 		expect(b?.agent_relevance_score).toBeNull();
 	});
 
-	it("feedback is scoped by agent_id", () => {
-		recordSessionCandidates(
+	it("feedback is scoped by agent_id", async () => {
+		await recordSessionCandidates(
 			"session-fb-agent",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
 			"agent-a",
 		);
-		recordSessionCandidates(
+		await recordSessionCandidates(
 			"session-fb-agent",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -624,8 +654,8 @@ describe("recordAgentFeedbackInner", () => {
 		expect(b?.agent_relevance_score).toBeNull();
 	});
 
-	it("handles negative scores correctly", () => {
-		recordSessionCandidates(
+	it("handles negative scores correctly", async () => {
+		await recordSessionCandidates(
 			"session-fb-7",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),
@@ -643,8 +673,8 @@ describe("recordAgentFeedbackInner", () => {
 		expect(result?.agent_feedback_count).toBe(2);
 	});
 
-	it("empty feedback object is a no-op", () => {
-		recordSessionCandidates(
+	it("empty feedback object is a no-op", async () => {
+		await recordSessionCandidates(
 			"session-fb-8",
 			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
 			new Set(["mem-aaa-111"]),

--- a/platform/daemon/src/session-memories.ts
+++ b/platform/daemon/src/session-memories.ts
@@ -10,6 +10,9 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { resolveDefaultBasePath } from "@signet/core";
 import { type WriteDb, getDbAccessor } from "./db-accessor";
+import { getDbOwner } from "./db-owner-runtime";
+import { DB_OWNER_MAX_TRANSACTION_STATEMENTS } from "./db-owner-protocol";
+import { ownerBatch } from "./db-owner-sql";
 import { logger } from "./logger";
 
 function getMemoryDbPath(): string {
@@ -46,75 +49,68 @@ export interface SessionMemoryCandidate {
  * between Bun and SQLite. Records are processed in chunks of 50 to
  * stay safely within SQLite's parameter limits.
  */
-export function recordSessionCandidates(
+export async function recordSessionCandidates(
 	sessionKey: string | undefined,
 	candidates: ReadonlyArray<SessionMemoryCandidate>,
 	injectedIds: ReadonlySet<string>,
 	agentId = "default",
-): void {
+): Promise<void> {
 	if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;
 
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
-			const now = new Date().toISOString();
-			const CHUNK_SIZE = 50;
-			const ROW = "(?,?,?,?,?,?,?,?,?,0,?,?,?,?,?,?)";
-			const BASE_SQL = `INSERT OR IGNORE INTO session_memories
-					 (id, session_key, agent_id, memory_id, source, effective_score,
-					  final_score, rank, was_injected,
-					  fts_hit_count, created_at,
-					  entity_slot, aspect_slot, is_constraint, structural_density,
-					  path_json)
-					 VALUES `;
+		const owner = await getDbOwner();
+		const now = new Date().toISOString();
+		const CHUNK_SIZE = 50;
+		const ROW = "(?,?,?,?,?,?,?,?,?,0,?,?,?,?,?,?)";
+		const BASE_SQL = `INSERT OR IGNORE INTO session_memories
+			 (id, session_key, agent_id, memory_id, source, effective_score,
+			  final_score, rank, was_injected,
+			  fts_hit_count, created_at,
+			  entity_slot, aspect_slot, is_constraint, structural_density,
+			  path_json)
+			 VALUES `;
+		const statements: Array<{ readonly sql: string; readonly params: readonly unknown[] }> = [];
+		let rank = 0;
 
-			// Pre-compile the full-chunk statement once to avoid recompiling
-			// identical SQL on every iteration of the loop.
-			const fullChunkStmt =
-				candidates.length >= CHUNK_SIZE
-					? db.prepare(BASE_SQL + Array.from({ length: CHUNK_SIZE }, () => ROW).join(","))
-					: null;
-
-			let rank = 0;
-			for (let i = 0; i < candidates.length; i += CHUNK_SIZE) {
-				const chunk = candidates.slice(i, i + CHUNK_SIZE);
-
-				// Reuse pre-compiled statement for full chunks; compile once for
-				// the remainder chunk (different SQL, can't reuse).
-				let stmt: NonNullable<typeof fullChunkStmt>;
-				if (chunk.length === CHUNK_SIZE) {
-					if (!fullChunkStmt) throw new Error("full session-memory statement was not prepared");
-					stmt = fullChunkStmt;
-				} else {
-					stmt = db.prepare(BASE_SQL + Array.from({ length: chunk.length }, () => ROW).join(","));
-				}
-
-				const values: unknown[] = [];
-				for (const c of chunk) {
-					const wasInjected = injectedIds.has(c.id) ? 1 : 0;
-					const finalScore = c.finalScore ?? c.effScore;
-					values.push(
-						crypto.randomUUID(),
-						sessionKey,
-						agentId,
-						c.id,
-						c.source,
-						c.effScore,
-						finalScore,
-						rank++,
-						wasInjected,
-						now,
-						c.entitySlot ?? null,
-						c.aspectSlot ?? null,
-						c.isConstraint ?? 0,
-						c.structuralDensity ?? null,
-						c.pathJson ?? null,
-					);
-				}
-
-				stmt.run(...values);
+		for (let i = 0; i < candidates.length; i += CHUNK_SIZE) {
+			const chunk = candidates.slice(i, i + CHUNK_SIZE);
+			const values: unknown[] = [];
+			for (const c of chunk) {
+				const wasInjected = injectedIds.has(c.id) ? 1 : 0;
+				const finalScore = c.finalScore ?? c.effScore;
+				values.push(
+					crypto.randomUUID(),
+					sessionKey,
+					agentId,
+					c.id,
+					c.source,
+					c.effScore,
+					finalScore,
+					rank++,
+					wasInjected,
+					now,
+					c.entitySlot ?? null,
+					c.aspectSlot ?? null,
+					c.isConstraint ?? 0,
+					c.structuralDensity ?? null,
+					c.pathJson ?? null,
+				);
 			}
-		}, "session-memories.ts:59");
+			statements.push({
+				sql: BASE_SQL + Array.from({ length: chunk.length }, () => ROW).join(","),
+				params: values,
+			});
+		}
+
+		for (let i = 0; i < statements.length; i += DB_OWNER_MAX_TRANSACTION_STATEMENTS) {
+			await ownerBatch(owner, statements.slice(i, i + DB_OWNER_MAX_TRANSACTION_STATEMENTS), {
+				operation: "session-start.session-memories.record-candidates",
+				lane: "write",
+				workloadClass: "foreground",
+				deadlineMs: 5_000,
+				estimatedWorkUnits: Math.max(1, Math.min(1_200, candidates.length)),
+			});
+		}
 
 		logger.debug("session-memories", "Recorded session candidates", {
 			sessionKey,
@@ -188,7 +184,7 @@ export function trackFtsHits(
 
 				stmt.run(...values);
 			}
-		}, "session-memories.ts:153");
+		}, "session-memories.ts:149");
 	} catch (e) {
 		logger.warn("session-memories", "Failed to track FTS hits", {
 			error: e instanceof Error ? e.message : String(e),
@@ -267,7 +263,7 @@ export function recordAgentFeedback(
 		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
 		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
 			recordAgentFeedbackInner(db, sessionKey, feedback, agentId);
-		}, "session-memories.ts:268");
+		}, "session-memories.ts:264");
 
 		logger.debug("session-memories", "Recorded agent feedback", {
 			sessionKey,

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(997);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(66);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(107);
+	expect(baseline).toHaveLength(985);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(106);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(68);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(235);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(225);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -327,8 +327,8 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 175, withWriteTx: 66, withReadDb: 109 });
-	expect(report).toContain("Exact ledger inventory: 997 sites");
-	expect(report).toContain("66 synchronous writes, 107 synchronous reads, and 308 async-named parent DB sites");
+	expect(report).toContain("Exact ledger inventory: 985 sites");
+	expect(report).toContain("65 synchronous writes, 106 synchronous reads, and 298 async-named parent DB sites");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1369,98 +1369,77 @@
     },
     {
       "path": "hooks.ts",
-      "line": 499,
+      "line": 501,
       "api": "existsSync",
       "source": "if (!existsSync(getMemoryDbPath())) return undefined;",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 502,
-      "api": "withReadDbAsync",
-      "source": "return await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 602,
+      "line": 603,
       "api": "existsSync",
       "source": "if (!existsSync(getMemoryDbPath())) return [];",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 605,
+      "line": 606,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 813,
+      "line": 814,
       "api": "existsSync",
       "source": "if (req.sessionKey && existsSync(getMemoryDbPath())) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 816,
+      "line": 817,
       "api": "withReadDbAsync",
       "source": "const block = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 894,
-      "api": "withReadDbAsync",
-      "source": "const focal = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 910,
-      "api": "withReadDbAsync",
-      "source": "getDbAccessor().withReadDbAsync(readFn, { siteToken: \"hooks.ts:910\", operation: \"hooks.graph-traversal\" }),",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 1673,
+      "line": 1670,
       "api": "existsSync",
       "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 1675,
+      "line": 1672,
       "api": "readFileSync",
       "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2083,
+      "line": 2080,
       "api": "existsSync",
       "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2085,
+      "line": 2082,
       "api": "readFileSync",
       "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2347,
+      "line": 2344,
       "api": "existsSync",
       "source": "} else if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2349,
+      "line": 2346,
       "api": "readFileSync",
       "source": "const raw = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
@@ -3329,58 +3308,9 @@
     },
     {
       "path": "pipeline/graph-traversal.ts",
-      "line": 406,
+      "line": 92,
       "api": "withReadDbAsync",
-      "source": "const constraintRows = await withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/graph-traversal.ts",
-      "line": 461,
-      "api": "withReadDbAsync",
-      "source": "const allAspectRows = await withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/graph-traversal.ts",
-      "line": 508,
-      "api": "withReadDbAsync",
-      "source": "attributeRows = await withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/graph-traversal.ts",
-      "line": 529,
-      "api": "withReadDbAsync",
-      "source": "attributeRows = await withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/graph-traversal.ts",
-      "line": 581,
-      "api": "withReadDbAsync",
-      "source": "mentionRows = await withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/graph-traversal.ts",
-      "line": 601,
-      "api": "withReadDbAsync",
-      "source": "mentionRows = await withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/graph-traversal.ts",
-      "line": 664,
-      "api": "withReadDbAsync",
-      "source": "if (!(await withReadDbAsync(db, hasTraversalTables))) return empty;",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/graph-traversal.ts",
-      "line": 683,
-      "api": "withReadDbAsync",
-      "source": "const dependencyRows = await withReadDbAsync(",
+      "source": "await withReadDbAsync(source, (db) => db.prepare(sql).all(...params) as ReadonlyArray<Row>);",
       "category": "hot-path"
     },
     {
@@ -3504,58 +3434,51 @@
     },
     {
       "path": "pipeline/reflection-worker.ts",
-      "line": 39,
+      "line": 41,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return null;",
       "category": "hot-path"
     },
     {
       "path": "pipeline/reflection-worker.ts",
-      "line": 40,
+      "line": 42,
       "api": "readFileSync",
       "source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "pipeline/reflection-worker.ts",
-      "line": 50,
+      "line": 52,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "pipeline/reflection-worker.ts",
-      "line": 51,
+      "line": 53,
       "api": "writeFileSync",
       "source": "writeFileSync(getLastReflectionPath(agentId), JSON.stringify({ lastDate: date }));",
       "category": "hot-path"
     },
     {
       "path": "pipeline/reflection-worker.ts",
-      "line": 366,
+      "line": 368,
       "api": "withReadDb",
       "source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
       "path": "pipeline/reflection-worker.ts",
-      "line": 399,
+      "line": 401,
       "api": "withReadDb",
       "source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
       "path": "pipeline/reflection-worker.ts",
-      "line": 461,
+      "line": 463,
       "api": "withWriteTx",
       "source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 527,
-      "api": "withReadDb",
-      "source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -5947,42 +5870,35 @@
     },
     {
       "path": "session-memories.ts",
-      "line": 55,
+      "line": 58,
       "api": "existsSync",
       "source": "if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;",
       "category": "hot-path"
     },
     {
       "path": "session-memories.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 149,
+      "line": 145,
       "api": "existsSync",
       "source": "if (!sessionKey || matchedIds.length === 0 || !existsSync(getMemoryDbPath())) return;",
       "category": "hot-path"
     },
     {
       "path": "session-memories.ts",
-      "line": 153,
+      "line": 149,
       "api": "withWriteTx",
       "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
       "path": "session-memories.ts",
-      "line": 264,
+      "line": 260,
       "api": "existsSync",
       "source": "if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;",
       "category": "hot-path"
     },
     {
       "path": "session-memories.ts",
-      "line": 268,
+      "line": 264,
       "api": "withWriteTx",
       "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"

--- a/scripts/legacy-sync-db-baseline.json
+++ b/scripts/legacy-sync-db-baseline.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"generatedFrom": "bun scripts/legacy-sync-db-baseline.ts",
 	"markedCallsites": {
-		"total": 173,
-		"withReadDb": 107,
-		"withWriteTx": 66
+		"total": 171,
+		"withReadDb": 106,
+		"withWriteTx": 65
 	}
 }


### PR DESCRIPTION
## Summary

Owner-route the remaining W5 contention-class database paths so session-start memory recording, session-gap summaries, reflection active-agent discovery, and knowledge-graph focal/traversal reads no longer execute through parent-owned SQLite seams.

## Changes

- Route session candidate recording through bounded DB-owner write batches, preserving rank, scope, and non-fatal failure behavior.
- Route session-gap aggregation through one bounded DB-owner read.
- Route reflection worker active-agent discovery through a DB-owner read and keep timer scheduling bounded and serialized.
- Add owner-backed focal-entity resolution and graph traversal while preserving the direct-source traversal path.
- Add seam regression coverage for the migrated paths.
- Regenerate the event-loop inventory and legacy sync DB baselines.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: 

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints: N/A, no endpoint changes
- [x] Docs updated for API/spec/status changes: event-loop audit regenerated
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally for the changed scope

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

No schema migration is included. The regenerated audit baselines are deterministic derived artifacts.

## Testing

- [ ] `bun test` passes: full daemon suite has a pre-existing Bun 1.4 async fixture race in `hooks.test.ts`; changed-scope suites pass below
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes for changed files via Biome
- [ ] Tested against running daemon
- [ ] N/A

Changed-scope proof:

- `bun test platform/daemon/src/session-memories.test.ts` : 34 pass, 0 fail
- `bun test platform/daemon/src/pipeline/graph-traversal.test.ts` : 5 pass, 0 fail
- `bun test platform/daemon/src/pipeline/reflection-worker.test.ts` : 16 pass, 0 fail
- `bun test scripts/audit-event-loop-contract.test.ts` : 22 pass, 0 fail
- `bun scripts/legacy-sync-db-baseline.ts`
- `bun run scripts/audit-event-loop-contract.ts --write-baseline`
- `bun run --filter '@signet/daemon' build` passes
- `git diff --check` passes

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full `hooks.test.ts` file still exposes an existing Bun 1.4 test-harness race: its shared `createMemoryDb` helper does not await the async `closeDbAccessor()` before reinitialization. That causes singleton accessor failures across parallel test groups and is outside this PR's scope.
