### PR TITLE
refactor(core): isolate migration contract

### DIFF
--- a/platform/core/src/migrations/001-baseline.ts
+++ b/platform/core/src/migrations/001-baseline.ts
@@ -7,7 +7,7 @@
  */
 
 import { createMemoriesFts } from "../fts-schema";
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/002-pipeline-v2.ts
+++ b/platform/core/src/migrations/002-pipeline-v2.ts
@@ -6,7 +6,7 @@
  * entity graph.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Check whether a column already exists on a table. */
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {

--- a/platform/core/src/migrations/003-unique-content-hash.ts
+++ b/platform/core/src/migrations/003-unique-content-hash.ts
@@ -9,7 +9,7 @@
  * before those columns were added to the baseline CREATE TABLE.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Conditionally add a column if it doesn't exist yet. */
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): boolean {

--- a/platform/core/src/migrations/004-history-actor-and-retention.ts
+++ b/platform/core/src/migrations/004-history-actor-and-retention.ts
@@ -6,7 +6,7 @@
  * queries on soft-deleted memories, expired history, and completed jobs.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/005-graph-extended.ts
+++ b/platform/core/src/migrations/005-graph-extended.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/006-idempotency-key.ts
+++ b/platform/core/src/migrations/006-idempotency-key.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/007-documents-and-connectors.ts
+++ b/platform/core/src/migrations/007-documents-and-connectors.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/008-embeddings-unique-hash.ts
+++ b/platform/core/src/migrations/008-embeddings-unique-hash.ts
@@ -7,7 +7,7 @@
  * unique index. Dedup any collisions then create the index.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	// Only run if embeddings table exists (baseline creates it)

--- a/platform/core/src/migrations/009-summary-jobs.ts
+++ b/platform/core/src/migrations/009-summary-jobs.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/010-umap-cache.ts
+++ b/platform/core/src/migrations/010-umap-cache.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/011-session-scores.ts
+++ b/platform/core/src/migrations/011-session-scores.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/012-scheduled-tasks.ts
+++ b/platform/core/src/migrations/012-scheduled-tasks.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/013-ingestion-tracking.ts
+++ b/platform/core/src/migrations/013-ingestion-tracking.ts
@@ -7,7 +7,7 @@
  *   - source_section column on memories: which section the memory came from
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Helper: add a column only if it doesn't already exist. */
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {

--- a/platform/core/src/migrations/014-telemetry.ts
+++ b/platform/core/src/migrations/014-telemetry.ts
@@ -7,7 +7,7 @@
  * optionally be batched to a self-hosted PostHog instance.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/015-session-memories.ts
+++ b/platform/core/src/migrations/015-session-memories.ts
@@ -7,7 +7,7 @@
  *   - continuity_reasoning column on session_scores: full LLM reasoning for audit
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Helper: add a column only if it doesn't already exist. */
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {

--- a/platform/core/src/migrations/016-session-checkpoints.ts
+++ b/platform/core/src/migrations/016-session-checkpoints.ts
@@ -6,7 +6,7 @@
  * after compaction or session restart.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/017-task-skills.ts
+++ b/platform/core/src/migrations/017-task-skills.ts
@@ -6,7 +6,7 @@
  * for how the skill content is integrated into the prompt.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	const cols = db.prepare("PRAGMA table_info(scheduled_tasks)").all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/018-skill-meta.ts
+++ b/platform/core/src/migrations/018-skill-meta.ts
@@ -6,7 +6,7 @@
  * with per-agent scoping, usage tracking, and decay.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	// Check if table already exists (idempotent)

--- a/platform/core/src/migrations/019-knowledge-structure.ts
+++ b/platform/core/src/migrations/019-knowledge-structure.ts
@@ -8,7 +8,7 @@
  * Part of KA-1 (Schema + Types + Read/Write Helpers).
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	// -- 1a. Backfill agent_id on entities (idempotent) --

--- a/platform/core/src/migrations/020-predictor-comparisons.ts
+++ b/platform/core/src/migrations/020-predictor-comparisons.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;

--- a/platform/core/src/migrations/021-checkpoint-structural.ts
+++ b/platform/core/src/migrations/021-checkpoint-structural.ts
@@ -6,7 +6,7 @@
  * metadata from the prior session.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	const columns = db.prepare("PRAGMA table_info(session_checkpoints)").all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/022-entity-pinning.ts
+++ b/platform/core/src/migrations/022-entity-pinning.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/023-predictor-columns.ts
+++ b/platform/core/src/migrations/023-predictor-columns.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(_db: MigrationDb): void {
 	// Reserved historical migration slot. The retired scorer was removed.

--- a/platform/core/src/migrations/024-predictor-comparison-columns.ts
+++ b/platform/core/src/migrations/024-predictor-comparison-columns.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(_db: MigrationDb): void {
 	// Reserved historical migration slot. The retired scorer was removed.

--- a/platform/core/src/migrations/025-agent-feedback.ts
+++ b/platform/core/src/migrations/025-agent-feedback.ts
@@ -6,7 +6,7 @@
  * becomes the primary training label for the predictive scorer.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Helper: add a column only if it doesn't already exist. */
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {

--- a/platform/core/src/migrations/026-predictor-training-pairs.ts
+++ b/platform/core/src/migrations/026-predictor-training-pairs.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(_db: MigrationDb): void {
 	// Reserved historical migration slot. The retired scorer was removed.

--- a/platform/core/src/migrations/027-backfill-canonical-names.ts
+++ b/platform/core/src/migrations/027-backfill-canonical-names.ts
@@ -8,7 +8,7 @@
  * skill reconciliation and extraction.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	// Match toCanonicalName(): trim, lowercase, collapse internal whitespace.

--- a/platform/core/src/migrations/028-lossless-retention.ts
+++ b/platform/core/src/migrations/028-lossless-retention.ts
@@ -6,7 +6,7 @@
  * memories_cold before being removed from the active table.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/029-session-summary-dag.ts
+++ b/platform/core/src/migrations/029-session-summary-dag.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/030-nullable-memory-job-memory-id.ts
+++ b/platform/core/src/migrations/030-nullable-memory-job-memory-id.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 030: Make memory_jobs.memory_id nullable

--- a/platform/core/src/migrations/031-dependency-reason.ts
+++ b/platform/core/src/migrations/031-dependency-reason.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 031: Add reason to dependencies, last_synthesized_at to entities

--- a/platform/core/src/migrations/032-embeddings-vector-column.ts
+++ b/platform/core/src/migrations/032-embeddings-vector-column.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 032: Ensure embeddings.vector column exists

--- a/platform/core/src/migrations/033-scope.ts
+++ b/platform/core/src/migrations/033-scope.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Add nullable `scope` column to memories table.

--- a/platform/core/src/migrations/034-scope-aware-dedup.ts
+++ b/platform/core/src/migrations/034-scope-aware-dedup.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Make the content_hash unique index scope-aware.

--- a/platform/core/src/migrations/035-entity-fts.ts
+++ b/platform/core/src/migrations/035-entity-fts.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Add FTS5 full-text search index for entities.

--- a/platform/core/src/migrations/036-dependency-confidence.ts
+++ b/platform/core/src/migrations/036-dependency-confidence.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 036: Add confidence column to entity_dependencies.

--- a/platform/core/src/migrations/037-entity-communities.ts
+++ b/platform/core/src/migrations/037-entity-communities.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 037: Entity Communities

--- a/platform/core/src/migrations/038-memory-hints.ts
+++ b/platform/core/src/migrations/038-memory-hints.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Add prospective indexing: memory_hints table + FTS5 virtual table.

--- a/platform/core/src/migrations/039-dedup-entity-dependencies.ts
+++ b/platform/core/src/migrations/039-dedup-entity-dependencies.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Add unique constraint on entity_dependencies to prevent duplicate rows.

--- a/platform/core/src/migrations/040-session-transcripts.ts
+++ b/platform/core/src/migrations/040-session-transcripts.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 040: Session Transcripts (Lossless Retention)

--- a/platform/core/src/migrations/041-path-feedback.ts
+++ b/platform/core/src/migrations/041-path-feedback.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	// SQLite PRAGMA/ALTER identifiers are not parameterizable.

--- a/platform/core/src/migrations/042-session-memories-agent-id.ts
+++ b/platform/core/src/migrations/042-session-memories-agent-id.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/043-agents-table.ts
+++ b/platform/core/src/migrations/043-agents-table.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/044-memory-md-temporal-head.ts
+++ b/platform/core/src/migrations/044-memory-md-temporal-head.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/045-lossless-working-memory-hardening.ts
+++ b/platform/core/src/migrations/045-lossless-working-memory-hardening.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/046-session-summary-uniqueness.ts
+++ b/platform/core/src/migrations/046-session-summary-uniqueness.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/047-agent-scoped-temporal-uniqueness.ts
+++ b/platform/core/src/migrations/047-agent-scoped-temporal-uniqueness.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 047: Agent-scoped temporal uniqueness

--- a/platform/core/src/migrations/048-thread-heads.ts
+++ b/platform/core/src/migrations/048-thread-heads.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 048: Persistent thread heads

--- a/platform/core/src/migrations/049-session-extract-cursors.ts
+++ b/platform/core/src/migrations/049-session-extract-cursors.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 049: Session extract cursors

--- a/platform/core/src/migrations/050-related-to-audit.ts
+++ b/platform/core/src/migrations/050-related-to-audit.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasTable(db: MigrationDb, name: string): boolean {
 	return (

--- a/platform/core/src/migrations/051-memory-md-rolling-window-lineage.ts
+++ b/platform/core/src/migrations/051-memory-md-rolling-window-lineage.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/052-mcp-invocations.ts
+++ b/platform/core/src/migrations/052-mcp-invocations.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 052: MCP invocation tracking

--- a/platform/core/src/migrations/053-skill-invocations.ts
+++ b/platform/core/src/migrations/053-skill-invocations.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 053: Skill invocation tracking

--- a/platform/core/src/migrations/054-task-agent-scope.ts
+++ b/platform/core/src/migrations/054-task-agent-scope.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/055-dreaming-state.ts
+++ b/platform/core/src/migrations/055-dreaming-state.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 055: Dreaming state tracking

--- a/platform/core/src/migrations/056-agent-scoped-content-hash.ts
+++ b/platform/core/src/migrations/056-agent-scoped-content-hash.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function ensureMemoriesScopeColumns(db: MigrationDb): void {
 	const cols = db.prepare("PRAGMA table_info(memories)").all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/057-memories-fts-tokenizer-repair.ts
+++ b/platform/core/src/migrations/057-memories-fts-tokenizer-repair.ts
@@ -1,5 +1,5 @@
 import { memoriesFtsNeedsTokenizerRepair, readMemoriesFtsSql, recreateMemoriesFts } from "../fts-schema";
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 057: Repair legacy porter-tokenized memories_fts tables.

--- a/platform/core/src/migrations/058-knowledge-graph-indices.ts
+++ b/platform/core/src/migrations/058-knowledge-graph-indices.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 058: Add indices that support the paginated-ID knowledge-graph

--- a/platform/core/src/migrations/059-entity-attribute-claim-key.ts
+++ b/platform/core/src/migrations/059-entity-attribute-claim-key.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 059: Add claim identity to structured attributes.

--- a/platform/core/src/migrations/060-entity-attribute-group-key.ts
+++ b/platform/core/src/migrations/060-entity-attribute-group-key.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 060: Add navigable group identity to structured attributes.

--- a/platform/core/src/migrations/061-memory-artifact-source-mtime.ts
+++ b/platform/core/src/migrations/061-memory-artifact-source-mtime.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 061: Persist indexed artifact file mtimes.

--- a/platform/core/src/migrations/062-memory-artifact-soft-delete.ts
+++ b/platform/core/src/migrations/062-memory-artifact-soft-delete.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 062: Soft-delete memory artifacts.

--- a/platform/core/src/migrations/064-source-graph-provenance.ts
+++ b/platform/core/src/migrations/064-source-graph-provenance.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: unknown }>;

--- a/platform/core/src/migrations/065-source-embedding-agent-scope.ts
+++ b/platform/core/src/migrations/065-source-embedding-agent-scope.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasTable(db: MigrationDb, table: string): boolean {
 	const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(table) as

--- a/platform/core/src/migrations/066-memory-search-telemetry.ts
+++ b/platform/core/src/migrations/066-memory-search-telemetry.ts
@@ -6,7 +6,7 @@
  * result snapshots, so it must never be forwarded to external telemetry sinks.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/067-ontology-proposals.ts
+++ b/platform/core/src/migrations/067-ontology-proposals.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: unknown }>;

--- a/platform/core/src/migrations/068-daily-reflections.ts
+++ b/platform/core/src/migrations/068-daily-reflections.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 068: Daily reflections.

--- a/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
+++ b/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 069: Daily reflections become dashboard-open insights.

--- a/platform/core/src/migrations/070-ontology-control-plane-state.ts
+++ b/platform/core/src/migrations/070-ontology-control-plane-state.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: unknown }>;

--- a/platform/core/src/migrations/071-epistemic-assertions.ts
+++ b/platform/core/src/migrations/071-epistemic-assertions.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 071: Epistemic assertions.

--- a/platform/core/src/migrations/072-agent-scoped-idempotency-key.ts
+++ b/platform/core/src/migrations/072-agent-scoped-idempotency-key.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function ensureMemoriesScopeColumns(db: MigrationDb): void {
 	const cols = db.prepare("PRAGMA table_info(memories)").all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/073-recall-context-dedupe.ts
+++ b/platform/core/src/migrations/073-recall-context-dedupe.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 073: Durable per-session recall context dedupe.

--- a/platform/core/src/migrations/074-aggregate-memory-links.ts
+++ b/platform/core/src/migrations/074-aggregate-memory-links.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 074: provenance links from aggregate recall memories to the

--- a/platform/core/src/migrations/075-memory-artifact-source-provenance.ts
+++ b/platform/core/src/migrations/075-memory-artifact-source-provenance.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/076-temporal-edges.ts
+++ b/platform/core/src/migrations/076-temporal-edges.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/077-entity-aliases.ts
+++ b/platform/core/src/migrations/077-entity-aliases.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/078-api-keys.ts
+++ b/platform/core/src/migrations/078-api-keys.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/079-transcript-capture-jobs.ts
+++ b/platform/core/src/migrations/079-transcript-capture-jobs.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/080-document-scope-columns.ts
+++ b/platform/core/src/migrations/080-document-scope-columns.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/081-aggregate-evidence-sources.ts
+++ b/platform/core/src/migrations/081-aggregate-evidence-sources.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 081: typed provenance links from aggregate recall memories to every

--- a/platform/core/src/migrations/082-skill-invocations-harness.ts
+++ b/platform/core/src/migrations/082-skill-invocations-harness.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 081: Harness skill-invocation columns

--- a/platform/core/src/migrations/083-memory-lifecycle-repair.ts
+++ b/platform/core/src/migrations/083-memory-lifecycle-repair.ts
@@ -1,7 +1,7 @@
 import { up as transcriptCaptureJobs } from "./079-transcript-capture-jobs";
 import { up as documentScopeColumns } from "./080-document-scope-columns";
 import { up as aggregateEvidenceSources } from "./081-aggregate-evidence-sources";
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 const DEPENDENCY_TYPES = new Set([
 	"uses",

--- a/platform/core/src/migrations/084-legacy-markdown-import-state.ts
+++ b/platform/core/src/migrations/084-legacy-markdown-import-state.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/085-backfill-relations-to-dependencies.ts
+++ b/platform/core/src/migrations/085-backfill-relations-to-dependencies.ts
@@ -12,7 +12,7 @@
  * source_entity_id, target_entity_id, dependency_type, agent_id via the
  * idx_entity_deps_unique index).
  */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	const tables = db

--- a/platform/core/src/migrations/086-summary-jobs-content-hash.ts
+++ b/platform/core/src/migrations/086-summary-jobs-content-hash.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/087-summary-jobs-boundary-reason.ts
+++ b/platform/core/src/migrations/087-summary-jobs-boundary-reason.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/088-transcript-recovery-files.ts
+++ b/platform/core/src/migrations/088-transcript-recovery-files.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/089-job-cancellations.ts
+++ b/platform/core/src/migrations/089-job-cancellations.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 089: Add `job_cancellations` audit table for issue #901.

--- a/platform/core/src/migrations/090-job-archive.ts
+++ b/platform/core/src/migrations/090-job-archive.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 090: Add `job_archive` provenance table for issue #901.

--- a/platform/core/src/migrations/091-embedding-index-generations.ts
+++ b/platform/core/src/migrations/091-embedding-index-generations.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Persist active/staging embedding generations separately from mutable config.

--- a/platform/core/src/migrations/092-embedding-staging-store.ts
+++ b/platform/core/src/migrations/092-embedding-staging-store.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * The inactive half of a rolling embedding migration. sqlite-vec's matching

--- a/platform/core/src/migrations/093-dreaming-evidence-cursor.ts
+++ b/platform/core/src/migrations/093-dreaming-evidence-cursor.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Persist the composite episodic cursor used by the Dreaming worker. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/094-memory-kind.ts
+++ b/platform/core/src/migrations/094-memory-kind.ts
@@ -37,7 +37,7 @@ import { DAEMON_DERIVED_MEMORY_SOURCE_TYPES } from "../memory-provenance";
  * Idempotent: re-runs are no-ops because the UPDATE is conditional on
  * `memory_kind IS NULL`.
  */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Daemon-derived source_types that are NOT primary episodic evidence. */
 const DERIVED_SOURCE_TYPES = DAEMON_DERIVED_MEMORY_SOURCE_TYPES;

--- a/platform/core/src/migrations/095-compaction-recall-projections.ts
+++ b/platform/core/src/migrations/095-compaction-recall-projections.ts
@@ -3,7 +3,7 @@
  * not primary episodic evidence. Their temporal-DAG summary is Dreaming's
  * canonical input, while the memory row remains available to ordinary recall.
  */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	return (db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>).some(

--- a/platform/core/src/migrations/096-retire-legacy-ingestion.ts
+++ b/platform/core/src/migrations/096-retire-legacy-ingestion.ts
@@ -6,7 +6,7 @@
  * rows remain available to retrieval; without immutable source artifacts,
  * they are deliberately not promoted into Dreaming evidence here.
  */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec("DROP TABLE IF EXISTS ingestion_jobs");

--- a/platform/core/src/migrations/097-dreaming-failure-backoff.ts
+++ b/platform/core/src/migrations/097-dreaming-failure-backoff.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Persist the timestamp used for Dreaming's restart-safe retry backoff. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/098-dreaming-evidence-exclusions.ts
+++ b/platform/core/src/migrations/098-dreaming-evidence-exclusions.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Records immutable episodic sources that Dreaming deliberately did not

--- a/platform/core/src/migrations/099-dreaming-tool-calls.ts
+++ b/platform/core/src/migrations/099-dreaming-tool-calls.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Auditable, scoped trace of the capability calls made during a Dreaming pass.

--- a/platform/core/src/migrations/100-dreaming-runbook.ts
+++ b/platform/core/src/migrations/100-dreaming-runbook.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Per-pass operational memory for Dreaming. It records selected evidence and

--- a/platform/core/src/migrations/101-dreaming-attention.ts
+++ b/platform/core/src/migrations/101-dreaming-attention.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Agent-scoped semantic work that should wake Dreaming even when no new

--- a/platform/core/src/migrations/102-attribute-semantic-memories.ts
+++ b/platform/core/src/migrations/102-attribute-semantic-memories.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	return (db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>).some(

--- a/platform/core/src/migrations/103-semantic-memory-kind.ts
+++ b/platform/core/src/migrations/103-semantic-memory-kind.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Attribute projections are semantic state, never primary evidence. Existing

--- a/platform/core/src/migrations/104-derived-memory-provenance.ts
+++ b/platform/core/src/migrations/104-derived-memory-provenance.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function tableExists(db: MigrationDb, table: string): boolean {
 	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) !== undefined;

--- a/platform/core/src/migrations/105-agent-scoped-entity-name.ts
+++ b/platform/core/src/migrations/105-agent-scoped-entity-name.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 105: agent-scoped entity name uniqueness.

--- a/platform/core/src/migrations/106-memory-review-after.ts
+++ b/platform/core/src/migrations/106-memory-review-after.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	return (db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>).some(

--- a/platform/core/src/migrations/107-dreaming-pass-usage.ts
+++ b/platform/core/src/migrations/107-dreaming-pass-usage.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	return (db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>).some(

--- a/platform/core/src/migrations/108-embedding-usage.ts
+++ b/platform/core/src/migrations/108-embedding-usage.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 108: daily-aggregate embedding token usage.

--- a/platform/core/src/migrations/109-telemetry-install.ts
+++ b/platform/core/src/migrations/109-telemetry-install.ts
@@ -9,7 +9,7 @@
  * analytics impossible.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/110-memory-mention-join-index.ts
+++ b/platform/core/src/migrations/110-memory-mention-join-index.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 110: entity-side composite index for memory_entity_mentions.

--- a/platform/core/src/migrations/111-telemetry-first-use.ts
+++ b/platform/core/src/migrations/111-telemetry-first-use.ts
@@ -11,7 +11,7 @@
  * Idempotent: guards each ADD COLUMN with a pragma check (SQLite ALTER
  * has no IF NOT EXISTS).
  */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;

--- a/platform/core/src/migrations/112-telemetry-queue-ownership.ts
+++ b/platform/core/src/migrations/112-telemetry-queue-ownership.ts
@@ -5,7 +5,7 @@
  * claim so concurrent processes cannot send the same batch simultaneously.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all();

--- a/platform/core/src/migrations/113-session-claims.ts
+++ b/platform/core/src/migrations/113-session-claims.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 113: durable session lifecycle claims (#1228).

--- a/platform/core/src/migrations/114-memory-traversal-hydration-index.ts
+++ b/platform/core/src/migrations/114-memory-traversal-hydration-index.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 114: index memory-side traversal hydration lookups (#1250).

--- a/platform/core/src/migrations/115-cross-agent-message-notifications.ts
+++ b/platform/core/src/migrations/115-cross-agent-message-notifications.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 115: durable cross-agent inbox and acknowledgements (#944).

--- a/platform/core/src/migrations/116-acp-delivery-reconciliation.ts
+++ b/platform/core/src/migrations/116-acp-delivery-reconciliation.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	return db

--- a/platform/core/src/migrations/117-retire-summary-worker.ts
+++ b/platform/core/src/migrations/117-retire-summary-worker.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasTable(db: MigrationDb, table: string): boolean {
 	return db.prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) != null;

--- a/platform/core/src/migrations/118-queue-pressure-indices.ts
+++ b/platform/core/src/migrations/118-queue-pressure-indices.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 118: bounded queue-pressure observation

--- a/platform/core/src/migrations/119-telemetry-version-observation.ts
+++ b/platform/core/src/migrations/119-telemetry-version-observation.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	return db

--- a/platform/core/src/migrations/120-source-lifecycle-telemetry.ts
+++ b/platform/core/src/migrations/120-source-lifecycle-telemetry.ts
@@ -4,7 +4,7 @@
  * The table is local correlation state only. The source key is a digest of
  * the configured source identity; it is never copied into telemetry events.
  */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/121-telemetry-delivery-health.ts
+++ b/platform/core/src/migrations/121-telemetry-delivery-health.ts
@@ -7,7 +7,7 @@
  * collector that is waiting to retry.
  */
 
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	return db

--- a/platform/core/src/migrations/122-dreaming-evidence-retry.ts
+++ b/platform/core/src/migrations/122-dreaming-evidence-retry.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Add restart-safe repair-aware retry state to quarantined Dreaming evidence. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/123-embedding-index-failures.ts
+++ b/platform/core/src/migrations/123-embedding-index-failures.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Persist terminal failures from an embedding-index migration. A provider can

--- a/platform/core/src/migrations/124-import-derived-lifecycle.ts
+++ b/platform/core/src/migrations/124-import-derived-lifecycle.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Imported source removal is not ordinary source purge: derived ontology must

--- a/platform/core/src/migrations/125-memory-content-safety.ts
+++ b/platform/core/src/migrations/125-memory-content-safety.ts
@@ -6,7 +6,7 @@
  * this table records only the policy decision used by prompt-facing readers.
  */
 import { MEMORY_CONTENT_SAFETY_POLICY_VERSION, scanMemoryContent } from "../memory-content-safety";
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 type SafetyRow = {
 	readonly agent_id: string | null;

--- a/platform/core/src/migrations/126-dreaming-surprisal-attention.ts
+++ b/platform/core/src/migrations/126-dreaming-surprisal-attention.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Add the opt-in embedding-geometry attention kind without rewriting any

--- a/platform/core/src/migrations/127-ontology-contradictions.ts
+++ b/platform/core/src/migrations/127-ontology-contradictions.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 127: persisted contradiction observations.

--- a/platform/core/src/migrations/128-bounded-queue-diagnostics.ts
+++ b/platform/core/src/migrations/128-bounded-queue-diagnostics.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 128: indexes for bounded queue diagnostics.

--- a/platform/core/src/migrations/129-retire-structural-jobs.ts
+++ b/platform/core/src/migrations/129-retire-structural-jobs.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function tableExists(db: MigrationDb, table: string): boolean {
 	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) != null;

--- a/platform/core/src/migrations/130-embedding-repair-state.ts
+++ b/platform/core/src/migrations/130-embedding-repair-state.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 129: durable admission and retry state for incremental embedding

--- a/platform/core/src/migrations/131-dreaming-evidence-consumption.ts
+++ b/platform/core/src/migrations/131-dreaming-evidence-consumption.ts
@@ -1,5 +1,5 @@
 /** Migration 131: durable Dreaming delivery frontier per immutable evidence revision. */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/132-observer-scoped-epistemic-assertions.ts
+++ b/platform/core/src/migrations/132-observer-scoped-epistemic-assertions.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Migration 132: make the existing agent scope an explicit observer query

--- a/platform/core/src/migrations/133-dreaming-memory-head.ts
+++ b/platform/core/src/migrations/133-dreaming-memory-head.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Migration 133: immutable, scoped Dreaming-curated MEMORY.md revisions. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/134-scope-memory-head-entries.ts
+++ b/platform/core/src/migrations/134-scope-memory-head-entries.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Repair migration 134: scope legacy memory-head entry identity by agent. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/135-memory-head-publication.ts
+++ b/platform/core/src/migrations/135-memory-head-publication.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Durable post-commit publication intents for the DB-authoritative memory head. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/136-memory-head-revisions.ts
+++ b/platform/core/src/migrations/136-memory-head-revisions.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Adds the audited entry-level contract to the lineage revision table. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/137-dreaming-head-manifest.ts
+++ b/platform/core/src/migrations/137-dreaming-head-manifest.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Pass-level audit manifest for content Dreaming MEMORY.md curation. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/138-bounded-status-projections.ts
+++ b/platform/core/src/migrations/138-bounded-status-projections.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<{ name?: unknown }>;

--- a/platform/core/src/migrations/139-native-source-sync-state.ts
+++ b/platform/core/src/migrations/139-native-source-sync-state.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Durable source-level pause and frontier for provider-gated native sync. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/140-transcript-recovery-frontier.ts
+++ b/platform/core/src/migrations/140-transcript-recovery-frontier.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Durable traversal cursor for the killable transcript recovery worker. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/141-source-sync-checkpoints.ts
+++ b/platform/core/src/migrations/141-source-sync-checkpoints.ts
@@ -1,5 +1,5 @@
 /** Migration 141: per-agent/source/phase scan cursors; distinct from 139 provider lifecycle state. */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	db.exec(`

--- a/platform/core/src/migrations/142-source-sync-frontier.ts
+++ b/platform/core/src/migrations/142-source-sync-frontier.ts
@@ -1,5 +1,5 @@
 /** Migration 142: add filesystem frontiers to the per-scan checkpoint table from migration 141. */
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 export function up(db: MigrationDb): void {
 	const columns = db.prepare("PRAGMA table_info(source_sync_checkpoints)").all() as Array<{ name: string }>;

--- a/platform/core/src/migrations/143-embedding-index-progress.ts
+++ b/platform/core/src/migrations/143-embedding-index-progress.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Durable visibility and projection cursor for the killable embedding owner.

--- a/platform/core/src/migrations/144-memory-job-lease-token.ts
+++ b/platform/core/src/migrations/144-memory-job-lease-token.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /**
  * Add durable fencing tokens to memory_jobs leases.

--- a/platform/core/src/migrations/145-dreaming-evidence-reviews.ts
+++ b/platform/core/src/migrations/145-dreaming-evidence-reviews.ts
@@ -1,4 +1,4 @@
-import type { MigrationDb } from "./index";
+import type { MigrationDb } from "./contract";
 
 /** Migration 145: durable reviewed exclusions for immutable Dreaming evidence revisions. */
 export function up(db: MigrationDb): void {

--- a/platform/core/src/migrations/contract.ts
+++ b/platform/core/src/migrations/contract.ts
@@ -1,0 +1,28 @@
+/** Minimal database surface available to every schema migration. */
+export interface MigrationDb {
+	exec(sql: string): void;
+	prepare(sql: string): {
+		run(...args: unknown[]): void;
+		get(...args: unknown[]): Record<string, unknown> | undefined;
+		all(...args: unknown[]): Record<string, unknown>[];
+	};
+}
+
+/** Schema artifacts used to detect migrations recorded without their effects. */
+export interface MigrationArtifacts {
+	readonly tables?: readonly string[];
+	readonly columns?: readonly {
+		readonly table: string;
+		readonly column: string;
+		/** Skip verification when the table itself does not exist. */
+		readonly optional?: boolean;
+	}[];
+}
+
+/** One ordered, append-only schema migration. */
+export interface Migration {
+	readonly version: number;
+	readonly name: string;
+	readonly up: (db: MigrationDb) => void;
+	readonly artifacts?: MigrationArtifacts;
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -6,6 +6,8 @@
  * records execution in `schema_migrations_audit`.
  */
 
+import type { Migration, MigrationDb } from "./contract";
+
 import { up as baseline } from "./001-baseline";
 import { up as pipelineV2 } from "./002-pipeline-v2";
 import { up as uniqueContentHash } from "./003-unique-content-hash";
@@ -152,33 +154,7 @@ import { up as embeddingIndexProgress } from "./143-embedding-index-progress";
 import { up as memoryJobLeaseToken } from "./144-memory-job-lease-token";
 import { up as dreamingEvidenceReviews } from "./145-dreaming-evidence-reviews";
 
-// -- Public interface consumed by Database.init() --
-
-export interface MigrationDb {
-	exec(sql: string): void;
-	prepare(sql: string): {
-		run(...args: unknown[]): void;
-		get(...args: unknown[]): Record<string, unknown> | undefined;
-		all(...args: unknown[]): Record<string, unknown>[];
-	};
-}
-
-export interface MigrationArtifacts {
-	readonly tables?: readonly string[];
-	readonly columns?: readonly {
-		readonly table: string;
-		readonly column: string;
-		/** Skip verification when the table itself doesn't exist (conditional/repair migrations). */
-		readonly optional?: boolean;
-	}[];
-}
-
-export interface Migration {
-	readonly version: number;
-	readonly name: string;
-	readonly up: (db: MigrationDb) => void;
-	readonly artifacts?: MigrationArtifacts;
-}
+export type { Migration, MigrationArtifacts, MigrationDb } from "./contract";
 
 /** Ordered list of all migrations. New migrations go at the end. */
 export const MIGRATIONS: readonly Migration[] = [


### PR DESCRIPTION
## Summary

Removes the 145-module type-only cycle between the migration registry and every numbered migration. The registry remains the public composition root; migration implementations now depend only on the contract they implement.

## Changes

- Add `platform/core/src/migrations/contract.ts` as the owner of `MigrationDb`, `MigrationArtifacts`, and `Migration`.
- Re-export those types from the existing migration index, preserving the public API.
- Point all 144 numbered migrations at the contract module instead of the registry that imports them.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no feature/spec change
- [x] Agent scoping verified on all new/changed data queries — no query changes
- [x] Input/config validation and bounds checks added — no input/config changes
- [x] Error handling and fallback paths tested (no silent swallow) — no runtime behavior change
- [x] Security checks applied to admin/mutation endpoints — no endpoint changes
- [x] Docs updated for API/spec/status changes — no public behavior change
- [x] Regression tests added for each bug fix — not a bug fix; existing migration suite is the behavior proof
- [x] Lint/typecheck/tests pass locally

## Migration Notes

- [x] Migration is idempotent — SQL and migration ordering are unchanged; 70 migration tests pass
- [x] Rollback / compatibility note included in PR description — public type exports remain available from the index

## Testing

- [x] `bun test platform/core/src/migrations/migrations.test.ts` — 70 pass
- [x] `bun run --filter '@signet/core' typecheck`
- [x] `bun run --filter '@signet/core' build`
- [x] `bunx biome check platform/core/src/migrations`
- [ ] Tested against running daemon

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

This is the first bounded slice from the architecture-erosion audit tracked alongside #1748. It changes dependency direction only; schema behavior and migration registration remain unchanged.
