### PR TITLE
fix(daemon): L1 wave 5 — routes clusters owner-routed (loop-8 killers)

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 931 sites
+- Exact ledger inventory: 902 sites
 - Synchronous `withWriteTx()` sites: 65
-- Synchronous `withReadDb()` sites: 104
-- Async-named DB sites: 246
-- Async-named ON-PARENT DB sites: 244
+- Synchronous `withReadDb()` sites: 99
+- Async-named DB sites: 222
+- Async-named ON-PARENT DB sites: 220
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
-- Compile-visible legacy DB sites remaining: 169
+- Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
-  - `withReadDb`: 104
+  - `withReadDb`: 99
 
-The 931-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 104 synchronous reads, and 246 async-named DB sites are the complete database-call inventory; 169 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 244 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 902-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 222 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 220 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 415
-- ON-PARENT callback execution: 413
+- Database accessor sites classified: 386
+- ON-PARENT callback execution: 384
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -287,53 +287,29 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `routes/marketplace.ts:1128` (withWriteTx)
 - `routes/mcp-analytics.ts:89` (withReadDb)
 - `routes/mcp-analytics.ts:171` (withReadDb)
-- `routes/memory-routes.ts:120` (withReadDbAsync)
-- `routes/memory-routes.ts:628` (withReadDbAsync)
-- `routes/memory-routes.ts:981` (withReadDbAsync)
-- `routes/memory-routes.ts:1025` (withReadDbAsync)
-- `routes/memory-routes.ts:1105` (withReadDbAsync)
-- `routes/memory-routes.ts:1160` (withReadDbAsync)
-- `routes/memory-routes.ts:1261` (withReadDbAsync)
-- `routes/memory-routes.ts:1308` (withReadDbAsync)
-- `routes/memory-routes.ts:1346` (withReadDbAsync)
-- `routes/memory-routes.ts:1377` (withReadDbAsync)
-- `routes/memory-routes.ts:1679` (withReadDbAsync)
-- `routes/memory-routes.ts:1687` (withReadDbAsync)
-- `routes/memory-routes.ts:1721` (withReadDbAsync)
-- `routes/memory-routes.ts:1928` (withReadDbAsync)
-- `routes/memory-routes.ts:2053` (withReadDbAsync)
-- `routes/memory-routes.ts:2272` (withReadDbAsync)
-- `routes/memory-routes.ts:2342` (withReadDbAsync)
-- `routes/memory-routes.ts:2352` (withReadDbAsync)
-- `routes/memory-routes.ts:2453` (withReadDbAsync)
-- `routes/memory-routes.ts:2528` (withReadDbAsync)
-- `routes/memory-routes.ts:3654` (withReadDbAsync)
-- `routes/memory-routes.ts:3688` (withReadDbAsync)
-- `routes/memory-routes.ts:3706` (withReadDbAsync)
-- `routes/memory-routes.ts:3787` (withReadDbAsync)
-- `routes/memory-routes.ts:3872` (withReadDbAsync)
-- `routes/memory-routes.ts:3890` (withReadDbAsync)
-- `routes/memory-routes.ts:3953` (withReadDbAsync)
-- `routes/memory-routes.ts:3993` (withReadDbAsync)
-- `routes/memory-routes.ts:4034` (withReadDbAsync)
-- `routes/memory-routes.ts:4037` (withReadDbAsync)
-- `routes/memory-routes.ts:4191` (withReadDbAsync)
-- `routes/memory-routes.ts:4232` (withReadDbAsync)
-- `routes/memory-routes.ts:4267` (withReadDbAsync)
-- `routes/memory-routes.ts:4302` (withReadDbAsync)
-- `routes/misc-routes.ts:291` (withReadDbAsync)
-- `routes/misc-routes.ts:306` (withReadDbAsync)
-- `routes/misc-routes.ts:340` (withReadDbAsync)
-- `routes/misc-routes.ts:354` (withReadDbAsync)
-- `routes/misc-routes.ts:518` (withReadDbAsync)
-- `routes/misc-routes.ts:615` (withReadDbAsync)
-- `routes/misc-routes.ts:711` (withReadDbAsync)
-- `routes/misc-routes.ts:720` (withReadDbAsync)
-- `routes/misc-routes.ts:740` (withReadDbAsync)
-- `routes/misc-routes.ts:815` (withReadDbAsync)
-- `routes/misc-routes.ts:824` (withReadDbAsync)
-- `routes/misc-routes.ts:948` (withReadDbAsync)
-- `routes/misc-routes.ts:961` (withReadDbAsync)
+- `routes/memory-routes.ts:121` (withReadDbAsync)
+- `routes/memory-routes.ts:1022` (withReadDbAsync)
+- `routes/memory-routes.ts:1102` (withReadDbAsync)
+- `routes/memory-routes.ts:1157` (withReadDbAsync)
+- `routes/memory-routes.ts:1258` (withReadDbAsync)
+- `routes/memory-routes.ts:1368` (withReadDbAsync)
+- `routes/memory-routes.ts:1670` (withReadDbAsync)
+- `routes/memory-routes.ts:1678` (withReadDbAsync)
+- `routes/memory-routes.ts:1712` (withReadDbAsync)
+- `routes/memory-routes.ts:1919` (withReadDbAsync)
+- `routes/memory-routes.ts:2044` (withReadDbAsync)
+- `routes/memory-routes.ts:2263` (withReadDbAsync)
+- `routes/memory-routes.ts:2442` (withReadDbAsync)
+- `routes/memory-routes.ts:3641` (withReadDbAsync)
+- `routes/memory-routes.ts:3675` (withReadDbAsync)
+- `routes/memory-routes.ts:3693` (withReadDbAsync)
+- `routes/memory-routes.ts:3774` (withReadDbAsync)
+- `routes/memory-routes.ts:3859` (withReadDbAsync)
+- `routes/memory-routes.ts:3877` (withReadDbAsync)
+- `routes/memory-routes.ts:3940` (withReadDbAsync)
+- `routes/memory-routes.ts:3980` (withReadDbAsync)
+- `routes/memory-routes.ts:4021` (withReadDbAsync)
+- `routes/memory-routes.ts:4024` (withReadDbAsync)
 - `routes/pipeline-routes.ts:121` (withReadDb)
 - `routes/pipeline-routes.ts:346` (withReadDbAsync)
 - `routes/pipeline-routes.ts:520` (withReadDb)
@@ -359,11 +335,6 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `routes/session-routes.ts:349` (withReadDb)
 - `routes/session-routes.ts:359` (withReadDb)
 - `routes/skill-analytics.ts:121` (withReadDb)
-- `routes/sources-routes.ts:906` (withReadDb)
-- `routes/sources-routes.ts:1045` (withReadDb)
-- `routes/sources-routes.ts:1157` (withReadDb)
-- `routes/sources-routes.ts:1220` (withReadDb)
-- `routes/sources-routes.ts:1259` (withReadDb)
 - `routes/state.ts:457` (withReadDb)
 - `routes/telemetry-routes.ts:200` (withReadDb)
 - `routes/telemetry-routes.ts:221` (withReadDb)
@@ -444,8 +415,8 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 
 ### OFF-PARENT sites
 
-- `db-owner-worker.ts:864` (withReadDbAsync)
-- `db-owner-worker.ts:897` (withReadDbAsync)
+- `db-owner-worker.ts:876` (withReadDbAsync)
+- `db-owner-worker.ts:909` (withReadDbAsync)
 
 ## A3 Slice 2 migration notes
 
@@ -462,4 +433,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 169 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 65 write and 104 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 164 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 65 write and 99 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -207,6 +207,12 @@ export interface DbOwnerSourceArtifactUpsert {
 	readonly conflictGuardSourceId?: boolean;
 }
 
+export interface DbOwnerSourceEvidenceEligibility {
+	readonly agentId: string;
+	readonly sourceEntryId: string;
+	readonly legacyObsidianRoot?: string;
+}
+
 export type DbOwnerRequest =
 	| { readonly kind: "initialize"; readonly agentsDir?: string }
 	| { readonly kind: "query"; readonly statement: DbOwnerStatement }
@@ -236,6 +242,7 @@ export type DbOwnerRequest =
 	| { readonly kind: "source_artifact_purge"; readonly input: DbOwnerSourceArtifactPurge }
 	| { readonly kind: "source_artifact_upsert"; readonly input: DbOwnerSourceArtifactUpsert }
 	| { readonly kind: "source_artifact_upsert_batch"; readonly input: readonly DbOwnerSourceArtifactUpsert[] }
+	| { readonly kind: "source_evidence_eligibility"; readonly input: DbOwnerSourceEvidenceEligibility }
 	| { readonly kind: "dreaming_hygiene_attention"; readonly input: DbOwnerDreamingHygieneAttention }
 	| { readonly kind: "dreaming_surprisal_attention"; readonly input: DbOwnerDreamingSurprisalAttention }
 	| { readonly kind: "dreaming_episodic_backlog"; readonly input: DbOwnerDreamingEpisodicBacklog }

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -23,6 +23,7 @@ import type {
 	DbOwnerNativeMemoryIndex,
 	DbOwnerSourceArtifactPurge,
 	DbOwnerSourceArtifactUpsert,
+	DbOwnerSourceEvidenceEligibility,
 	DbOwnerStatement,
 	DbOwnerWorkloadClass,
 } from "./db-owner-protocol";
@@ -89,6 +90,17 @@ async function inlineRequest(accessor: DbAccessor, request: DbOwnerRequest): Pro
 			}
 			return results;
 		});
+	}
+	if (request.kind === "source_evidence_eligibility") {
+		const { sourceHasEligibleUnconsumedEvidence } = await import("./pipeline/dreaming-evidence-consumption");
+		return await invokeAccessor(accessor, "withReadDb", (db) =>
+			sourceHasEligibleUnconsumedEvidence(
+				db as never,
+				request.input.agentId,
+				request.input.sourceEntryId,
+				request.input.legacyObsidianRoot,
+			),
+		);
 	}
 	if (request.kind === "dreaming_hygiene_attention") {
 		const { getDreamingHygieneCandidatesInDb } = await import("./knowledge-graph-hygiene");
@@ -475,6 +487,18 @@ export async function dbOwnerSourceArtifactUpsert(
 		owner,
 		{ kind: "source_artifact_upsert", input },
 		{ ...options, lane: options.lane ?? "write" },
+	);
+}
+
+export async function dbOwnerSourceEvidenceEligibility(
+	input: DbOwnerSourceEvidenceEligibility,
+	options: DbOwnerSqlOptions,
+): Promise<boolean> {
+	const owner = await getDbOwner();
+	return await submitWithAdmission<boolean>(
+		owner,
+		{ kind: "source_evidence_eligibility", input },
+		{ ...options, lane: "read" },
 	);
 }
 

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -16,6 +16,7 @@ import { applySourceSnapshotImportInTx } from "./source-snapshots";
 import { getDreamingHygieneCandidatesInDb } from "./knowledge-graph-hygiene";
 import { enqueueDreamingAttentionInTx } from "./pipeline/dreaming-attention";
 import { DREAMING_SURPRISAL_SELECTOR_VERSION, selectDreamingSurprisalInDb } from "./pipeline/dreaming-surprisal";
