### PR TITLE
fix(daemon): bound scheduled Dreaming backlog probes (repairs #1737's shipped gap)

### DIFF
--- a/platform/daemon/src/db-owner-maintenance.ts
+++ b/platform/daemon/src/db-owner-maintenance.ts
@@ -17,6 +17,7 @@ import {
 } from "./db-owner-client";
 import { createDbOwnerClient } from "./db-owner-client";
 import type {
+	DbOwnerDreamingEpisodicBacklog,
 	DbOwnerDreamingHygieneAttention,
 	DbOwnerDreamingSurprisalAttention,
 	DbOwnerParameter,
@@ -231,6 +232,19 @@ export async function ownerDreamingSurprisalAttention(
 	);
 }
 
+export async function ownerDreamingEpisodicBacklog(
+	owner: DbOwnerClient,
+	input: DbOwnerDreamingEpisodicBacklog,
+	options: DbOwnerMaintenanceOptions = {},
+): Promise<number> {
+	return await runOwnerMaintenanceWithRetry<number>(
+		owner,
+		{ kind: "dreaming_episodic_backlog", input },
+		"maintenance.dreaming.episodic-backlog",
+		{ ...options, estimatedWorkUnits: options.estimatedWorkUnits ?? input.maxSources * 10 },
+	);
+}
+
 const DEFAULT_FTS_CHUNK_SIZE = 100;
 const MAX_FTS_CHUNK_SIZE = 500;
 const DEFAULT_FTS_DEADLINE_MS = 10_000;
@@ -311,6 +325,10 @@ export interface DbOwnerMaintenance {
 		input: DbOwnerDreamingSurprisalAttention,
 		options?: DbOwnerMaintenanceOptions,
 	) => Promise<DreamingSurprisalSelection | null>;
+	readonly dreamingEpisodicBacklog: (
+		input: DbOwnerDreamingEpisodicBacklog,
+		options?: DbOwnerMaintenanceOptions,
+	) => Promise<number>;
 	readonly health: () => DbOwnerHealth;
 	readonly close: () => Promise<void>;
 }
@@ -764,6 +782,10 @@ export function createDbOwnerMaintenance(options: CreateDbOwnerMaintenanceOption
 		input: DbOwnerDreamingSurprisalAttention,
 		maintenanceOptions?: DbOwnerMaintenanceOptions,
 	): Promise<DreamingSurprisalSelection | null> => ownerDreamingSurprisalAttention(owner, input, maintenanceOptions);
