### PR TITLE
fix(daemon): route predictive context DB scans through owner

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,16 +4,16 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 985 sites
+- Exact ledger inventory: 981 sites
 - Synchronous `withWriteTx()` sites: 65
-- Synchronous `withReadDb()` sites: 106
-- Async-named parent DB sites: 298
+- Synchronous `withReadDb()` sites: 104
+- Async-named parent DB sites: 296
 - Synchronous filesystem/process sites: 516
-- Compile-visible legacy DB sites remaining: 171
+- Compile-visible legacy DB sites remaining: 169
   - `withWriteTx`: 65
-  - `withReadDb`: 106
+  - `withReadDb`: 104
 
-The 985-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 65 synchronous writes, 106 synchronous reads, and 298 async-named parent DB sites are the complete database-call inventory; 171 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 981-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 65 synchronous writes, 104 synchronous reads, and 296 async-named parent DB sites are the complete database-call inventory; 169 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## A3 Slice 2 migration notes
 
@@ -30,4 +30,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 171 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 65 write and 106 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 169 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 65 write and 104 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/agent-id.ts
+++ b/platform/daemon/src/agent-id.ts
@@ -3,7 +3,9 @@
  */
 
 import type { AgentRosterReadPolicy } from "@signet/core";
-import { getDbAccessor } from "./db-accessor";
+import { getDbAccessorPath } from "./db-accessor";
+import { getDbOwner } from "./db-owner-runtime";
+import { ownerReadOne, ownerRun } from "./db-owner-sql";
 
 export interface AgentScope {
 	readonly readPolicy: AgentRosterReadPolicy;
@@ -93,18 +95,25 @@ export async function getAgentScope(agentId: string): Promise<AgentScope> {
 		let read = agentScopeReads.get(id);
 		if (read === undefined) {
 			read = Promise.resolve()
-				.then(() =>
-					getDbAccessor().withReadDbAsync(
-						(db) => {
-							const row = db.prepare("SELECT read_policy, policy_group FROM agents WHERE id = ?").get(id);
-							if (!row || typeof row !== "object") return isolatedScope;
-							const readPolicy = parseReadPolicy("read_policy" in row ? row.read_policy : undefined);
-							const policyGroup = parseScopeValue("policy_group" in row ? row.policy_group : undefined);
-							return { readPolicy, policyGroup };
+				.then(async () => {
+					const owner = await getDbOwner(getDbAccessorPath());
+					const row = await ownerReadOne<{ readonly read_policy: unknown; readonly policy_group: unknown }>(
+						owner,
+						"SELECT read_policy, policy_group FROM agents WHERE id = ?",
+						[id],
+						{
+							operation: "agent-scope.read",
+							lane: "read",
+							deadlineMs: 5_000,
+							estimatedWorkUnits: 1,
 						},
-						{ siteToken: "agent-id.ts:97", operation: "agent-scope.read" },
-					),
-				)
+					);
+					if (!row) return isolatedScope;
+					return {
+						readPolicy: parseReadPolicy(row.read_policy),
+						policyGroup: parseScopeValue(row.policy_group),
+					};
+				})
 				.catch(() => isolatedScope)
 				.then((scope) => {
 					if (generation === agentScopeGeneration) {
@@ -133,19 +142,21 @@ export async function ensureAgentRegistered(
 	const id = normalizedAgentId(agentId);
 	const now = new Date().toISOString();
 	try {
-		const created = await getDbAccessor().withWriteTxAsync(
-			(db) => {
-				const existing = db.prepare("SELECT 1 FROM agents WHERE id = ?").get(id);
-				db.prepare(
-					`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
-					 VALUES (?, ?, ?, NULL, ?, ?)
-					 ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at`,
-				).run(id, id, readPolicy, now, now);
-				return existing == null;
+		const owner = await getDbOwner(getDbAccessorPath());
+		await ownerRun(
+			owner,
+			`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
+			 VALUES (?, ?, ?, NULL, ?, ?)
+			 ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at`,
+			[id, id, readPolicy, now, now],
+			{
+				operation: "agent-scope.register",
+				lane: "write",
+				deadlineMs: 5_000,
+				estimatedWorkUnits: 1,
 			},
-			{ siteToken: "agent-id.ts:136", operation: "agent-scope.register" },
 		);
-		if (created) invalidateAgentScopeCache(id);
+		invalidateAgentScopeCache(id);
 	} catch (err) {
 		console.warn(
 			`[agent-id] Failed to register agent "${id}" (non-fatal):`,

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -3025,6 +3025,12 @@ export function hasDbAccessor(): boolean {
 	return accessor !== null;
 }
 
+/** Return the initialized database path for owner-routed helpers. */
+export function getDbAccessorPath(): string {
+	if (dbPath === null) throw new Error("DbAccessor not initialised — call initDbAccessor() first");
+	return dbPath;
+}
+
 /** Register the live bounded DB-owner health provider for diagnostics. */
 export function registerDbOwnerHealthProvider(provider: (() => DbOwnerHealth) | null): void {
 	dbOwnerHealthProvider = provider;

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -550,7 +550,7 @@ export async function getAllScoredCandidates(
 	return memoryCandidates.getAllScoredCandidates(getMemoryDbPath(), project, limit, agentId, readPolicy, policyGroup);
 }
 
-function getPredictedContextMemories(
+async function getPredictedContextMemories(
 	project: string | undefined,
 	limit: number,
 	charBudget: number,
@@ -558,7 +558,7 @@ function getPredictedContextMemories(
 	agentId: string,
 	readPolicy: AgentRosterReadPolicy = "isolated",
 	policyGroup: string | null = null,
-): ScoredMemory[] {
+): Promise<ScoredMemory[]> {
 	return memoryCandidates.getPredictedContextMemories(
 		getMemoryDbPath(),
 		project,
@@ -1024,7 +1024,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	// would starve it to zero whenever recall fills to recallLimit (default 50),
 	// silently dropping the predicted-context feature entirely.
 	const existingIds = new Set(memories.map((m) => m.id));
-	const predictedMemories = getPredictedContextMemories(
+	const predictedMemories = await getPredictedContextMemories(
 		req.project,
 		10,
 		600,

--- a/platform/daemon/src/memory-candidates.test.ts
+++ b/platform/daemon/src/memory-candidates.test.ts
@@ -3,7 +3,12 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { MAX_TRAVERSAL_CANDIDATE_IDS, fetchTraversalCandidates, getAllScoredCandidates } from "./memory-candidates";
+import {
+	MAX_TRAVERSAL_CANDIDATE_IDS,
+	fetchTraversalCandidates,
+	getAllScoredCandidates,
+	getPredictedContextMemories,
+} from "./memory-candidates";
 
 function temporaryDbPath(): { readonly directory: string; readonly path: string } {
 	const directory = join(tmpdir(), `signet-memory-candidates-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -152,6 +157,26 @@ describe("fetchTraversalCandidates (#1250)", () => {
 		try {
 			const rows = await getAllScoredCandidates(dbPath, undefined, 30, "agent-a");
 			expect(rows.map((row) => row.id)).toEqual(["memory-owner"]);
+		} finally {
+			accessor.withReadDb = originalWithReadDb;
+			accessor.withReadDbAsync = originalWithReadDbAsync;
+		}
+	});
+	test("routes predicted context through the DB owner, not the parent sync DB seam", async () => {
+		const accessor = getDbAccessor() as unknown as {
+			withReadDb: (...args: never[]) => unknown;
+			withReadDbAsync: (...args: never[]) => Promise<unknown>;
+		};
+		const originalWithReadDb = accessor.withReadDb;
+		const originalWithReadDbAsync = accessor.withReadDbAsync;
+		accessor.withReadDb = () => {
+			throw new Error("predicted context crossed the parent sync DB seam");
+		};
+		accessor.withReadDbAsync = async () => {
+			throw new Error("predicted context crossed the parent async DB seam");
+		};
+		try {
+			expect(await getPredictedContextMemories(dbPath, "/repo", 10, 600, new Set(), "agent-a")).toEqual([]);
 		} finally {
 			accessor.withReadDb = originalWithReadDb;
 			accessor.withReadDbAsync = originalWithReadDbAsync;

--- a/platform/daemon/src/memory-candidates.test.ts
+++ b/platform/daemon/src/memory-candidates.test.ts
@@ -27,6 +27,28 @@ function insertMemory(id: string, agentId: string, importance: number, isDeleted
 	});
 }
 
+function insertTranscript(sessionKey: string, project: string, agentId: string, content: string): void {
+	const now = new Date().toISOString();
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO session_transcripts
+				(session_key, content, harness, project, agent_id, created_at, updated_at, completed_at)
+			 VALUES (?, ?, 'test', ?, ?, ?, ?, ?)`,
+		).run(sessionKey, content, project, agentId, now, now, now);
+	});
+}
+
+function insertProjectMemory(id: string, agentId: string, project: string, content: string): void {
+	const now = new Date().toISOString();
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO memories
+				(id, content, type, importance, is_deleted, agent_id, visibility, project, created_at, updated_at, updated_by)
+			 VALUES (?, ?, 'fact', 0.9, 0, ?, 'global', ?, ?, ?, 'test')`,
+		).run(id, content, agentId, project, now, now);
+	});
+}
+
 function insertAttribute(id: string, memoryId: string, agentId: string, importance: number): void {
 	const now = new Date().toISOString();
 	getDbAccessor().withWriteTx((db) => {
@@ -162,7 +184,21 @@ describe("fetchTraversalCandidates (#1250)", () => {
 			accessor.withReadDbAsync = originalWithReadDbAsync;
 		}
 	});
-	test("routes predicted context through the DB owner, not the parent sync DB seam", async () => {
+	test("returns predicted context through the DB owner, not the parent sync DB seam", async () => {
+		insertTranscript(
+			"session-predicted-a",
+			"/repo",
+			"agent-a",
+			"The phoenix deployment uses a stable editor workflow.",
+		);
+		insertTranscript(
+			"session-predicted-b",
+			"/repo",
+			"agent-a",
+			"The phoenix deployment requires careful editor workflow.",
+		);
+		insertProjectMemory("memory-predicted", "agent-a", "/repo", "The phoenix deployment needs the editor workflow.");
+
 		const accessor = getDbAccessor() as unknown as {
 			withReadDb: (...args: never[]) => unknown;
 			withReadDbAsync: (...args: never[]) => Promise<unknown>;
@@ -176,7 +212,8 @@ describe("fetchTraversalCandidates (#1250)", () => {
 			throw new Error("predicted context crossed the parent async DB seam");
 		};
 		try {
-			expect(await getPredictedContextMemories(dbPath, "/repo", 10, 600, new Set(), "agent-a")).toEqual([]);
+			const rows = await getPredictedContextMemories(dbPath, "/repo", 10, 600, new Set(), "agent-a");
+			expect(rows.map((row) => row.id)).toEqual(["memory-predicted"]);
 		} finally {
 			accessor.withReadDb = originalWithReadDb;
 			accessor.withReadDbAsync = originalWithReadDbAsync;

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -6,7 +6,6 @@ import { getDbOwner } from "./db-owner-runtime";
 import { ownerReadAll, ownerReadOne } from "./db-owner-sql";
 import { logger } from "./logger";
 import { effectiveScore } from "./memory-classification";
-import { isMemoryContentContextEligible } from "./memory-content-safety";
 import { buildAgentScopeClause } from "./memory-search";
 
 export interface ScoredMemory {
@@ -316,7 +315,7 @@ export async function getAllScoredCandidates(
  * the regular project-filtered memories with context the user is
  * likely to need based on recent sessions.
  */
-export function getPredictedContextMemories(
+export async function getPredictedContextMemories(
 	memoryDbPath: string,
 	project: string | undefined,
 	limit: number,
@@ -325,39 +324,55 @@ export function getPredictedContextMemories(
 	agentId: string,
 	readPolicy: AgentRosterReadPolicy = "isolated",
 	policyGroup: string | null = null,
-): ScoredMemory[] {
+): Promise<ScoredMemory[]> {
 	if (!existsSync(memoryDbPath)) return [];
 	if (!project || project.trim().length === 0) return [];
 
 	try {
-		// Get recent completed transcripts for this project only. Global predictive
-		// FTS is too broad for session-start latency on large memory stores.
-		const transcriptRows: Array<{ session_key: string; transcript: string }> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-				return (
-					db
-						.prepare(
-							`SELECT session_key, content AS transcript FROM session_transcripts
-					 WHERE project = ? AND completed_at IS NOT NULL AND agent_id = ?
-					 ORDER BY COALESCE(updated_at, created_at) DESC LIMIT 5`,
-						)
-						.all(project, agentId) as Array<{ session_key: string; transcript: string }>
-				).filter((row) =>
-					isMemoryContentContextEligible(db, {
-						agentId,
-						sourceKind: "transcript",
-						sourceId: row.session_key,
-						content: row.transcript,
-					}),
-				);
-			}, "memory-candidates.ts:337");
+		const owner = await getDbOwner(memoryDbPath);
+		const readOptions = {
+			operation: "session-start.predicted-context",
+			lane: "read" as const,
+			deadlineMs: 5_000,
+			estimatedWorkUnits: Math.max(1, Math.min(500, limit * 10)),
+		};
+		const safetyTable = await ownerReadOne<{ readonly name: string }>(
+			owner,
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+			["memory_content_safety"],
+			{ ...readOptions, operation: "session-start.predicted-context.safety-table" },
+		);
+		const hasSafetyTable = safetyTable !== null;
+		const transcriptRows = await ownerReadAll<{
+			readonly session_key: string;
+			readonly transcript: string;
+			readonly safety_status: string | null;
+			readonly safety_context_eligible: number | null;
+		}>(
+			owner,
+			`SELECT st.session_key, st.content AS transcript,
+			        ${hasSafetyTable ? "safety.status" : "NULL"} AS safety_status,
+			        ${hasSafetyTable ? "safety.context_eligible" : "NULL"} AS safety_context_eligible
+			 FROM session_transcripts st
+			 ${hasSafetyTable ? "LEFT JOIN memory_content_safety safety ON safety.agent_id = ? AND safety.source_kind = 'transcript' AND safety.source_id = st.session_key" : ""}
+			 WHERE st.project = ? AND st.completed_at IS NOT NULL AND st.agent_id = ?
+			 ORDER BY COALESCE(st.updated_at, st.created_at) DESC LIMIT 5`,
+			hasSafetyTable ? [agentId, project, agentId] : [project, agentId],
+			{ ...readOptions, operation: "session-start.predicted-context.transcripts" },
+		);
+		const eligibleTranscriptRows = transcriptRows.filter(
+			(row) =>
+				scanMemoryContent(row.transcript).contextEligible &&
+				(!hasSafetyTable ||
+					row.safety_status === null ||
+					(row.safety_status === "clean" && row.safety_context_eligible === 1)),
+		);
 
-		if (transcriptRows.length === 0) return [];
+		if (eligibleTranscriptRows.length === 0) return [];
 
 		// Extract recurring terms from recent sessions.
 		const termFreq = new Map<string, number>();
-		for (const row of transcriptRows) {
+		for (const row of eligibleTranscriptRows) {
 			const text = row.transcript.slice(0, 3000);
 			const words = text
 				.toLowerCase()
@@ -384,60 +399,50 @@ export function getPredictedContextMemories(
 		// Use recurring terms as FTS query.
 		const ftsQuery = recurring.join(" OR ");
 		const scope = buildAgentScopeClause(agentId, readPolicy, policyGroup);
-		const rows: Array<{
-			id: string;
-			content: string;
-			type: string;
-			importance: number;
-			tags: string | null;
-			pinned: number;
-			project: string | null;
-			created_at: string;
-			access_count: number;
-		}> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb(
-				(db: import("./db-accessor").ReadDb) =>
-					(
-						db
-							.prepare(
-								`SELECT m.id, m.content, m.type, m.importance, m.tags,
-						        m.pinned, m.project, m.created_at,
-						        COALESCE(m.access_count, 0) AS access_count
-						 FROM memories_fts
-						 JOIN memories m ON memories_fts.rowid = m.rowid
-						 WHERE memories_fts MATCH ?
-						   AND m.is_deleted = 0
-						   AND m.project = ?
-						   ${scope.sql}
-						 ORDER BY bm25(memories_fts)
-						 LIMIT ?`,
-							)
-							.all(ftsQuery, project, ...scope.args, limit * 2) as Array<{
-							id: string;
-							content: string;
-							type: string;
-							importance: number;
-							tags: string | null;
-							pinned: number;
-							project: string | null;
-							created_at: string;
-							access_count: number;
-						}>
-					).filter((row) =>
-						isMemoryContentContextEligible(db, {
-							agentId,
-							sourceKind: "memory",
-							sourceId: row.id,
-							content: row.content,
-						}),
-					),
-				"memory-candidates.ts:399",
-			);
+		const rows = await ownerReadAll<{
+			readonly id: string;
+			readonly content: string;
+			readonly type: string;
+			readonly importance: number;
+			readonly tags: string | null;
+			readonly pinned: number;
+			readonly project: string | null;
+			readonly created_at: string;
+			readonly access_count: number;
+			readonly safety_status: string | null;
+			readonly safety_context_eligible: number | null;
+		}>(
+			owner,
+			`SELECT m.id, m.content, m.type, m.importance, m.tags,
+			        m.pinned, m.project, m.created_at,
+			        COALESCE(m.access_count, 0) AS access_count,
+			        ${hasSafetyTable ? "safety.status" : "NULL"} AS safety_status,
+			        ${hasSafetyTable ? "safety.context_eligible" : "NULL"} AS safety_context_eligible
+			 FROM memories_fts
+			 JOIN memories m ON memories_fts.rowid = m.rowid
+			 ${hasSafetyTable ? "LEFT JOIN memory_content_safety safety ON safety.agent_id = ? AND safety.source_kind = 'memory' AND safety.source_id = m.id" : ""}
+			 WHERE memories_fts MATCH ?
+			   AND m.is_deleted = 0
+			   AND m.project = ?
+			   ${scope.sql}
+			 ORDER BY bm25(memories_fts)
+			 LIMIT ?`,
+			hasSafetyTable
+				? [agentId, ftsQuery, project, ...scope.args, limit * 2]
+				: [ftsQuery, project, ...scope.args, limit * 2],
+			{ ...readOptions, operation: "session-start.predicted-context.fts" },
+		);
+		const eligibleRows = rows.filter(
+			(row) =>
+				scanMemoryContent(row.content).contextEligible &&
+				(!hasSafetyTable ||
+					row.safety_status === null ||
+					(row.safety_status === "clean" && row.safety_context_eligible === 1)),
+		);
 
 		const selected: ScoredMemory[] = [];
 		let used = 0;
-		for (const r of rows) {
+		for (const r of eligibleRows) {
 			if (excludeIds.has(r.id)) continue;
 			if (selected.length >= limit) break;
 			if (used + r.content.length > charBudget) break;
@@ -479,7 +484,7 @@ export function getRecentMemories(memoryDbPath: string, limit: number, recencyBi
 			return (db.prepare(query).all(limit) as unknown as Array<SimpleMemory>).filter(
 				(row) => scanMemoryContent(row.content).contextEligible,
 			);
-		}, "memory-candidates.ts:465");
+		}, "memory-candidates.ts:470");
 
 		return rows.map((r) => ({
 			id: r.id,
@@ -514,7 +519,7 @@ export function getMemoriesSince(memoryDbPath: string, sinceMs: number, limit: n
 			`)
 				.all(sinceIso, limit) as unknown as Array<SimpleMemory>;
 			return rows.filter((row) => scanMemoryContent(row.content).contextEligible);
-		}, "memory-candidates.ts:506");
+		}, "memory-candidates.ts:511");
 
 		return rows.map((r) => ({
 			id: r.id,

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(985);
+	expect(baseline).toHaveLength(981);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(106);
-	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(68);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(104);
+	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(67);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(225);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(224);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -326,9 +326,9 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 175, withWriteTx: 66, withReadDb: 109 });
-	expect(report).toContain("Exact ledger inventory: 985 sites");
-	expect(report).toContain("65 synchronous writes, 106 synchronous reads, and 298 async-named parent DB sites");
+	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
+	expect(report).toContain("Exact ledger inventory: 981 sites");
+	expect(report).toContain("65 synchronous writes, 104 synchronous reads, and 296 async-named parent DB sites");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -3,20 +3,6 @@
   "generatedFrom": "bun scripts/audit-event-loop-contract.ts --write-baseline",
   "sites": [
     {
-      "path": "agent-id.ts",
-      "line": 97,
-      "api": "withReadDbAsync",
-      "source": "getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "agent-id.ts",
-      "line": 136,
-      "api": "withWriteTxAsync",
-      "source": "const created = await getDbAccessor().withWriteTxAsync(",
-      "category": "hot-path"
-    },
-    {
       "path": "aggregate-recall.ts",
       "line": 743,
       "api": "withReadDbAsync",
@@ -1936,63 +1922,49 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 134,
+      "line": 133,
       "api": "existsSync",
       "source": "if (memoryIds.length === 0 || !existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 241,
+      "line": 240,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 329,
+      "line": 328,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 337,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 399,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 461,
+      "line": 466,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 465,
+      "line": 470,
       "api": "withReadDb",
       "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 501,
+      "line": 506,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 506,
+      "line": 511,
       "api": "withReadDb",
       "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"

--- a/scripts/legacy-sync-db-baseline.json
+++ b/scripts/legacy-sync-db-baseline.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"generatedFrom": "bun scripts/legacy-sync-db-baseline.ts",
 	"markedCallsites": {
-		"total": 171,
-		"withReadDb": 106,
+		"total": 169,
+		"withReadDb": 104,
 		"withWriteTx": 65
 	}
 }


### PR DESCRIPTION
## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Summary

- Named the fifth boot/session-start loop: `getPredictedContextMemories()` in `platform/daemon/src/memory-candidates.ts` (pre-fix `withReadDb()` at lines 337 and 399), which synchronously ran the recent-transcript scan and FTS `MATCH ... ORDER BY bm25` query on the parent.
- Routed both predicted-context queries through the DB owner, preserving persisted safety filtering and agent/project scope.
- Finished the small agent-scope table item by routing `getAgentScope()` and `ensureAgentRegistered()` through the owner; added `getDbAccessorPath()` so isolated/test accessors select the correct owner DB.
- Added a parent-DB-seam regression test and regenerated the event-loop ledger/report and legacy marker ratchet.

## Loop diagnosis

The controlled source-run CPU profile did not reproduce the live wedge in its 90-second window. The live 0.214.22 parent had 1,041,584 `pread64` calls plus futex waits in a 15-second strace, consistent with repeated parent-side SQLite/page-cache work. Source correlation identified the previously unsampled predicted-context FTS fallback: it runs during every project-scoped session start and used synchronous `withReadDb()` callbacks. The FTS query is now submitted to the owner and only bounded rows are filtered/scored in the parent.

Cycle: session-start -> recent completed transcripts (LIMIT 5) -> recurring terms -> FTS MATCH/BM25 (LIMIT 2x) -> prompt injection; one cycle per session-start request.

## Post-fix ranked parent-loop table

| Rank | Parent-side path | Trigger/cycle | Status |
|---|---|---|---|
| 1 | `memory-candidates.ts:399` predicted-context FTS | Every project-scoped session start; FTS/BM25 over `memories_fts` | Fixed in this PR: DB-owner query |
| 2 | `memory-candidates.ts:337` predicted-context transcript scan | Same cycle; recent completed transcripts and safety checks | Fixed in this PR: DB-owner query |
| 3 | `hooks.ts:817` inherited-context lookup | Only session starts with `sessionKey`; parent resolution, checkpoint, transcript-tail, and constraint reads | Remains; multi-query callback is not a trivial scalar migration |
| 4 | `memory-candidates.ts:470` recent-memory fallback | Pre-compaction path; bounded caller limit, not boot session-start | Transitional legacy sync site |
| 5 | `memory-candidates.ts:511` memories-since fallback | Currently no production caller found; retained compatibility path | Transitional legacy sync site |
| 6 | Native-memory indexing, transcript recovery, connector reconciliation, telemetry flush, and Dreaming evidence paths | Background workers/startup maintenance | Cross-referenced against the full ledger; owner/isolated-worker paths already route their DB work and were not the fifth loop |

The complete post-fix static inventory is 981 sites: 65 synchronous writes, 104 synchronous reads, 296 async-named parent DB sites, and 516 filesystem/process sites. The compile-visible legacy DB ratchet is 169 sites (65 writes, 104 reads), down from 171. The full allowlist remains in `scripts/event-loop-contract-baseline.json`.

## Verification

- `bun scripts/audit-event-loop-contract.ts`
- `bun run --filter '@signet/daemon' typecheck`
- `bun test platform/daemon/src/agent-id.test.ts platform/daemon/src/memory-candidates.test.ts` (13 pass, 0 fail)
- `bunx biome check ...` (no errors; one pre-existing unused `getMemoriesSince` warning in `hooks.ts`)

The broader `hooks.test.ts` file has pre-existing shared-singleton/concurrent-test failures when run as a file; the focused owner-routing and agent-scope suites pass.