+import { sourceHasEligibleUnconsumedEvidence } from "./pipeline/dreaming-evidence-consumption";
 import type {
 	DbOwnerCommand,
 	DbOwnerEvent,
@@ -530,6 +531,17 @@ export function runDbOwnerWorker(): void {
 		}
 	}
 
+	function executeSourceEvidenceEligibility(
+		request: Extract<DbOwnerJob["request"], { readonly kind: "source_evidence_eligibility" }>,
+	): boolean {
+		return sourceHasEligibleUnconsumedEvidence(
+			db as unknown as import("./db-accessor").ReadDb,
+			request.input.agentId,
+			request.input.sourceEntryId,
+			request.input.legacyObsidianRoot,
+		);
+	}
+
 	function executeSourceGraph(
 		request: Extract<
 			DbOwnerJob["request"],
@@ -863,7 +875,7 @@ export function runDbOwnerWorker(): void {
 		}
 		const embedding = await getDbAccessor().withReadDbAsync(
 			async (db) => resolveActiveEmbeddingConfig(db, config.embedding),
-			{ siteToken: "db-owner-worker.ts:864" },
+			{ siteToken: "db-owner-worker.ts:876" },
 		);
 		const query = payload.query;
 		const queryEmbedding =
@@ -896,7 +908,7 @@ export function runDbOwnerWorker(): void {
 		const { getDbAccessor } = await import("./db-accessor");
 		return await getDbAccessor().withReadDbAsync(
 			(db) => vectorSearchWithMetadata(db, new Float32Array(payload.queryEmbedding), payload.options),
-			{ siteToken: "db-owner-worker.ts:897" },
+			{ siteToken: "db-owner-worker.ts:909" },
 		);
 	}
 
@@ -966,6 +978,7 @@ export function runDbOwnerWorker(): void {
 		}
 		if (job.request.kind === "source_artifact_upsert" || job.request.kind === "source_artifact_upsert_batch")
 			return executeSourceArtifactUpsert(job.request, context);
+		if (job.request.kind === "source_evidence_eligibility") return executeSourceEvidenceEligibility(job.request);
 		if (job.request.kind === "vector_search") return await executeVectorSearch(job.request.payload);
 		if (
 			job.request.kind === "source_graph_index" ||

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -10,6 +10,7 @@ import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
 import type { DbOwnerClient } from "../db-owner-client";
 import { DB_OWNER_MAX_WORK_UNITS } from "../db-owner-protocol";
+import { dbOwnerQuery } from "../db-owner-runtime";
 import { hybridRecallThroughDbOwner, vectorSearchThroughDbOwner } from "../db-owner-recall";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type ReadDb, type WriteDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "../db-accessor";
@@ -118,7 +119,7 @@ async function withActiveEmbeddingConfig(cfg: ResolvedMemoryConfig): Promise<Res
 	return {
 		...cfg,
 		embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding), {
-			siteToken: "routes/memory-routes.ts:120",
+			siteToken: "routes/memory-routes.ts:121",
 		}),
 	};
 }
@@ -625,14 +626,13 @@ async function authorizeMemoryMutationScope(c: Context, memoryIds: readonly stri
 	if (!shouldEnforceAuthScope(c)) return {};
 	const ids = [...new Set(memoryIds.map((id) => id.trim()).filter(Boolean))];
 	if (ids.length === 0) return {};
-	const rows = await getDbAccessor().withReadDbAsync(
-		async (db) => {
-			const stmt = db.prepare("SELECT id, agent_id, project FROM memories WHERE id = ?");
-			return ids.map(
-				(id) => stmt.get(id) as { id: string; agent_id: string | null; project: string | null } | undefined,
-			);
-		},
-		{ siteToken: "routes/memory-routes.ts:628" },
+	const rows = await Promise.all(
+		ids.map((id) =>
+			dbOwnerQuery<{ id: string; agent_id: string | null; project: string | null } | undefined>(
+				{ sql: "SELECT id, agent_id, project FROM memories WHERE id = ?", params: [id], result: "get" },
+				{ operation: "memory.authorize_mutation", lane: "read", deadlineMs: 2_000 },
+			),
+		),
 	);
 	const claims = c.get("auth")?.claims ?? null;
 	for (const row of rows) {
@@ -978,12 +978,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const auth = c.get("auth");
 			if (auth?.claims?.scope?.project) {
 				const memoryId = c.req.param("id");
-				const row = await getDbAccessor().withReadDbAsync(
-					async (db) =>
-						db.prepare("SELECT project FROM memories WHERE id = ?").get(memoryId) as
-							| { project: string | null }
-							| undefined,
-					{ siteToken: "routes/memory-routes.ts:981" },
+				const row = await dbOwnerQuery<{ project: string | null } | undefined>(
+					{ sql: "SELECT project FROM memories WHERE id = ?", params: [memoryId], result: "get" },
+					{ operation: "memory.authorize_project", lane: "read", deadlineMs: 2_000 },
 				);
 				if (row) {
 					const decision = checkScope(auth.claims, { project: row.project ?? undefined }, authConfig.mode);
@@ -1081,7 +1078,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						},
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1025" },
+				{ siteToken: "routes/memory-routes.ts:1022" },
 			);
 
 			return c.json(result);
@@ -1126,7 +1123,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						)
 						.map(({ agent_id: _agentId, ...row }) => row);
 				},
-				{ siteToken: "routes/memory-routes.ts:1105" },
+				{ siteToken: "routes/memory-routes.ts:1102" },
 			);
 			return c.json({ memories });
 		} catch (e) {
@@ -1236,7 +1233,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						highUsed: filterSafe(highUsed).map(({ agent_id: _agentId, ...row }) => row),
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1160" },
+				{ siteToken: "routes/memory-routes.ts:1157" },
 			);
 			return c.json({ agentId, minSessions, limit, ...slices });
 		} catch (e) {
@@ -1266,7 +1263,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						readPolicy: agentScope.readPolicy,
 						policyGroup: agentScope.policyGroup ?? undefined,
 					}),
-				{ siteToken: "routes/memory-routes.ts:1261" },
+				{ siteToken: "routes/memory-routes.ts:1258" },
 			);
 			return c.json(timeline);
 		} catch (e) {
@@ -1305,11 +1302,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const projectSql = scopeProject ? " AND m.project = ?" : "";
 			const scopeArgs = scopeProject ? [...access.args, scopeProject] : access.args;
 			const scopePredicate = shouldEnforceAuthScope(c) ? `${access.sql}${projectSql}` : "";
-			const rows = await getDbAccessor().withReadDbAsync(
-				async (db) => {
-					return db
-						.prepare(
-							`SELECT h.id, h.memory_id, h.event, h.old_content, h.new_content,
+			const rows = await dbOwnerQuery<unknown[]>(
+				{
+					sql: `SELECT h.id, h.memory_id, h.event, h.old_content, h.new_content,
 						        h.reason, h.metadata, h.created_at, h.session_id,
 						        m.content AS current_content, m.type AS memory_type,
 						        m.importance
@@ -1320,10 +1315,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					   ${scopePredicate}
 					 ORDER BY h.created_at DESC
 					 LIMIT 200`,
-						)
-						.all(...(shouldEnforceAuthScope(c) ? scopeArgs : []));
+					params: shouldEnforceAuthScope(c) ? (scopeArgs as Array<string | number | boolean | null>) : [],
+					result: "all",
 				},
-				{ siteToken: "routes/memory-routes.ts:1308" },
+				{ operation: "memory.review_queue", lane: "read", deadlineMs: 5_000 },
 			);
 			return c.json({ items: rows });
 		} catch (e) {
@@ -1343,15 +1338,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		// Shortcut: return distinct values for a column
 		if (distinct === "who") {
 			try {
-				const values = await getDbAccessor().withReadDbAsync(
-					async (db) => {
-						const rows = db.prepare("SELECT DISTINCT who FROM memories WHERE who IS NOT NULL ORDER BY who").all() as {
-							who: string;
-						}[];
-						return rows.map((r) => r.who);
-					},
-					{ siteToken: "routes/memory-routes.ts:1346" },
+				const rows = await dbOwnerQuery<{ who: string }[]>(
+					{ sql: "SELECT DISTINCT who FROM memories WHERE who IS NOT NULL ORDER BY who", result: "all" },
+					{ operation: "memory.search_distinct_who", lane: "read", deadlineMs: 2_000 },
 				);
+				const values = rows.map((r) => r.who);
 				return c.json({ values });
 			} catch {
 				return c.json({ values: [] });
@@ -1444,7 +1435,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							return publicRow;
 						});
 				},
-				{ siteToken: "routes/memory-routes.ts:1377" },
+				{ siteToken: "routes/memory-routes.ts:1368" },
 			);
 
 			recordRecallOutcome({
@@ -1678,7 +1669,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1679" },
+				{ siteToken: "routes/memory-routes.ts:1670" },
 			);
 			if (baseIdempotencyMemory) {
 				return c.json({ error: "idempotencyKey already used for non-chunk content" }, 409);
@@ -1686,7 +1677,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const existingChunks = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1687" },
+				{ siteToken: "routes/memory-routes.ts:1678" },
 			);
 			if (existingChunks.length > 0) {
 				const groupIds = new Set(existingChunks.map((row) => row.sourceId).filter((id): id is string => !!id));
@@ -1720,7 +1711,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				contentHashes.add(plan.normalized.contentHash);
 				const byHash = await getDbAccessor().withReadDbAsync(
 					async (db) => getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope),
-					{ siteToken: "routes/memory-routes.ts:1721" },
+					{ siteToken: "routes/memory-routes.ts:1712" },
 				);
 				if (byHash) {
 					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
@@ -1927,7 +1918,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				? []
 				: await getDbAccessor().withReadDbAsync(
 						async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-						{ siteToken: "routes/memory-routes.ts:1928" },
+						{ siteToken: "routes/memory-routes.ts:1919" },
 					);
 		if (chunkedIdempotencyMemory.length > 0) {
 			return c.json({ error: "idempotencyKey already used for chunked content" }, 409);
@@ -2056,7 +2047,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						if (byIdempotencyKey) return byIdempotencyKey;
 						return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 					},
-					{ siteToken: "routes/memory-routes.ts:2053" },
+					{ siteToken: "routes/memory-routes.ts:2044" },
 				);
 				if (existing) {
 					c.header("x-signet-operation-skipped", "1");
@@ -2300,7 +2291,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					: null;
 				return { row, safety };
 			},
-			{ siteToken: "routes/memory-routes.ts:2272" },
+			{ siteToken: "routes/memory-routes.ts:2263" },
 		);
 		const row = memoryRead.row;
 
@@ -2339,42 +2330,40 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const limit = Math.min(parseOptionalInt(c.req.query("limit")) ?? 200, 1000);
 
-		const exists = await getDbAccessor().withReadDbAsync(
-			async (db) => {
-				return db.prepare("SELECT id FROM memories WHERE id = ?").get(memoryId) as { id: string } | undefined;
-			},
-			{ siteToken: "routes/memory-routes.ts:2342" },
+		const exists = await dbOwnerQuery<{ id: string } | undefined>(
+			{ sql: "SELECT id FROM memories WHERE id = ?", params: [memoryId], result: "get" },
+			{ operation: "memory.history_exists", lane: "read", deadlineMs: 2_000 },
 		);
 		if (!exists) {
 			return c.json({ error: "Not found", memoryId }, 404);
 		}
 
-		const history = await getDbAccessor().withReadDbAsync(
-			async (db) => {
-				return db
-					.prepare(
-						`SELECT id, event, old_content, new_content, changed_by, reason,
+		const history = await dbOwnerQuery<
+			Array<{
+				id: string;
+				event: string;
+				old_content: string | null;
+				new_content: string | null;
+				changed_by: string;
+				reason: string | null;
+				metadata: string | null;
+				created_at: string;
+				actor_type: string | null;
+				session_id: string | null;
+				request_id: string | null;
+			}>
+		>(
+			{
+				sql: `SELECT id, event, old_content, new_content, changed_by, reason,
 					        metadata, created_at, actor_type, session_id, request_id
 					 FROM memory_history
 					 WHERE memory_id = ?
 					 ORDER BY created_at ASC
 					 LIMIT ?`,
-					)
-					.all(memoryId, limit) as Array<{
-					id: string;
-					event: string;
-					old_content: string | null;
-					new_content: string | null;
-					changed_by: string;
-					reason: string | null;
-					metadata: string | null;
-					created_at: string;
-					actor_type: string | null;
-					session_id: string | null;
-					request_id: string | null;
-				}>;
+				params: [memoryId, limit],
+				result: "all",
 			},
-			{ siteToken: "routes/memory-routes.ts:2352" },
+			{ operation: "memory.history", lane: "read", deadlineMs: 5_000 },
 		);
 
 		return c.json({
@@ -2495,7 +2484,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				// order — creation time is.
 				return [...byId.values()].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.version - b.version);
 			},
-			{ siteToken: "routes/memory-routes.ts:2453" },
+			{ siteToken: "routes/memory-routes.ts:2442" },
 		);
 
 		return c.json({
@@ -2525,20 +2514,18 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "job id is required" }, 400);
 		}
 
-		const maybeRow = await getDbAccessor().withReadDbAsync(
-			async (db) => {
-				return db
-					.prepare(
-						`SELECT id, memory_id, document_id, job_type, status,
+		const maybeRow = await dbOwnerQuery<unknown>(
+			{
+				sql: `SELECT id, memory_id, document_id, job_type, status,
 					        attempts, max_attempts, leased_at, completed_at,
 					        failed_at, error, created_at, updated_at
 					 FROM memory_jobs
 					 WHERE id = ?
 					 LIMIT 1`,
-					)
-					.get(jobId) as unknown;
+				params: [jobId],
+				result: "get",
 			},
-			{ siteToken: "routes/memory-routes.ts:2528" },
+			{ operation: "memory.job", lane: "read", deadlineMs: 2_000 },
 		);
 
 		type JobRow = {
@@ -3664,7 +3651,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
         LIMIT 1
       `)
 						.get(id) as { vector: Buffer } | undefined,
-				{ siteToken: "routes/memory-routes.ts:3654" },
+				{ siteToken: "routes/memory-routes.ts:3641" },
 			);
 
 			if (!embeddingRow) {
@@ -3686,7 +3673,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const searchData =
 				recallOwner === undefined
 					? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions), {
-							siteToken: "routes/memory-routes.ts:3688",
+							siteToken: "routes/memory-routes.ts:3675",
 						})
 					: await vectorSearchThroughDbOwner(recallOwner, [...queryVector], searchOptions);
 
@@ -3729,7 +3716,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						}),
 					);
 				},