+	const dreamingEpisodicBacklog = (
+		input: DbOwnerDreamingEpisodicBacklog,
+		maintenanceOptions?: DbOwnerMaintenanceOptions,
+	): Promise<number> => ownerDreamingEpisodicBacklog(owner, input, maintenanceOptions);
 	const backfill = (backfillOptions?: FtsBackfillOptions): Promise<FtsBackfillResult> =>
 		backfillFts(owner, backfillOptions);
 	const rebuild = async (rebuildOptions: FtsBackfillOptions = {}): Promise<FtsBackfillResult> => {
@@ -847,6 +869,7 @@ export function createDbOwnerMaintenance(options: CreateDbOwnerMaintenanceOption
 		queueIsHealthy,
 		dreamingHygieneAttention,
 		dreamingSurprisalAttention,
+		dreamingEpisodicBacklog,
 		health: () => owner.health(),
 		close: async () => {
 			if (ownsOwner) await owner.close();

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -238,6 +238,7 @@ export type DbOwnerRequest =
 	| { readonly kind: "source_artifact_upsert_batch"; readonly input: readonly DbOwnerSourceArtifactUpsert[] }
 	| { readonly kind: "dreaming_hygiene_attention"; readonly input: DbOwnerDreamingHygieneAttention }
 	| { readonly kind: "dreaming_surprisal_attention"; readonly input: DbOwnerDreamingSurprisalAttention }
+	| { readonly kind: "dreaming_episodic_backlog"; readonly input: DbOwnerDreamingEpisodicBacklog }
 	| {
 			readonly kind: "vector_backfill";
 			readonly expectedDimensions: number;
@@ -289,6 +290,13 @@ export interface DbOwnerDreamingSurprisalAttention {
 		readonly maxCandidates: number;
 		readonly minScore: number;
 	};
+}
+
+/** Bounded episodic backlog probe used by the scheduled Dreaming gate. */
+export interface DbOwnerDreamingEpisodicBacklog {
+	readonly agentId: string;
+	/** Maximum number of source records to inspect before treating the backlog as reached. */
+	readonly maxSources: number;
 }
 
 export interface DbOwnerJob {

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -799,7 +799,7 @@ export function runDbOwnerWorker(): void {
 		}
 		const embedding = await getDbAccessor().withReadDbAsync(
 			async (db) => resolveActiveEmbeddingConfig(db, config.embedding),
-			{ siteToken: "db-owner-worker.ts:790" },
+			{ siteToken: "db-owner-worker.ts:800" },
 		);
 		const query = payload.query;
 		const queryEmbedding =
@@ -832,7 +832,7 @@ export function runDbOwnerWorker(): void {
 		const { getDbAccessor } = await import("./db-accessor");
 		return await getDbAccessor().withReadDbAsync(
 			(db) => vectorSearchWithMetadata(db, new Float32Array(payload.queryEmbedding), payload.options),
-			{ siteToken: "db-owner-worker.ts:823" },
+			{ siteToken: "db-owner-worker.ts:833" },
 		);
 	}
 

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -428,6 +428,16 @@ export function runDbOwnerWorker(): void {
 		}
 	}
 
+	async function executeDreamingEpisodicBacklog(
+		request: Extract<DbOwnerJob["request"], { readonly kind: "dreaming_episodic_backlog" }>,
+	): Promise<number> {
+		// Keep source selection, evidence rendering, and exact token counting out
+		// of the daemon process. The helper enforces the finite source cap before
+		// it materializes any result for the parent.
+		const { getDreamingEpisodicTokenBacklogInDb } = await import("./pipeline/dreaming");
+		return await getDreamingEpisodicTokenBacklogInDb(db as never, request.input.agentId, request.input.maxSources);
+	}
+
 	function executeSourceArtifactUpsert(
 		request: Extract<
 			DbOwnerJob["request"],
@@ -858,6 +868,7 @@ export function runDbOwnerWorker(): void {
 		if (job.request.kind === "dreaming_hygiene_attention") return executeDreamingHygieneAttention(job.request, context);
 		if (job.request.kind === "dreaming_surprisal_attention")
 			return executeDreamingSurprisalAttention(job.request, context);
+		if (job.request.kind === "dreaming_episodic_backlog") return await executeDreamingEpisodicBacklog(job.request);
 		if (job.request.kind === "source_artifact_upsert" || job.request.kind === "source_artifact_upsert_batch")
 			return executeSourceArtifactUpsert(job.request, context);
 		if (job.request.kind === "vector_search") return await executeVectorSearch(job.request.payload);

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -237,8 +237,10 @@ describe("dreaming worker agent scope", () => {
 		}
 	});
 
-	it("routes the scheduled hygiene scan through the maintenance owner", async () => {
+	it("routes the scheduled hygiene scan and backlog probe through the maintenance owner", async () => {
 		let hygieneCalls = 0;
+		let backlogCalls = 0;
+		let backlogMaxSources = 0;
 		const ownerMaintenance = {
 			queueIsHealthy: async () => true,
 			dreamingHygieneAttention: async () => {
@@ -246,14 +248,21 @@ describe("dreaming worker agent scope", () => {
 				return 0;
 			},
 			dreamingSurprisalAttention: async () => null,
+			dreamingEpisodicBacklog: async (input: { readonly agentId: string; readonly maxSources: number }) => {
+				backlogCalls += 1;
+				backlogMaxSources = input.maxSources;
+				return 0;
+			},
 		} as unknown as DbOwnerMaintenance;
 		const worker = startDreamingWorker(accessor, defaultCfg(), agentsDir, "default", {
 			checkIntervalMs: 10,
 			ownerMaintenance,
 		});
 		try {
-			await waitFor(() => hygieneCalls === 1, 2_000);
+			await waitFor(() => hygieneCalls === 1 && backlogCalls === 1, 2_000);
 			expect(hygieneCalls).toBe(1);
+			expect(backlogCalls).toBe(1);
+			expect(backlogMaxSources).toBe(50);
 		} finally {
 			worker.stop();
 		}

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -206,6 +206,7 @@ export async function selectDreamingCheckMode(
 	accessor: DbAccessor,
 	scopes: readonly string[],
 	lastScheduled: DreamingPassFocus | null,
+	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<DreamingMode> {
 	const hasPendingHygieneAttention = (
 		await Promise.all(
@@ -227,7 +228,9 @@ export async function selectDreamingCheckMode(
 			),
 		)
 	).some(Boolean);
-	const backlogs = await Promise.all(scopes.map((scope) => getDreamingEpisodicTokenBacklog(accessor, scope)));
+	const backlogs = await Promise.all(
+		scopes.map((scope) => getDreamingEpisodicTokenBacklog(accessor, scope, ownerMaintenance)),
+	);
 	const hasBacklog = backlogs.some((backlog) => backlog > 0);
 	return selectDreamingPassMode(lastScheduled, hasPendingHygieneAttention, hasBacklog, hasPendingContentAttention);
 }
@@ -387,7 +390,7 @@ export function startDreamingWorker(
 			try {
 				await enqueueDreamingHygieneAttention(accessor, scopeId, undefined, caps, options.ownerMaintenance);
 				await enqueueDreamingSurprisalAttention(accessor, scopeId, cfg, options.ownerMaintenance);
-				const episodicTokens = await getDreamingEpisodicTokenBacklog(accessor, scopeId);
+				const episodicTokens = await getDreamingEpisodicTokenBacklog(accessor, scopeId, options.ownerMaintenance);
 				if (!(await shouldTriggerDreaming(accessor, cfg, scopeId, Date.now(), episodicTokens))) continue;
 				triggered = true;
 				logger.info("dreaming-worker", "Episodic evidence threshold reached, starting dreaming pass", {
@@ -410,7 +413,7 @@ export function startDreamingWorker(
 		// content a guaranteed turn: alternate the runbook per check cycle
 		// when both kinds of work are pending; run the only-pending kind
 		// directly otherwise.
-		const mode = await selectDreamingCheckMode(accessor, scopes, nextScheduledFocus);
+		const mode = await selectDreamingCheckMode(accessor, scopes, nextScheduledFocus, options.ownerMaintenance);
 		nextScheduledFocus = dreamingFocusOfMode(mode) ?? nextScheduledFocus;
 		try {
 			await runPass(defaultAgentId, mode, undefined, scopes);

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -212,7 +212,7 @@ export async function selectDreamingCheckMode(
 		await Promise.all(
 			scopes.map((scope) =>
 				accessor.withReadDbAsync((db) => hasDreamingAttentionKindInDb(db, scope, ["hygiene"]), {
-					siteToken: "pipeline/dreaming-worker.ts:213",
+					siteToken: "pipeline/dreaming-worker.ts:214",
 					operation: "dreaming.worker.hygiene-attention",
 				}),
 			),
@@ -222,7 +222,7 @@ export async function selectDreamingCheckMode(
 		await Promise.all(
 			scopes.map((scope) =>
 				accessor.withReadDbAsync((db) => hasDreamingAttentionKindInDb(db, scope, DREAMING_CONTENT_ATTENTION_KINDS), {
-					siteToken: "pipeline/dreaming-worker.ts:223",
+					siteToken: "pipeline/dreaming-worker.ts:224",
 					operation: "dreaming.worker.content-attention",
 				}),
 			),

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -16,6 +16,7 @@ import {
 	dreamingEarlyExitSummary,
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
+	getDreamingEpisodicTokenBacklogInDb,
 	getDreamingEvidenceExclusions,
 	getDreamingPasses,
 	getDreamingState,
@@ -1101,6 +1102,20 @@ describe("Dreaming", () => {
 		expect(
 			await shouldTriggerDreaming(accessor, defaultCfg({ tokenThreshold: expected, backfillOnFirstRun: false }), AGENT),
 		).toBe(true);
+	});
+
+	it("bounds the scheduled episodic backlog probe without suppressing a large backlog", async () => {
+		for (let index = 0; index < 51; index += 1) {
+			seedArtifact(
+				db,
+				`imports/bounded-${index}.md`,
+				`pending bounded source ${index}`,
+				`bounded-${index}`,
+				"2026-08-01T00:00:00.000Z",
+			);
+		}
+
+		expect(await getDreamingEpisodicTokenBacklogInDb(db as unknown as ReadDb, AGENT, 50)).toBe(Number.MAX_SAFE_INTEGER);
 	});
 
 	it("runs a pass when attention is pending and leaves it for the agent to consume", async () => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -1525,7 +1525,9 @@ export async function runDreamingAgentPass(
 		]);
 		const backlogByScope = new Map(
 			await Promise.all(
-				scopes.map(async (scope) => [scope, await getDreamingEpisodicTokenBacklog(accessor, scope)] as const),
+				scopes.map(
+					async (scope) => [scope, await getDreamingEpisodicTokenBacklog(accessor, scope, ownerMaintenance)] as const,
+				),
 			),
 		);
 		const totalBacklog = [...backlogByScope.values()].reduce((total, backlog) => total + backlog, 0);
@@ -1975,6 +1977,7 @@ function writeDreamingTranscriptManifestInTx(
 // on the next forced or post-cooldown pass (#1059).
 export const DREAMING_FAILURE_HALT_THRESHOLD = 5;
 export const DREAMING_HALT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+export const DREAMING_SCHEDULE_BACKLOG_MAX_SOURCES = 50;
 const dreamingBacklogTokenCache = new DreamingBacklogTokenCache();
 
 export function isDreamingScopeHalted(state: DreamingState, nowMs = Date.now()): boolean {
@@ -1992,10 +1995,23 @@ export async function isDreamingHaltActive(
 	return isDreamingScopeHalted(await getDreamingState(accessor, agentId), nowMs);
 }
 
+interface DreamingBacklogRead {
+	readonly entries: readonly DreamingBacklogTokenEntry[];
+	readonly truncated: boolean;
+}
+
+function boundedDreamingBacklogSourceLimit(maxSources: number | undefined): number | null {
+	if (maxSources === undefined) return null;
+	if (!Number.isFinite(maxSources)) throw new RangeError("Dreaming backlog source limit must be finite");
+	return Math.max(1, Math.min(Math.floor(maxSources), DREAMING_SCHEDULE_BACKLOG_MAX_SOURCES));
+}
+
 function readDreamingEpisodicTokenBacklogEntriesInDb(
 	db: ReadDb,
 	agentId: string,
-): readonly DreamingBacklogTokenEntry[] {
+	maxSources?: number,
+): DreamingBacklogRead {
+	const sourceLimit = boundedDreamingBacklogSourceLimit(maxSources);
 	const hasConsumption =
 		db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'dreaming_evidence_consumption'").get() !=
 		null;
@@ -2004,23 +2020,24 @@ function readDreamingEpisodicTokenBacklogEntriesInDb(
 			agentId,
 			query: "",
 			excludeDelivered: true,
-			// The trigger metric must include every pending revision. The ordinary
-			// search API is page-bounded, but backlog accounting cannot use a
-			// newest-50 slice without suppressing automatic Dreaming (#1559).
-			limit: null,
+			// Scheduled probes use the finite page; status and manual paths keep
+			// the exact aggregate by omitting maxSources.
+			limit: sourceLimit,
 		});
-		return queued.flatMap((source) => {
-			const remaining = renderDreamingEvidence(source).slice(deliveredOffsetForSource(db, agentId, source));
-			return remaining.length === 0
-				? []
-				: [{ key: `${source.kind}:${source.id}:${deliveredOffsetForSource(db, agentId, source)}`, text: remaining }];
-		});
+		return {
+			entries: queued.flatMap((source) => {
+				const offset = deliveredOffsetForSource(db, agentId, source);
+				const remaining = renderDreamingEvidence(source).slice(offset);
+				return remaining.length === 0 ? [] : [{ key: `${source.kind}:${source.id}:${offset}`, text: remaining }];
+			}),
+			truncated: sourceLimit !== null && queued.length >= sourceLimit,
+		};
 	}
 	const state = readDreamingState(db, agentId);
 	const queued = readRecentEpisodicSources(
 		db,
 		agentId,
-		500,
+		sourceLimit ?? 500,
 		DREAMING_EVIDENCE_KINDS,
 		state.evidenceCursor ? null : state.lastPassAt,
 		"newest",
@@ -2034,28 +2051,52 @@ function readDreamingEpisodicTokenBacklogEntriesInDb(
 		key: `${source.kind}:${source.id}:0`,
 		text: renderDreamingEvidence(source),
 	}));
-	if (resumed === null) return entries;
+	if (resumed === null) {
+		return { entries, truncated: sourceLimit !== null && queued.length >= sourceLimit };
+	}
 	const remaining = renderDreamingEvidence(resumed).slice(state.evidenceCursor?.fragmentOffset);
-	return remaining.length === 0
-		? entries
-		: [
-				...entries,
-				{ key: `${resumed.kind}:${resumed.id}:${state.evidenceCursor?.fragmentOffset ?? 0}`, text: remaining },
-			];
+	const includeResumed = sourceLimit === null || queued.length < sourceLimit;
+	return {
+		entries:
+			remaining.length === 0 || !includeResumed
+				? entries
+				: [
+						...entries,
+						{ key: `${resumed.kind}:${resumed.id}:${state.evidenceCursor?.fragmentOffset ?? 0}`, text: remaining },
+					],
+		truncated: sourceLimit !== null && queued.length >= sourceLimit,
+	};
 }
 
 /**
  * Refresh the exact BPE backlog count without encoding on the daemon thread.
- * Database reads and evidence rendering stay bounded on the caller; the
- * worker owns all cl100k encoding and memoizes unchanged source fragments.
+ * Scheduled probes keep database reads and evidence rendering to a finite
+ * source page; status and manual paths retain the exact aggregate by omitting
+ * the cap. The token worker owns all cl100k encoding and memoizes unchanged
+ * source fragments.
+ * A scheduled probe returns Number.MAX_SAFE_INTEGER when its finite page is
+ * full, preserving the threshold gate without scanning the remaining backlog.
  */
-export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string): Promise<number> {
-	return dreamingBacklogTokenCache.refresh(agentId, readDreamingEpisodicTokenBacklogEntriesInDb(db, agentId));
+export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string, maxSources?: number): Promise<number> {
+	const read = readDreamingEpisodicTokenBacklogEntriesInDb(db, agentId, maxSources);
+	return dreamingBacklogTokenCache
+		.refresh(agentId, read.entries)
+		.then((count) => (read.truncated ? Number.MAX_SAFE_INTEGER : count));
 }
 
-export async function getDreamingEpisodicTokenBacklog(accessor: DbAccessor, agentId: string): Promise<number> {
-	const entries = await readDb(accessor, (db) => readDreamingEpisodicTokenBacklogEntriesInDb(db, agentId));
-	return dreamingBacklogTokenCache.refresh(agentId, entries);
+export async function getDreamingEpisodicTokenBacklog(
+	accessor: DbAccessor,
+	agentId: string,
+	ownerMaintenance?: DbOwnerMaintenance,
+): Promise<number> {
+	if (ownerMaintenance) {
+		return await ownerMaintenance.dreamingEpisodicBacklog(
+			{ agentId, maxSources: DREAMING_SCHEDULE_BACKLOG_MAX_SOURCES },
+			{ deadlineMs: 60_000, estimatedWorkUnits: DREAMING_SCHEDULE_BACKLOG_MAX_SOURCES * 10 },
+		);
+	}
+	const read = await readDb(accessor, (db) => readDreamingEpisodicTokenBacklogEntriesInDb(db, agentId));
+	return await dreamingBacklogTokenCache.refresh(agentId, read.entries);
 }
 
 /** Read the last worker-computed value for synchronous dashboard metadata. */

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -963,35 +963,35 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 790,
+      "line": 800,
       "api": "withReadDbAsync",
       "source": "const embedding = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 823,
+      "line": 833,
       "api": "withReadDbAsync",
       "source": "return await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 833,
+      "line": 843,
       "api": "writeFileSync",
       "source": "writeFileSync(startedMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 834,
+      "line": 844,
       "api": "existsSync",
       "source": "while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 895,
+      "line": 906,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"
@@ -3231,14 +3231,14 @@
     },
     {
       "path": "pipeline/dreaming-worker.ts",
-      "line": 213,
+      "line": 214,
       "api": "withReadDbAsync",
       "source": "accessor.withReadDbAsync((db) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"]), {",
       "category": "hot-path"
     },
     {
       "path": "pipeline/dreaming-worker.ts",
-      "line": 223,
+      "line": 224,
       "api": "withReadDbAsync",
       "source": "accessor.withReadDbAsync((db) => hasDreamingAttentionKindInDb(db, scope, DREAMING_CONTENT_ATTENTION_KINDS), {",
       "category": "hot-path"


### PR DESCRIPTION
Repairs the shipped defect from #1737: the scheduled Dreaming check's episodic backlog read ran parent-side with no limit (searchEpisodicSources limit:null -> SQLite LIMIT -1), rendering the entire accumulated backlog on the parent each tick — the 16.3-minute stall observed on 0.214.26.

## Summary

- The scheduled backlog probe is now owner-routed in the maintenance worker with a hard 50-source page cap and a high-watermark sentinel when the page is full (trigger logic sees ">50 pending" without fetching them all).
- Telemetry ordering restored (completeness logger fires after the await).
- Follow-up 69d79ad12: site tokens realigned (4 drifted), both contract baselines regenerated and committed, ratchet 169.

## Type

- [ ] `feat`
- [x] `fix` — bug fix
- [ ] `refactor`
- [ ] `chore`
- [ ] `perf`
- [ ] `test`

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

None — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Verification

- Owner IPC path + regression coverage passed (worker review approved the bounding)
- Audit suite 22/22 at 69d79ad12; dreaming-worker suite green; daemon tsc clean
- Adversarial review at exact head in progress (merge gate)

## Migration Notes

No schema migrations.