-				{ siteToken: "routes/memory-routes.ts:3706" },
+				{ siteToken: "routes/memory-routes.ts:3693" },
 			);
 
 			const rowMap = new Map(rows.map((r) => [r.id, r]));
@@ -3824,7 +3811,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 					return { total: totalRow?.count ?? 0, rows: rowData };
 				},
-				{ siteToken: "routes/memory-routes.ts:3787" },
+				{ siteToken: "routes/memory-routes.ts:3774" },
 			);
 
 			const embeddings = rows.map((row) => ({
@@ -3876,7 +3863,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					? { ...state, coverage: stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint) }
 					: state;
 			},
-			{ siteToken: "routes/memory-routes.ts:3872" },
+			{ siteToken: "routes/memory-routes.ts:3859" },
 		);
 		return c.json({ ...status, tracker, index });
 	});
@@ -3889,7 +3876,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const providerStatus = await checkEmbeddingProvider(cfg.embedding);
 		const report = await getDbAccessor().withReadDbAsync(
 			async (db) => buildEmbeddingHealth(db, cfg.embedding, providerStatus),
-			{ siteToken: "routes/memory-routes.ts:3890" },
+			{ siteToken: "routes/memory-routes.ts:3877" },
 		);
 		return c.json(report);
 	});
@@ -3970,7 +3957,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 									}
 								: undefined,
 						}),
-					{ siteToken: "routes/memory-routes.ts:3953" },
+					{ siteToken: "routes/memory-routes.ts:3940" },
 				);
 
 				return c.json({
@@ -4000,7 +3987,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						: 0;
 				return { cached: cachedResult, total: count };
 			},
-			{ siteToken: "routes/memory-routes.ts:3993" },
+			{ siteToken: "routes/memory-routes.ts:3980" },
 		);
 
 		if (cached !== null && cached.embeddingCount === total) {
@@ -4032,7 +4019,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const computation = (async () => {
 				try {
 					const result = await getDbAccessor().withReadDbAsync(async (db) => computeProjection(db, nComponents), {
-						siteToken: "routes/memory-routes.ts:4034",
+						siteToken: "routes/memory-routes.ts:4021",
 					});
 					const count = await getDbAccessor().withReadDbAsync(
 						async (db) => {
@@ -4041,7 +4028,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 								? row.count
 								: 0;
 						},
-						{ siteToken: "routes/memory-routes.ts:4037" },
+						{ siteToken: "routes/memory-routes.ts:4024" },
 					);
 					await runWriteTxAsync(getDbAccessor(), (db) => cacheProjection(db, nComponents, result, count));
 				} catch (err) {
@@ -4187,30 +4174,23 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const offset = Math.max(0, Number.parseInt(c.req.query("offset") ?? "0", 10) || 0);
 
 		try {
-			const accessor = getDbAccessor();
-			const result = await accessor.withReadDbAsync(
-				async (db) => {
-					const countSql = status
-						? "SELECT COUNT(*) AS cnt FROM documents WHERE status = ?"
-						: "SELECT COUNT(*) AS cnt FROM documents";
-					const countRow = (status ? db.prepare(countSql).get(status) : db.prepare(countSql).get()) as
-						| { cnt: number }
-						| undefined;
-					const total = countRow?.cnt ?? 0;
-
-					const listSql = status
-						? `SELECT * FROM documents WHERE status = ?
-					   ORDER BY created_at DESC LIMIT ? OFFSET ?`
-						: `SELECT * FROM documents
-					   ORDER BY created_at DESC LIMIT ? OFFSET ?`;
-					const documents = status
-						? db.prepare(listSql).all(status, limit, offset)
-						: db.prepare(listSql).all(limit, offset);
-
-					return { documents, total };
-				},
-				{ siteToken: "routes/memory-routes.ts:4191" },
-			);
+			const countSql = status
+				? "SELECT COUNT(*) AS cnt FROM documents WHERE status = ?"
+				: "SELECT COUNT(*) AS cnt FROM documents";
+			const listSql = status
+				? "SELECT * FROM documents WHERE status = ? ORDER BY created_at DESC LIMIT ? OFFSET ?"
+				: "SELECT * FROM documents ORDER BY created_at DESC LIMIT ? OFFSET ?";
+			const [countRow, documents] = await Promise.all([
+				dbOwnerQuery<{ cnt: number } | undefined>(
+					{ sql: countSql, params: status ? [status] : [], result: "get" },
+					{ operation: "documents.count", lane: "read", deadlineMs: 3_000 },
+				),
+				dbOwnerQuery<unknown[]>(
+					{ sql: listSql, params: status ? [status, limit, offset] : [limit, offset], result: "all" },
+					{ operation: "documents.list", lane: "read", deadlineMs: 5_000 },
+				),
+			]);
+			const result = { documents, total: countRow?.cnt ?? 0 };
 
 			return c.json({ ...result, limit, offset });
 		} catch (e) {
@@ -4228,12 +4208,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 		const id = c.req.param("id");
 		try {
-			const accessor = getDbAccessor();
-			const doc = await accessor.withReadDbAsync(
-				async (db) => {
-					return db.prepare("SELECT * FROM documents WHERE id = ?").get(id);
-				},
-				{ siteToken: "routes/memory-routes.ts:4232" },
+			const doc = await dbOwnerQuery<Record<string, unknown> | undefined>(
+				{ sql: "SELECT * FROM documents WHERE id = ?", params: [id], result: "get" },
+				{ operation: "documents.get", lane: "read", deadlineMs: 3_000 },
 			);
 			if (!doc) return c.json({ error: "Document not found" }, 404);
 			return c.json(doc);
@@ -4263,12 +4240,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				: [scopedAgent.agentId, ...access.args];
 			const documentScopeSql = " AND d.agent_id = ?";
 			const scopePredicate = shouldEnforceAuthScope(c) ? `${documentScopeSql}${access.sql}${projectSql}` : "";
-			const accessor = getDbAccessor();
-			const chunks = await accessor.withReadDbAsync(
-				async (db) => {
-					return db
-						.prepare(
-							`SELECT m.id, m.content, m.type, m.created_at,
+			const chunks = await dbOwnerQuery<unknown[]>(
+				{
+					sql: `SELECT m.id, m.content, m.type, m.created_at,
 					        dm.chunk_index
 					 FROM document_memories dm
 					 JOIN documents d ON d.id = dm.document_id
@@ -4276,10 +4250,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						 WHERE dm.document_id = ? AND d.status != 'deleted' AND m.is_deleted = 0
 						   ${scopePredicate}
 					 ORDER BY dm.chunk_index ASC`,
-						)
-						.all(id, ...(shouldEnforceAuthScope(c) ? scopeArgs : []));
+					params: [id, ...(shouldEnforceAuthScope(c) ? (scopeArgs as Array<string | number | boolean | null>) : [])],
+					result: "all",
 				},
-				{ siteToken: "routes/memory-routes.ts:4267" },
+				{ operation: "documents.list_chunks", lane: "read", deadlineMs: 5_000 },
 			);
 			return c.json({ chunks, count: chunks.length });
 		} catch (e) {
@@ -4298,17 +4272,13 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "reason query parameter is required" }, 400);
 		}
 
-		const accessor = getDbAccessor();
-		const doc = await accessor.withReadDbAsync(
-			async (db) => {
-				return db.prepare("SELECT id, agent_id, project FROM documents WHERE id = ?").get(id) as
-					| ({ id: string } & DocumentScopeRow)
-					| undefined;
-			},
-			{ siteToken: "routes/memory-routes.ts:4302" },
+		const doc = await dbOwnerQuery<({ id: string } & DocumentScopeRow) | undefined>(
+			{ sql: "SELECT id, agent_id, project FROM documents WHERE id = ?", params: [id], result: "get" },
+			{ operation: "documents.get_for_delete", lane: "read", deadlineMs: 3_000 },
 		);
 		if (!doc) return c.json({ error: "Document not found" }, 404);
 
+		const accessor = getDbAccessor();
 		try {
 			const now = new Date().toISOString();
 			const actor = resolveMutationActor(c, "document-api");

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -5,8 +5,7 @@ import type { Hono } from "hono";
 import { invalidateAgentScopeCache } from "../agent-id.js";
 import { requirePermission } from "../auth";
 import { checkPermission } from "../auth/policy";
-import { getDbAccessor, runWriteTxAsync } from "../db-accessor.js";
-import { dbOwnerQuery } from "../db-owner-runtime.js";
+import { dbOwnerBatch, dbOwnerQuery } from "../db-owner-runtime.js";
 import { type LogCategory, type LogEntry, logger } from "../logger.js";
 import { loadPipelineConfig } from "../memory-config.js";
 import {
@@ -18,7 +17,7 @@ import {
 	validateCron,
 } from "../scheduler";
 import { emitTaskStream, getTaskStreamSnapshot, subscribeTaskStream } from "../scheduler/task-stream.js";
-import { readScopedTask, readTaskAgentId } from "../task-scope.js";
+import { readTaskAgentId } from "../task-scope.js";
 import {
 	MAX_UPDATE_INTERVAL_SECONDS,
 	MIN_UPDATE_INTERVAL_SECONDS,
@@ -281,19 +280,23 @@ export function registerMiscRoutes(app: Hono): void {
 		const readPolicy = resolved.readPolicy;
 		const group = resolved.policyGroup;
 		const now = new Date().toISOString();
-		await runWriteTxAsync(getDbAccessor(), (db) => {
-			db.prepare(
-				`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
+		await dbOwnerQuery(
+			{
+				sql: `INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`,
-			).run(name, name, readPolicy, group, now, now);
-		});
+				params: [name, name, readPolicy, group, now, now],
+				result: "run",
+			},
+			{ operation: "agents.create", lane: "write", deadlineMs: 5_000 },
+		);
 		invalidateAgentScopeCache(name);
-		const created = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db
-					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?")
-					.get(name) as unknown as AgentRow,
-			{ siteToken: "routes/misc-routes.ts:291" },
+		const created = await dbOwnerQuery<AgentRow | undefined>(
+			{
+				sql: "SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?",
+				params: [name],
+				result: "get",
+			},
+			{ operation: "agents.get_created", lane: "read", deadlineMs: 2_000 },
 		);
 		return c.json(created, 201);
 	});
@@ -303,12 +306,13 @@ export function registerMiscRoutes(app: Hono): void {
 		if (name === "default") return c.json({ error: "Cannot modify the default agent" }, 400);
 		const body = toRecord(await c.req.json().catch(() => null));
 		if (!body) return c.json({ error: "Invalid JSON body" }, 400);
-		const existing = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db.prepare("SELECT id, read_policy, policy_group FROM agents WHERE name = ?").get(name) as
-					| { id: string; read_policy: string; policy_group: string | null }
-					| undefined,
-			{ siteToken: "routes/misc-routes.ts:306" },
+		const existing = await dbOwnerQuery<{ id: string; read_policy: string; policy_group: string | null } | undefined>(
+			{
+				sql: "SELECT id, read_policy, policy_group FROM agents WHERE name = ?",
+				params: [name],
+				result: "get",
+			},
+			{ operation: "agents.get_for_update", lane: "read", deadlineMs: 2_000 },
 		);
 		if (!existing) return c.json({ error: "Agent not found" }, 404);
 		let resolved: ReturnType<typeof resolveAgentMemoryPolicy>;
@@ -331,18 +335,22 @@ export function registerMiscRoutes(app: Hono): void {
 			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
 		}
 		const now = new Date().toISOString();
-		await runWriteTxAsync(getDbAccessor(), (db) =>
-			db
-				.prepare("UPDATE agents SET read_policy = ?, policy_group = ?, updated_at = ? WHERE id = ?")
-				.run(resolved.readPolicy, resolved.policyGroup, now, existing.id),
+		await dbOwnerQuery(
+			{
+				sql: "UPDATE agents SET read_policy = ?, policy_group = ?, updated_at = ? WHERE id = ?",
+				params: [resolved.readPolicy, resolved.policyGroup, now, existing.id],
+				result: "run",
+			},
+			{ operation: "agents.update", lane: "write", deadlineMs: 5_000 },
 		);
 		invalidateAgentScopeCache(existing.id);
-		const updated = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db
-					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?")
-					.get(existing.id) as unknown as AgentRow,
-			{ siteToken: "routes/misc-routes.ts:340" },
+		const updated = await dbOwnerQuery<AgentRow | undefined>(
+			{
+				sql: "SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?",
+				params: [existing.id],
+				result: "get",
+			},
+			{ operation: "agents.get_updated", lane: "read", deadlineMs: 2_000 },
 		);
 		return c.json({ ...updated, effective_scope: resolved.effectiveScope });
 	});
@@ -351,19 +359,24 @@ export function registerMiscRoutes(app: Hono): void {
 		const name = c.req.param("name");
 		if (name === "default") return c.json({ error: "Cannot remove the default agent" }, 400);
 		const purge = c.req.query("purge") === "true";
-		const agent = await getDbAccessor().withReadDbAsync(
-			async (db) => db.prepare("SELECT id FROM agents WHERE name = ?").get(name) as { id: string } | undefined,
-			{ siteToken: "routes/misc-routes.ts:354" },
+		const agent = await dbOwnerQuery<{ id: string } | undefined>(
+			{ sql: "SELECT id FROM agents WHERE name = ?", params: [name], result: "get" },
+			{ operation: "agents.get_for_delete", lane: "read", deadlineMs: 2_000 },
 		);
 		if (!agent) return c.json({ error: "Agent not found" }, 404);
-		await runWriteTxAsync(getDbAccessor(), (db) => {
-			if (purge) {
-				db.prepare("DELETE FROM memories WHERE agent_id = ?").run(name);
-			} else {
-				db.prepare("UPDATE memories SET visibility = 'archived' WHERE agent_id = ?").run(name);
-			}
-			db.prepare("DELETE FROM agents WHERE id = ?").run(agent.id);
-		});
+		await dbOwnerBatch(
+			[
+				{
+					sql: purge
+						? "DELETE FROM memories WHERE agent_id = ?"
+						: "UPDATE memories SET visibility = 'archived' WHERE agent_id = ?",
+					params: [name],
+					result: "run",
+				},
+				{ sql: "DELETE FROM agents WHERE id = ?", params: [agent.id], result: "run" },
+			],
+			{ operation: "agents.delete", lane: "write", deadlineMs: 10_000 },
+		);
 		invalidateAgentScopeCache(agent.id);
 		return c.json({ success: true, purged: purge });
 	});
@@ -515,9 +528,9 @@ export function registerMiscRoutes(app: Hono): void {
 	app.get("/api/tasks/:id/stream", async (c) => {
 		const taskId = c.req.param("id");
 
-		const taskExists = await getDbAccessor().withReadDbAsync(
-			async (db) => db.prepare("SELECT 1 FROM scheduled_tasks WHERE id = ?").get(taskId),
-			{ siteToken: "routes/misc-routes.ts:518" },
+		const taskExists = await dbOwnerQuery(
+			{ sql: "SELECT 1 FROM scheduled_tasks WHERE id = ?", params: [taskId], result: "get" },
+			{ operation: "tasks.stream_exists", lane: "read", deadlineMs: 2_000 },
 		);
 
 		if (!taskExists) {
@@ -612,11 +625,9 @@ export function registerMiscRoutes(app: Hono): void {
 	});
 
 	app.get("/api/tasks", async (c) => {
-		const tasks = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db
-					.prepare(
-						`SELECT t.*,
+		const tasks = await dbOwnerQuery<unknown[]>(
+			{
+				sql: `SELECT t.*,
 					        r.status AS last_run_status,
 					        r.exit_code AS last_run_exit_code
 					 FROM scheduled_tasks t
@@ -626,9 +637,9 @@ export function registerMiscRoutes(app: Hono): void {
 					     ORDER BY started_at DESC LIMIT 1
 					 )
 					 ORDER BY t.created_at DESC`,
-					)
-					.all(),
-			{ siteToken: "routes/misc-routes.ts:615" },
+				result: "all",
+			},
+			{ operation: "tasks.list", lane: "read", deadlineMs: 5_000 },
 		);
 
 		return c.json({ tasks, presets: CRON_PRESETS });
@@ -675,31 +686,38 @@ export function registerMiscRoutes(app: Hono): void {
 		const now = new Date().toISOString();
 		const nextRunAt = computeNextRun(cronExpression);
 
-		await runWriteTxAsync(getDbAccessor(), (db) => {
-			db.prepare(
-				`INSERT INTO scheduled_tasks
+		await dbOwnerBatch(
+			[
+				{
+					sql: `INSERT INTO scheduled_tasks
 				 (id, name, prompt, cron_expression, harness, working_directory,
 				  enabled, next_run_at, skill_name, skill_mode, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)`,
-			).run(
-				id,
-				name,
-				prompt,
-				cronExpression,
-				harness,
-				workingDirectory || null,
-				nextRunAt,
-				skillName || null,
-				skillMode || null,
-				now,
-				now,
-			);
-			db.prepare(
-				`INSERT INTO task_scope_hints (task_id, agent_id, created_at, updated_at)
+					params: [
+						id,
+						name,
+						prompt,
+						cronExpression,
+						harness,
+						workingDirectory || null,
+						nextRunAt,
+						skillName || null,
+						skillMode || null,
+						now,
+						now,
+					],
+					result: "run",
+				},
+				{
+					sql: `INSERT INTO task_scope_hints (task_id, agent_id, created_at, updated_at)
 				 VALUES (?, ?, ?, ?)
 				 ON CONFLICT(task_id) DO UPDATE SET agent_id = excluded.agent_id, updated_at = excluded.updated_at`,
-			).run(id, scoped.agentId, now, now);
-		});
+					params: [id, scoped.agentId, now, now],
+					result: "run",
+				},
+			],
+			{ operation: "tasks.create", lane: "write", deadlineMs: 10_000 },
+		);
 
 		logger.info("scheduler", `Task created: ${name}`, { taskId: id });
 		return c.json({ id, nextRunAt }, 201);
@@ -708,26 +726,25 @@ export function registerMiscRoutes(app: Hono): void {
 	app.get("/api/tasks/:id", async (c) => {
 		const taskId = c.req.param("id");
 
-		const task = await getDbAccessor().withReadDbAsync(
-			async (db) => db.prepare("SELECT * FROM scheduled_tasks WHERE id = ?").get(taskId),
-			{ siteToken: "routes/misc-routes.ts:711" },
+		const task = await dbOwnerQuery<Record<string, unknown> | undefined>(
+			{ sql: "SELECT * FROM scheduled_tasks WHERE id = ?", params: [taskId], result: "get" },
+			{ operation: "tasks.get", lane: "read", deadlineMs: 2_000 },
 		);
 
 		if (!task) {
 			return c.json({ error: "Task not found" }, 404);
 		}
 
-		const runs = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db
-					.prepare(
-						`SELECT * FROM task_runs
+		const runs = await dbOwnerQuery<unknown[]>(
+			{
+				sql: `SELECT * FROM task_runs
 					 WHERE task_id = ?
 					 ORDER BY started_at DESC
 					 LIMIT 20`,
-					)
-					.all(taskId),
-			{ siteToken: "routes/misc-routes.ts:720" },
+				params: [taskId],
+				result: "all",
+			},
+			{ operation: "tasks.get_runs", lane: "read", deadlineMs: 5_000 },
 		);
 
 		return c.json({ task, runs });
@@ -737,10 +754,10 @@ export function registerMiscRoutes(app: Hono): void {
 		const taskId = c.req.param("id");
 		const body = await c.req.json();
 
-		const existing = (await getDbAccessor().withReadDbAsync(
-			async (db) => db.prepare("SELECT * FROM scheduled_tasks WHERE id = ?").get(taskId),
-			{ siteToken: "routes/misc-routes.ts:740" },
-		)) as Record<string, unknown> | undefined;
+		const existing = await dbOwnerQuery<Record<string, unknown> | undefined>(
+			{ sql: "SELECT * FROM scheduled_tasks WHERE id = ?", params: [taskId], result: "get" },
+			{ operation: "tasks.get_for_update", lane: "read", deadlineMs: 2_000 },
+		);
 
 		if (!existing) {
 			return c.json({ error: "Task not found" }, 404);
@@ -771,27 +788,30 @@ export function registerMiscRoutes(app: Hono): void {
 			return c.json({ error: "skillMode must be 'inject' or 'slash' when skillName is set" }, 400);
 		}
 
-		await runWriteTxAsync(getDbAccessor(), (db) => {
-			db.prepare(
-				`UPDATE scheduled_tasks SET
+		await dbOwnerQuery(
+			{
+				sql: `UPDATE scheduled_tasks SET
 				 name = ?, prompt = ?, cron_expression = ?, harness = ?,
 				 working_directory = ?, enabled = ?, next_run_at = ?,
 				 skill_name = ?, skill_mode = ?, updated_at = ?
 				 WHERE id = ?`,
-			).run(
-				body.name ?? existing.name,
-				body.prompt ?? existing.prompt,
-				cronExpr,
-				body.harness ?? existing.harness,
-				body.workingDirectory !== undefined ? body.workingDirectory : existing.working_directory,
-				enabled,
-				nextRunAt,
-				skillName,
-				skillMode,
-				now,
-				taskId,
-			);
-		});
+				params: [
+					body.name ?? existing.name,
+					body.prompt ?? existing.prompt,
+					cronExpr,
+					body.harness ?? existing.harness,
+					body.workingDirectory !== undefined ? body.workingDirectory : existing.working_directory,
+					enabled,
+					nextRunAt,
+					skillName,
+					skillMode,
+					now,
+					taskId,
+				],
+				result: "run",
+			},
+			{ operation: "tasks.update", lane: "write", deadlineMs: 5_000 },
+		);
 
 		return c.json({ success: true });
 	});
@@ -799,10 +819,10 @@ export function registerMiscRoutes(app: Hono): void {
 	app.delete("/api/tasks/:id", async (c) => {
 		const taskId = c.req.param("id");
 
-		await runWriteTxAsync(getDbAccessor(), (db) => {
-			const info = db.prepare("DELETE FROM scheduled_tasks WHERE id = ?").run(taskId);
-			return info;
-		});
+		await dbOwnerQuery(
+			{ sql: "DELETE FROM scheduled_tasks WHERE id = ?", params: [taskId], result: "run" },
+			{ operation: "tasks.delete", lane: "write", deadlineMs: 5_000 },
+		);
 
 		return c.json({ success: true });
 	});
@@ -812,18 +832,28 @@ export function registerMiscRoutes(app: Hono): void {
 		const scoped = resolveScopedAgentId(c, c.req.query("agent_id"));
 		if (scoped.error) return c.json({ error: scoped.error }, 403);
 
-		const task = await getDbAccessor().withReadDbAsync(
-			async (db) => readScopedTask(db, taskId, scoped.agentId, shouldEnforceAuthScope(c)),
-			{ siteToken: "routes/misc-routes.ts:815" },
+		const task = await dbOwnerQuery<Record<string, unknown> | undefined>(
+			{
+				sql: shouldEnforceAuthScope(c)
+					? "SELECT t.*, COALESCE(h.agent_id, 'default') AS scoped_agent_id FROM scheduled_tasks t LEFT JOIN task_scope_hints h ON h.task_id = t.id WHERE t.id = ? AND COALESCE(h.agent_id, 'default') = ?"
+					: "SELECT t.*, COALESCE(h.agent_id, 'default') AS scoped_agent_id FROM scheduled_tasks t LEFT JOIN task_scope_hints h ON h.task_id = t.id WHERE t.id = ?",
+				params: shouldEnforceAuthScope(c) ? [taskId, scoped.agentId] : [taskId],
+				result: "get",
+			},
+			{ operation: "tasks.get_scoped", lane: "read", deadlineMs: 2_000 },
 		);
 
 		if (!task) {
 			return c.json({ error: "Task not found" }, 404);
 		}
 
-		const running = await getDbAccessor().withReadDbAsync(
-			async (db) => db.prepare("SELECT 1 FROM task_runs WHERE task_id = ? AND status = 'running' LIMIT 1").get(taskId),
-			{ siteToken: "routes/misc-routes.ts:824" },
+		const running = await dbOwnerQuery(
+			{
+				sql: "SELECT 1 FROM task_runs WHERE task_id = ? AND status = 'running' LIMIT 1",
+				params: [taskId],
+				result: "get",
+			},
+			{ operation: "tasks.running", lane: "read", deadlineMs: 2_000 },
 		);
 
 		if (running) {
@@ -833,14 +863,22 @@ export function registerMiscRoutes(app: Hono): void {
 		const runId = crypto.randomUUID();
 		const now = new Date().toISOString();
 
-		await runWriteTxAsync(getDbAccessor(), (db) => {
-			db.prepare(
-				`INSERT INTO task_runs (id, task_id, status, started_at)
+		await dbOwnerBatch(
+			[
+				{
+					sql: `INSERT INTO task_runs (id, task_id, status, started_at)
 				 VALUES (?, ?, 'running', ?)`,
-			).run(runId, taskId, now);
-
-			db.prepare("UPDATE scheduled_tasks SET last_run_at = ?, updated_at = ? WHERE id = ?").run(now, now, taskId);
-		});
+					params: [runId, taskId, now],
+					result: "run",
+				},
+				{
+					sql: "UPDATE scheduled_tasks SET last_run_at = ?, updated_at = ? WHERE id = ?",
+					params: [now, now, taskId],
+					result: "run",
+				},
+			],
+			{ operation: "tasks.start_run", lane: "write", deadlineMs: 10_000 },
+		);
 
 		emitTaskStream({
 			type: "run-started",
@@ -902,14 +940,17 @@ export function registerMiscRoutes(app: Hono): void {
 					const status =
 						result.error !== null || (result.exitCode !== null && result.exitCode !== 0) ? "failed" : "completed";
 
-					await runWriteTxAsync(getDbAccessor(), (db) => {
-						db.prepare(
-							`UPDATE task_runs
+					await dbOwnerQuery(
+						{
+							sql: `UPDATE task_runs
 						 SET status = ?, completed_at = ?, exit_code = ?,
 						     stdout = ?, stderr = ?, error = ?
 						 WHERE id = ?`,
-						).run(status, completedAt, result.exitCode, result.stdout, result.stderr, result.error, runId);
-					});
+							params: [status, completedAt, result.exitCode, result.stdout, result.stderr, result.error, runId],
+							result: "run",
+						},
+						{ operation: "tasks.complete_run", lane: "write", deadlineMs: 10_000 },
+					);
 
 					emitTaskStream({
 						type: "run-completed",
@@ -945,28 +986,23 @@ export function registerMiscRoutes(app: Hono): void {
 		const limit = Number(c.req.query("limit") ?? 20);
 		const offset = Number(c.req.query("offset") ?? 0);
 
-		const runs = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db
-					.prepare(
-						`SELECT * FROM task_runs
+		const runs = await dbOwnerQuery<unknown[]>(
+			{
+				sql: `SELECT * FROM task_runs
 					 WHERE task_id = ?
 					 ORDER BY started_at DESC
 					 LIMIT ? OFFSET ?`,
-					)
-					.all(taskId, limit, offset),
-			{ siteToken: "routes/misc-routes.ts:948" },
+				params: [taskId, limit, offset],
+				result: "all",
+			},
+			{ operation: "tasks.list_runs", lane: "read", deadlineMs: 5_000 },
 		);
 
-		const total = await getDbAccessor().withReadDbAsync(
-			async (db) => {
-				const row = db.prepare("SELECT COUNT(*) as count FROM task_runs WHERE task_id = ?").get(taskId) as {
-					count: number;
-				};
-				return row.count;
-			},
-			{ siteToken: "routes/misc-routes.ts:961" },
+		const totalRow = await dbOwnerQuery<{ count: number } | undefined>(
+			{ sql: "SELECT COUNT(*) as count FROM task_runs WHERE task_id = ?", params: [taskId], result: "get" },
+			{ operation: "tasks.count_runs", lane: "read", deadlineMs: 2_000 },
 		);
+		const total = totalRow?.count ?? 0;
 
 		return c.json({ runs, total, hasMore: offset + limit < total });
 	});

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -18,7 +18,7 @@ import {
 import type { Context, Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
 import { getPeerAddress } from "../auth/middleware";
-import { type ReadDb, getDbAccessor } from "../db-accessor";
+import { dbOwnerQuery, dbOwnerSourceEvidenceEligibility } from "../db-owner-runtime";
 import { fetchEmbedding } from "../embedding-fetch";
 import { type ImportExtractionOutcome, readImportedSourceOutcome } from "../imported-source-outcome";
 import { logger } from "../logger";
@@ -30,7 +30,7 @@ import {
 	resolveEmbeddingBridgeOptions,
 	startNativeMemoryBridge,
 } from "../native-memory-sources";
-import { sourceHasEligibleUnconsumedEvidence } from "../pipeline/dreaming-evidence-consumption";
+
 import { getActiveTelemetry } from "../telemetry";
 import {
 	type SourceIndexJob,
@@ -181,27 +181,30 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	const recordIndexOperation = deps.recordIndexOperation ?? recordSourceIndexOperation;
 	const pickerExecFile = deps.pickerExecFile ?? execFileAsync;
 	const pickerPlatform = deps.pickerPlatform ?? process.platform;
-	app.get("/api/sources", (c) => {
+	app.get("/api/sources", async (c) => {
 		const config = loadSourcesConfig(agentsDir);
 		const agentId = resolveDaemonAgentId();
 		const tombstonedSourceGenerations = loadTombstonedSourceGenerations(agentsDir, agentId);
-		return c.json({
-			version: config.version,
-			sources: config.sources
+		const sources = await Promise.all(
+			config.sources
 				.filter(
 					(source) =>
 						isSourceVisibleToAgent(source, agentId) &&
 						!isSourceGenerationTombstoned(source, tombstonedSourceGenerations),
 				)
-				.map((source) => {
-					const stats = sourceStats(source, agentId);
+				.map(async (source) => {
+					const stats = await sourceStats(source, agentId);
 					return {
 						...source,
 						stats,
-						health: sourceHealth(source, agentId, stats),
+						health: await sourceHealth(source, agentId, stats),
 						indexJob: getSourceIndexJob(source.id),
 					};
 				}),
+		);
+		return c.json({
+			version: config.version,
+			sources,
 		});
 	});
 
@@ -337,13 +340,13 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		);
 	});
 
-	app.get("/api/sources/:sourceId/health", (c) => {
+	app.get("/api/sources/:sourceId/health", async (c) => {
 		const sourceId = c.req.param("sourceId");
 		const source = findConfiguredSource(sourceId, agentsDir, resolveDaemonAgentId());
 		if (!source) return c.json({ error: "Source not found" }, 404);
 		const agentId = resolveDaemonAgentId();
-		const stats = sourceStats(source, agentId);
-		return c.json({ source, stats, health: sourceHealth(source, agentId, stats) });
+		const stats = await sourceStats(source, agentId);
+		return c.json({ source, stats, health: await sourceHealth(source, agentId, stats) });
 	});
 
 	app.post("/api/sources/:sourceId/snapshot/import", async (c) => {
@@ -898,77 +901,52 @@ interface SourceHealth {
 	};
 }
 
-function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
+async function sourceStats(source: SignetSourceEntry, agentId: string): Promise<SourceStats> {
 	const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
 	const chunkPrefix = `${source.id}:`;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-			const artifacts =
-				source.kind === "obsidian"
-					? countRow(
-							db
-								.prepare(
-									`SELECT COUNT(*) AS n FROM memory_artifacts
-									 WHERE agent_id = ?
-									   AND (
-										   source_id = ?
-										   OR (
-											   harness = 'obsidian'
-											   AND source_id IS NULL
-											   AND source_path >= ?
-											   AND source_path < ?
-										   )
-									   )
-									   AND COALESCE(is_deleted, 0) = 0`,
-								)
-								.get(agentId, source.id, rootPrefix, `${rootPrefix}\uffff`),
-						)
-					: countRow(
-							db
-								.prepare(
-									`SELECT COUNT(*) AS n FROM memory_artifacts
-									 WHERE agent_id = ?
-									   AND source_id = ?
-									   AND COALESCE(is_deleted, 0) = 0`,
-								)
-								.get(agentId, source.id),
-						);
-			const chunks = countRow(
-				db
-					.prepare(
-						`SELECT COUNT(*) AS n FROM embeddings
-						 WHERE agent_id = ?
-						   AND source_type IN (?, ?)
-						   AND source_id >= ?
-						   AND source_id < ?`,
-					)
-					.get(
+		const artifactSql =
+			source.kind === "obsidian"
+				? `SELECT COUNT(*) AS n FROM memory_artifacts
+				 WHERE agent_id = ? AND (source_id = ? OR (harness = 'obsidian' AND source_id IS NULL AND source_path >= ? AND source_path < ?))
+				   AND COALESCE(is_deleted, 0) = 0`
+				: `SELECT COUNT(*) AS n FROM memory_artifacts
+				 WHERE agent_id = ? AND source_id = ? AND COALESCE(is_deleted, 0) = 0`;
+		const artifactParams =
+			source.kind === "obsidian" ? [agentId, source.id, rootPrefix, `${rootPrefix}\uffff`] : [agentId, source.id];
+		const [artifactRow, chunkRow, hasEligibleUnconsumedEvidence] = await Promise.all([
+			dbOwnerQuery<{ n: number }>(
+				{ sql: artifactSql, params: artifactParams, result: "get" },
+				{ operation: "sources.stats_artifacts", lane: "read", deadlineMs: 3_000 },
+			),
+			dbOwnerQuery<{ n: number }>(
+				{
+					sql: `SELECT COUNT(*) AS n FROM embeddings WHERE agent_id = ? AND source_type IN (?, ?) AND source_id >= ? AND source_id < ?`,
+					params: [
 						agentId,
 						SOURCE_CHUNK_SOURCE_TYPE,
 						LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
 						chunkPrefix,
 						`${chunkPrefix}\uffff`,
-					),
-			);
-			return {
-				artifacts,
-				chunks,
-				indexed: artifacts,
-				hasEligibleUnconsumedEvidence: sourceHasEligibleUnconsumedEvidence(
-					db,
-					agentId,
-					source.id,
-					source.kind === "obsidian" ? source.root : undefined,
-				),
-			};
-		}, "routes/sources-routes.ts:906");
+					],
+					result: "get",
+				},
+				{ operation: "sources.stats_chunks", lane: "read", deadlineMs: 3_000 },
+			),
+			dbOwnerSourceEvidenceEligibility(
+				{ agentId, sourceEntryId: source.id, legacyObsidianRoot: source.kind === "obsidian" ? source.root : undefined },
+				{ operation: "sources.stats_evidence", deadlineMs: 3_000 },
+			),
+		]);
+		const artifacts = Number(artifactRow?.n ?? 0);
+		const chunks = Number(chunkRow?.n ?? 0);
+		return { artifacts, chunks, indexed: artifacts, hasEligibleUnconsumedEvidence };
 	} catch {
 		return { artifacts: 0, chunks: 0, indexed: 0, hasEligibleUnconsumedEvidence: false };
 	}
 }
 
-function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceStats): SourceHealth {
+async function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceStats): Promise<SourceHealth> {
 	const generatedAt = new Date().toISOString();
 	try {
 		const permission =
@@ -978,11 +956,13 @@ function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceS
 						agentId,
 					)
 				: { status: "clear" as const, issues: [] };
-		const artifactSummary = artifactHealthSummary(source, agentId);
-		const discordSummary = discordHealthSummary(source, agentId);
-		const semantic = semanticHealthSummary(source, agentId);
+		const [artifactSummary, discordSummary, semantic, orphanChunks] = await Promise.all([
+			artifactHealthSummary(source, agentId),
+			discordHealthSummary(source, agentId),
+			semanticHealthSummary(source, agentId),
+			sourceOrphanChunks(source, agentId),
+		]);
 		const importExtraction = source.kind === "import" ? readImportedSourceOutcome(source.id, agentId) : undefined;
-		const orphanChunks = sourceOrphanChunks(source, agentId);
 		const hasDegradation =
 			permission.status === "denied" ||
 			discordSummary.failures.total > 0 ||
@@ -1039,62 +1019,53 @@ function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceS
 	}
 }
 
-function sourceOrphanChunks(source: SignetSourceEntry, agentId: string): number {
+async function sourceOrphanChunks(source: SignetSourceEntry, agentId: string): Promise<number> {
 	const chunkPrefix = `${source.id}:`;
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-		const livePaths = liveSourceArtifactPaths(db, source, agentId);
-		const chunks = db
-			.prepare(
-				`SELECT source_id, chunk_text
-				   FROM embeddings
-				  WHERE agent_id = ?
-				    AND source_type IN (?, ?)
-				    AND source_id >= ?
-				    AND source_id < ?`,
-			)
-			.all(
-				agentId,
-				SOURCE_CHUNK_SOURCE_TYPE,
-				LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
-				chunkPrefix,
-				`${chunkPrefix}\uffff`,
-			) as SourceChunkHealthRow[];
-		return chunks.filter((chunk) => !sourceChunkMatchesLiveArtifact(source, chunk, livePaths)).length;
-	}, "routes/sources-routes.ts:1045");
+	const [livePaths, chunks] = await Promise.all([
+		liveSourceArtifactPaths(source, agentId),
+		dbOwnerQuery<SourceChunkHealthRow[]>(
+			{
+				sql: `SELECT source_id, chunk_text FROM embeddings
+				 WHERE agent_id = ? AND source_type IN (?, ?) AND source_id >= ? AND source_id < ?`,
+				params: [
+					agentId,
+					SOURCE_CHUNK_SOURCE_TYPE,
+					LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+					chunkPrefix,
+					`${chunkPrefix}\uffff`,
+				],
+				result: "all",
+			},
+			{ operation: "sources.health_orphan_chunks", lane: "read", deadlineMs: 5_000 },
+		),
+	]);
+	return chunks.filter((chunk) => !sourceChunkMatchesLiveArtifact(source, chunk, livePaths)).length;
 }
 
-function liveSourceArtifactPaths(db: ReadDb, source: SignetSourceEntry, agentId: string): ReadonlySet<string> {
+async function liveSourceArtifactPaths(source: SignetSourceEntry, agentId: string): Promise<ReadonlySet<string>> {
 	if (source.kind === "obsidian") {
 		const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
-		const rows = db
-			.prepare(
-				`SELECT source_path
-				   FROM memory_artifacts
-				  WHERE agent_id = ?
-				    AND COALESCE(is_deleted, 0) = 0
-				    AND (
-					    source_id = ?
-					    OR (
-						    harness = 'obsidian'
-						    AND source_id IS NULL
-						    AND source_path >= ?
-						    AND source_path < ?
-					    )
-				    )`,
-			)
-			.all(agentId, source.id, rootPrefix, `${rootPrefix}\uffff`) as SourcePathHealthRow[];
+		const rows = await dbOwnerQuery<SourcePathHealthRow[]>(
+			{
+				sql: `SELECT source_path FROM memory_artifacts
+				 WHERE agent_id = ? AND COALESCE(is_deleted, 0) = 0
+				   AND (source_id = ? OR (harness = 'obsidian' AND source_id IS NULL AND source_path >= ? AND source_path < ?))`,
+				params: [agentId, source.id, rootPrefix, `${rootPrefix}\uffff`],
+				result: "all",
+			},
+			{ operation: "sources.health_live_paths", lane: "read", deadlineMs: 5_000 },
+		);
 		return new Set(rows.map((row) => normalizeSourcePath(row.source_path)));
 	}
-	const rows = db
-		.prepare(
-			`SELECT source_path
-			   FROM memory_artifacts
-			  WHERE agent_id = ?
-			    AND source_id = ?
-			    AND COALESCE(is_deleted, 0) = 0`,
-		)
-		.all(agentId, source.id) as SourcePathHealthRow[];
+	const rows = await dbOwnerQuery<SourcePathHealthRow[]>(
+		{
+			sql: `SELECT source_path FROM memory_artifacts
+			 WHERE agent_id = ? AND source_id = ? AND COALESCE(is_deleted, 0) = 0`,
+			params: [agentId, source.id],
+			result: "all",
+		},
+		{ operation: "sources.health_live_paths", lane: "read", deadlineMs: 5_000 },
+	);
 	return new Set(rows.map((row) => normalizeSourcePath(row.source_path)));
 }
 
@@ -1146,53 +1117,33 @@ function normalizeSourcePath(value: string): string {
 	return value.replace(/\\/g, "/").replace(/([^:])\/{2,}/g, "$1/");
 }
 
-function artifactHealthSummary(
+async function artifactHealthSummary(
 	source: SignetSourceEntry,
 	agentId: string,
-): {
+): Promise<{
 	readonly latestArtifactAt: string | null;
 	readonly deletedArtifacts: number;
-} {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-		if (source.kind === "obsidian") {
-			const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
-			const row = db
-				.prepare(
-					`SELECT MAX(updated_at) AS latestArtifactAt,
-					        SUM(CASE WHEN COALESCE(is_deleted, 0) = 1 THEN 1 ELSE 0 END) AS deletedArtifacts
-					   FROM memory_artifacts
-					  WHERE agent_id = ?
-					    AND (
-						    source_id = ?
-						    OR (
-							    harness = 'obsidian'
-							    AND source_id IS NULL
-							    AND source_path >= ?
-							    AND source_path < ?
-						    )
-					    )`,
-				)
-				.get(agentId, source.id, rootPrefix, `${rootPrefix}\uffff`) as HealthAggregateRow | null;
-			return {
-				latestArtifactAt: stringOrNull(row?.latestArtifactAt),
-				deletedArtifacts: numberOrZero(row?.deletedArtifacts),
-			};
-		}
-		const row = db
-			.prepare(
-				`SELECT MAX(updated_at) AS latestArtifactAt,
-				        SUM(CASE WHEN COALESCE(is_deleted, 0) = 1 THEN 1 ELSE 0 END) AS deletedArtifacts
-				   FROM memory_artifacts
-				  WHERE agent_id = ?
-				    AND source_id = ?`,
-			)
-			.get(agentId, source.id) as HealthAggregateRow | null;
-		return {
-			latestArtifactAt: stringOrNull(row?.latestArtifactAt),
-			deletedArtifacts: numberOrZero(row?.deletedArtifacts),
-		};
-	}, "routes/sources-routes.ts:1157");
+}> {
+	const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
+	const sql =
+		source.kind === "obsidian"
+			? `SELECT MAX(updated_at) AS latestArtifactAt,
+			        SUM(CASE WHEN COALESCE(is_deleted, 0) = 1 THEN 1 ELSE 0 END) AS deletedArtifacts
+			   FROM memory_artifacts WHERE agent_id = ?
+			     AND (source_id = ? OR (harness = 'obsidian' AND source_id IS NULL AND source_path >= ? AND source_path < ?))`
+			: `SELECT MAX(updated_at) AS latestArtifactAt,
+			        SUM(CASE WHEN COALESCE(is_deleted, 0) = 1 THEN 1 ELSE 0 END) AS deletedArtifacts
+			   FROM memory_artifacts WHERE agent_id = ? AND source_id = ?`;
+	const params =
+		source.kind === "obsidian" ? [agentId, source.id, rootPrefix, `${rootPrefix}\uffff`] : [agentId, source.id];
+	const row = await dbOwnerQuery<HealthAggregateRow | undefined>(
+		{ sql, params, result: "get" },
+		{ operation: "sources.health_artifacts", lane: "read", deadlineMs: 3_000 },
+	);
+	return {
+		latestArtifactAt: stringOrNull(row?.latestArtifactAt),
+		deletedArtifacts: numberOrZero(row?.deletedArtifacts),
+	};
 }
 
 interface DiscordHealthSummary {
@@ -1208,7 +1159,7 @@ interface DiscordHealthSummary {
 	};
 }
 
-function discordHealthSummary(source: SignetSourceEntry, agentId: string): DiscordHealthSummary {
+async function discordHealthSummary(source: SignetSourceEntry, agentId: string): Promise<DiscordHealthSummary> {
 	if (source.kind !== "discord") {
 		return {
 			latestCheckpointAt: null,
@@ -1216,91 +1167,104 @@ function discordHealthSummary(source: SignetSourceEntry, agentId: string): Disco
 			checkpoints: { total: 0, partial: 0, stale: 0 },
 		};
 	}
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-		const rows = db
-			.prepare(
-				`SELECT source_kind, source_meta_json, updated_at
-				   FROM memory_artifacts
-				  WHERE agent_id = ?
-				    AND source_id = ?
-				    AND source_kind IN ('source_discord_failure', 'source_discord_checkpoint')
-				    AND COALESCE(is_deleted, 0) = 0`,
-			)
-			.all(agentId, source.id) as DiscordHealthRow[];
-		let failures = 0;
-		let recoverable = 0;
-		let checkpoints = 0;
-		let partial = 0;
-		let stale = 0;
-		let latestCheckpointAt: string | null = null;
-		for (const row of rows) {
-			const meta = parseJsonObject(row.source_meta_json);
-			if (row.source_kind === "source_discord_failure") {
-				failures++;
-				if (meta?.recoverable === true) recoverable++;
-				continue;
-			}
-			checkpoints++;
-			if (meta?.status === "partial") partial++;
-			if (isStaleCheckpoint(row.updated_at, source.lastIndexedAt)) stale++;
-			latestCheckpointAt = maxIsoTimestamp(latestCheckpointAt, stringOrNull(row.updated_at));
-		}
-		return {
-			latestCheckpointAt,
-			failures: { total: failures, recoverable },
-			checkpoints: { total: checkpoints, partial, stale },
-		};
-	}, "routes/sources-routes.ts:1220");
-}
-
-function semanticHealthSummary(source: SignetSourceEntry, agentId: string): SourceHealth["semantic"] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-		const entities = countSourceRows(db, "entities", agentId, source.id);
-		const documentEntity = db
-			.prepare(
-				`SELECT id
-				   FROM entities
-				  WHERE agent_id = ? AND source_id = ? AND entity_type = 'source_document'
-				  ORDER BY updated_at DESC
-				  LIMIT 1`,
-			)
-			.get(agentId, source.id) as { id: string } | null | undefined;
-		const aspects = countRow(
-			db
-				.prepare(
-					`SELECT COUNT(*) AS n
-					   FROM entity_aspects AS a
-					   JOIN entities AS e ON e.id = a.entity_id AND e.agent_id = a.agent_id
-					  WHERE a.agent_id = ? AND e.source_id = ?`,
-				)
-				.get(agentId, source.id),
-		);
-		const attributes = countSourceRows(db, "entity_attributes", agentId, source.id);
-		const dependencies = countSourceRows(db, "entity_dependencies", agentId, source.id);
-		const communities = countSourceRows(db, "entity_communities", agentId, source.id);
-		return {
-			entities,
-			aspects,
-			attributes,
-			dependencies,
-			communities,
-			total: entities + aspects + attributes + dependencies + communities,
-			documentEntityId: documentEntity?.id ?? null,
-		};
-	}, "routes/sources-routes.ts:1259");
-}
-
-function countSourceRows(
-	db: { prepare: (sql: string) => { get: (...args: unknown[]) => unknown } },
-	table: string,
-	agentId: string,
-	sourceId: string,
-): number {
-	return countRow(
-		db.prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE agent_id = ? AND source_id = ?`).get(agentId, sourceId),
+	const rows = await dbOwnerQuery<DiscordHealthRow[]>(
+		{
+			sql: `SELECT source_kind, source_meta_json, updated_at FROM memory_artifacts WHERE agent_id = ? AND source_id = ? AND source_kind IN ('source_discord_failure', 'source_discord_checkpoint') AND COALESCE(is_deleted, 0) = 0`,
+			params: [agentId, source.id],
+			result: "all",
+		},
+		{ operation: "sources.health_discord", lane: "read", deadlineMs: 5_000 },
 	);
+	let failures = 0;
+	let recoverable = 0;
+	let checkpoints = 0;
+	let partial = 0;
+	let stale = 0;
+	let latestCheckpointAt: string | null = null;
+	for (const row of rows) {
+		const meta = parseJsonObject(row.source_meta_json);
+		if (row.source_kind === "source_discord_failure") {
+			failures++;
+			if (meta?.recoverable === true) recoverable++;
+			continue;
+		}
+		checkpoints++;
+		if (meta?.status === "partial") partial++;
+		if (isStaleCheckpoint(row.updated_at, source.lastIndexedAt)) stale++;
+		latestCheckpointAt = maxIsoTimestamp(latestCheckpointAt, stringOrNull(row.updated_at));
+	}
+	return {
+		latestCheckpointAt,
+		failures: { total: failures, recoverable },
+		checkpoints: { total: checkpoints, partial, stale },
+	};
+}
+
+async function semanticHealthSummary(source: SignetSourceEntry, agentId: string): Promise<SourceHealth["semantic"]> {
+	const [entityRow, documentEntity, aspectsRow, attributesRow, dependenciesRow, communitiesRow] = await Promise.all([
+		dbOwnerQuery<{ n: number }>(
+			{
+				sql: "SELECT COUNT(*) AS n FROM entities WHERE agent_id = ? AND source_id = ?",
+				params: [agentId, source.id],
+				result: "get",
+			},
+			{ operation: "sources.health_entities", lane: "read", deadlineMs: 3_000 },
+		),
+		dbOwnerQuery<{ id: string } | undefined>(
+			{
+				sql: "SELECT id FROM entities WHERE agent_id = ? AND source_id = ? AND entity_type = 'source_document' ORDER BY updated_at DESC LIMIT 1",
+				params: [agentId, source.id],
+				result: "get",
+			},
+			{ operation: "sources.health_document_entity", lane: "read", deadlineMs: 3_000 },
+		),
+		dbOwnerQuery<{ n: number }>(
+			{
+				sql: "SELECT COUNT(*) AS n FROM entity_aspects AS a JOIN entities AS e ON e.id = a.entity_id AND e.agent_id = a.agent_id WHERE a.agent_id = ? AND e.source_id = ?",
+				params: [agentId, source.id],
+				result: "get",
+			},
+			{ operation: "sources.health_aspects", lane: "read", deadlineMs: 3_000 },
+		),
+		dbOwnerQuery<{ n: number }>(
+			{
+				sql: "SELECT COUNT(*) AS n FROM entity_attributes WHERE agent_id = ? AND source_id = ?",
+				params: [agentId, source.id],
+				result: "get",
+			},
+			{ operation: "sources.health_attributes", lane: "read", deadlineMs: 3_000 },
+		),
+		dbOwnerQuery<{ n: number }>(
+			{
+				sql: "SELECT COUNT(*) AS n FROM entity_dependencies WHERE agent_id = ? AND source_id = ?",
+				params: [agentId, source.id],
+				result: "get",
+			},
+			{ operation: "sources.health_dependencies", lane: "read", deadlineMs: 3_000 },
+		),
+		dbOwnerQuery<{ n: number }>(
+			{
+				sql: "SELECT COUNT(*) AS n FROM entity_communities WHERE agent_id = ? AND source_id = ?",
+				params: [agentId, source.id],
+				result: "get",
+			},
+			{ operation: "sources.health_communities", lane: "read", deadlineMs: 3_000 },
+		),
+	]);
+	const entities = Number(entityRow?.n ?? 0);
+	const aspects = Number(aspectsRow?.n ?? 0);
+	const attributes = Number(attributesRow?.n ?? 0);
+	const dependencies = Number(dependenciesRow?.n ?? 0);
+	const communities = Number(communitiesRow?.n ?? 0);
+	return {
+		entities,
+		aspects,
+		attributes,
+		dependencies,
+		communities,
+		total: entities + aspects + attributes + dependencies + communities,
+		documentEntityId: documentEntity?.id ?? null,
+	};
 }
 
 interface HealthAggregateRow {
@@ -1346,12 +1310,6 @@ function stringOrNull(value: unknown): string | null {
 
 function numberOrZero(value: unknown): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function countRow(row: unknown): number {
-	return typeof row === "object" && row !== null && "n" in row && typeof (row as { n?: unknown }).n === "number"
-		? (row as { n: number }).n
-		: 0;
 }
 
 async function pickFiles(

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(931);
+	expect(baseline).toHaveLength(902);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(104);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(191);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(167);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,16 +353,16 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 931 sites");
-	expect(report).toContain("65 synchronous writes, 104 synchronous reads, and 246 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 244");
+	expect(report).toContain("Exact ledger inventory: 902 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 222 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 220");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 244 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 220 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 415");
-	expect(report).toContain("ON-PARENT callback execution: 413");
+	expect(report).toContain("Database accessor sites classified: 386");
+	expect(report).toContain("ON-PARENT callback execution: 384");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -844,70 +844,70 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 123,
+      "line": 124,
       "api": "readFileSync",
       "source": "return readFileSync(cancellationRegistryPath, \"utf8\").includes(`${jobId}\\n`);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 151,
+      "line": 152,
       "api": "writeFileSync",
       "source": "writeFileSync(startupStarted, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 153,
+      "line": 154,
       "api": "existsSync",
       "source": "while (!existsSync(startupRelease)) Atomics.wait(signal, 0, 0, 5);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 159,
+      "line": 160,
       "api": "existsSync",
       "source": "if (sqlitePath !== undefined && existsSync(sqlitePath) && typeof Database.setCustomSQLite === \"function\") {",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 188,
+      "line": 189,
       "api": "writeFileSync",
       "source": "if (commitMarker !== undefined) writeFileSync(commitMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 864,
+      "line": 876,
       "api": "withReadDbAsync",
       "source": "const embedding = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 897,
+      "line": 909,
       "api": "withReadDbAsync",
       "source": "return await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 907,
+      "line": 919,
       "api": "writeFileSync",
       "source": "writeFileSync(startedMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 908,
+      "line": 920,
       "api": "existsSync",
       "source": "while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 1001,
+      "line": 1014,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"
@@ -4071,373 +4071,205 @@
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 120,
+      "line": 121,
       "api": "withReadDbAsync",
       "source": "embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding), {",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 289,
+      "line": 290,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 305,
+      "line": 306,
       "api": "writeFileSync",
       "source": "writeFileSync(path, noteContent, { encoding: \"utf-8\", flag: \"wx\" });",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 628,
-      "api": "withReadDbAsync",
-      "source": "const rows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 981,
-      "api": "withReadDbAsync",
-      "source": "const row = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1025,
+      "line": 1022,
       "api": "withReadDbAsync",
       "source": "const result = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1105,
+      "line": 1102,
       "api": "withReadDbAsync",
       "source": "const memories = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1160,
+      "line": 1157,
       "api": "withReadDbAsync",
       "source": "const slices = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1261,
+      "line": 1258,
       "api": "withReadDbAsync",
       "source": "const timeline = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1308,
-      "api": "withReadDbAsync",
-      "source": "const rows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1346,
-      "api": "withReadDbAsync",
-      "source": "const values = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1377,
+      "line": 1368,
       "api": "withReadDbAsync",
       "source": "const results = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1679,
+      "line": 1670,
       "api": "withReadDbAsync",
       "source": "const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1687,
+      "line": 1678,
       "api": "withReadDbAsync",
       "source": "const existingChunks = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1721,
+      "line": 1712,
       "api": "withReadDbAsync",
       "source": "const byHash = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1928,
+      "line": 1919,
       "api": "withReadDbAsync",
       "source": ": await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2053,
+      "line": 2044,
       "api": "withReadDbAsync",
       "source": "const existing = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2272,
+      "line": 2263,
       "api": "withReadDbAsync",
       "source": "const memoryRead = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2342,
-      "api": "withReadDbAsync",
-      "source": "const exists = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2352,
-      "api": "withReadDbAsync",
-      "source": "const history = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2453,
+      "line": 2442,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2528,
-      "api": "withReadDbAsync",
-      "source": "const maybeRow = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3654,
+      "line": 3641,
       "api": "withReadDbAsync",
       "source": "const embeddingRow = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3688,
+      "line": 3675,
       "api": "withReadDbAsync",
       "source": "? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions), {",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3706,
+      "line": 3693,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3787,
+      "line": 3774,
       "api": "withReadDbAsync",
       "source": "const { total, rows } = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3872,
+      "line": 3859,
       "api": "withReadDbAsync",
       "source": "const index = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3890,
+      "line": 3877,
       "api": "withReadDbAsync",
       "source": "const report = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3953,
+      "line": 3940,
       "api": "withReadDbAsync",
       "source": "const projection = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3993,
+      "line": 3980,
       "api": "withReadDbAsync",
       "source": "const { cached, total } = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4034,
+      "line": 4021,
       "api": "withReadDbAsync",
       "source": "const result = await getDbAccessor().withReadDbAsync(async (db) => computeProjection(db, nComponents), {",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4037,
+      "line": 4024,
       "api": "withReadDbAsync",
       "source": "const count = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
-      "path": "routes/memory-routes.ts",
-      "line": 4191,
-      "api": "withReadDbAsync",
-      "source": "const result = await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4232,
-      "api": "withReadDbAsync",
-      "source": "const doc = await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4267,
-      "api": "withReadDbAsync",
-      "source": "const chunks = await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4302,
-      "api": "withReadDbAsync",
-      "source": "const doc = await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/misc-routes.ts",
-      "line": 133,
+      "line": 132,
       "api": "readdirSync",
       "source": "const dirFiles = readdirSync(AGENTS_DIR);",
       "category": "hot-path"
     },
     {
       "path": "routes/misc-routes.ts",
-      "line": 138,
+      "line": 137,
       "api": "statSync",
       "source": "const fileStat = statSync(filePath);",
       "category": "hot-path"
     },
     {
       "path": "routes/misc-routes.ts",
-      "line": 140,
+      "line": 139,
       "api": "readFileSync",
       "source": "const content = readFileSync(filePath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "routes/misc-routes.ts",
-      "line": 201,
+      "line": 200,
       "api": "writeFileSync",
       "source": "writeFileSync(filePath, content, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 291,
-      "api": "withReadDbAsync",
-      "source": "const created = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 306,
-      "api": "withReadDbAsync",
-      "source": "const existing = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 340,
-      "api": "withReadDbAsync",
-      "source": "const updated = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 354,
-      "api": "withReadDbAsync",
-      "source": "const agent = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 518,
-      "api": "withReadDbAsync",
-      "source": "const taskExists = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 615,
-      "api": "withReadDbAsync",
-      "source": "const tasks = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 711,
-      "api": "withReadDbAsync",
-      "source": "const task = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 720,
-      "api": "withReadDbAsync",
-      "source": "const runs = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 740,
-      "api": "withReadDbAsync",
-      "source": "const existing = (await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 815,
-      "api": "withReadDbAsync",
-      "source": "const task = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 824,
-      "api": "withReadDbAsync",
-      "source": "const running = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 948,
-      "api": "withReadDbAsync",
-      "source": "const runs = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 961,
-      "api": "withReadDbAsync",
-      "source": "const total = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
@@ -4904,72 +4736,37 @@
     },
     {
       "path": "routes/sources-routes.ts",
-      "line": 821,
+      "line": 824,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return [];",
       "category": "hot-path"
     },
     {
       "path": "routes/sources-routes.ts",
-      "line": 823,
+      "line": 826,
       "api": "readFileSync",
       "source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as unknown;",
       "category": "hot-path"
     },
     {
       "path": "routes/sources-routes.ts",
-      "line": 833,
+      "line": 836,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(path), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/sources-routes.ts",
-      "line": 835,
+      "line": 838,
       "api": "writeFileSync",
       "source": "writeFileSync(tmp, `${JSON.stringify(tombstones, null, 2)}\\n`, \"utf8\");",
       "category": "hot-path"
     },
     {
       "path": "routes/sources-routes.ts",
-      "line": 836,
+      "line": 839,
       "api": "renameSync",
       "source": "renameSync(tmp, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 906,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1045,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1157,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1220,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1259,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {

--- a/scripts/legacy-sync-db-baseline.json
+++ b/scripts/legacy-sync-db-baseline.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"generatedFrom": "bun scripts/legacy-sync-db-baseline.ts",
 	"markedCallsites": {
-		"total": 169,
-		"withReadDb": 104,
+		"total": 164,
+		"withReadDb": 99,
 		"withWriteTx": 65
 	}
 }


### PR DESCRIPTION
L1 WAVE 5 — the loop-8 stall family. Baseline: async ON-PARENT 244 -> 220; legacy sync 169 -> 164; total ON-PARENT callbacks 436 -> 384.

## Summary

- The exact sites named by loop-8's 73s stall latches (sources-routes.ts:906/1045/1157/1220/1259, memory-routes.ts:1025, imported-source-outcome.ts:62) plus the remaining routes-cluster sites now execute through owner IPC: new source-evidence owner op, owner-routed memory/document reads, misc task/agent ops, source health/stat diagnostics.
- Targets the 0.214.32 owner-deadline storm (6,628 DbOwnerDeadlineError events; scan-hungry route scans + polling retry loop).
- Baselines regenerated; contract-test assertions realigned at 15fd7d69d.

## Regression tests

- 90 targeted tests: source/document route suites 57/57, agent policy 3/3, DB-owner client suite — all exercising the owner-routed behavior at head.

## Type

- [x] `fix`
- [ ] `feat`
- [ ] `refactor`
- [ ] `chore`

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] Other:

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Verification

- Audit at head: 902 inventory, 164 legacy, 220 async ON-PARENT (was 244), 384 total ON-PARENT (was 436); route suites green; typecheck + build clean.

## Migration Notes

No schema migrations.
