### PR TITLE
refactor(daemon): isolate DB foundation lifecycle

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 931 sites
+- Exact ledger inventory: 928 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 104
-- Async-named DB sites: 246
-- Async-named ON-PARENT DB sites: 244
+- Async-named DB sites: 243
+- Async-named ON-PARENT DB sites: 241
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 169
   - `withWriteTx`: 65
   - `withReadDb`: 104
 
-The 931-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 104 synchronous reads, and 246 async-named DB sites are the complete database-call inventory; 169 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 244 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 928-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 104 synchronous reads, and 243 async-named DB sites are the complete database-call inventory; 169 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 241 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 415
-- ON-PARENT callback execution: 413
+- Database accessor sites classified: 412
+- ON-PARENT callback execution: 410
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -60,13 +60,11 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `database-integrity.ts:712` (withReadDbAsync)
 - `database-integrity.ts:830` (withReadDbAsync)
 - `db-accessor.ts:3031` (withWriteTxAsync)
-- `db-vacuum.ts:340` (withReadDb)
-- `db-vacuum.ts:348` (withReadDbAsync)
-- `db-vacuum.ts:460` (incrementalVacuumAsync)
-- `db-vacuum.ts:498` (withWriteTxAsync)
-- `db-vacuum.ts:528` (vacuumConversionAsync)
-- `db-vacuum.ts:530` (withWriteTxAsync)
-- `db-vacuum.ts:548` (withWriteTxAsync)
+- `db-vacuum.ts:331` (withReadDb)
+- `db-vacuum.ts:339` (withReadDbAsync)
+- `db-vacuum.ts:347` (withWriteTxAsync)
+- `db-vacuum.ts:367` (withWriteTxAsync)
+- `db-vacuum.ts:386` (withWriteTxAsync)
 - `discord-desktop-cache-source.ts:484` (withReadDbAsync)
 - `discord-desktop-cache-source.ts:497` (withWriteTxAsync)
 - `discord-source-provider.ts:573` (withReadDbAsync)
@@ -222,7 +220,6 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `pipeline/maintenance-worker.ts:148` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:485` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:535` (withReadDbAsync)
 - `pipeline/prospective-index.ts:284` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:300` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:336` (withWriteTxAsync)

--- a/platform/daemon/src/agent-id.ts
+++ b/platform/daemon/src/agent-id.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AgentRosterReadPolicy } from "@signet/core";
+import { registerDbAccessorCloseParticipant } from "./db-accessor-lifecycle";
 import { getDbAccessorPath } from "./db-accessor";
 import { getDbOwner } from "./db-owner-runtime";
 import { ownerReadOne, ownerRun } from "./db-owner-sql";
@@ -77,6 +78,12 @@ export function invalidateAgentScopeCache(agentId?: string): void {
 	}
 	agentScopeCache.delete(normalizedAgentId(agentId));
 }
+
+registerDbAccessorCloseParticipant({
+	name: "agent-scope-cache",
+	order: 200,
+	close: () => invalidateAgentScopeCache(),
+});
 
 /**
  * Read an agent's policy through the async DB boundary.

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -80,7 +80,7 @@ import {
 	registerDbOwnerHealthProvider,
 	setDatabaseIntegrityWritesBlocked,
 } from "./db-accessor";
-import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
+import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum-worker";
 import { createDbOwnerClient, type DbOwnerClient, type DbOwnerClientOptions } from "./db-owner-client";
 import {
 	type DbOwnerMaintenance,

--- a/platform/daemon/src/db-accessor-lifecycle.ts
+++ b/platform/daemon/src/db-accessor-lifecycle.ts
@@ -13,6 +13,7 @@ export interface DbAccessorLifecycle {
 export function createDbAccessorLifecycle(): DbAccessorLifecycle {
 	const closeParticipants = new Map<string, DbAccessorCloseParticipant>();
 	let closeStarted = false;
+	let closePromise: Promise<void> | undefined;
 
 	return {
 		register(participant: DbAccessorCloseParticipant): void {
@@ -25,14 +26,28 @@ export function createDbAccessorLifecycle(): DbAccessorLifecycle {
 			closeParticipants.set(participant.name, participant);
 		},
 
-		async close(dbPath: string | undefined): Promise<void> {
-			// Set the gate before the first await so a late module registration cannot
-			// race an in-progress close and be omitted from the participant snapshot.
+		close(dbPath: string | undefined): Promise<void> {
+			if (closePromise !== undefined) return closePromise;
+
+			// Set the gate and snapshot synchronously, before the first await, so a
+			// late module registration cannot race an in-progress close and be
+			// omitted from the participant snapshot.
 			closeStarted = true;
 			const participants = [...closeParticipants.values()].sort(
 				(left, right) => left.order - right.order || left.name.localeCompare(right.name),
 			);
-			for (const participant of participants) await participant.close(dbPath);
+			closePromise = (async () => {
+				try {
+					for (const participant of participants) await participant.close(dbPath);
+				} finally {
+					// The registry is process-scoped while accessors are replaceable. Keep
+					// the gate closed for this close operation, then allow the next
+					// accessor lifecycle to register any modules loaded in the meantime.
+					closeStarted = false;
+					closePromise = undefined;
+				}
+			})();
+			return closePromise;
 		},
 	};
 }

--- a/platform/daemon/src/db-accessor-lifecycle.ts
+++ b/platform/daemon/src/db-accessor-lifecycle.ts
@@ -1,0 +1,27 @@
+export interface DbAccessorCloseParticipant {
+	readonly name: string;
+	readonly order: number;
+	close(dbPath: string | undefined): void | Promise<void>;
+}
+
+const closeParticipants = new Map<string, DbAccessorCloseParticipant>();
+
+/**
+ * Register a daemon service whose state is coupled to the active database.
+ * Foundational accessor code invokes this boundary without importing the
+ * higher-level service itself.
+ */
+export function registerDbAccessorCloseParticipant(participant: DbAccessorCloseParticipant): void {
+	if (closeParticipants.has(participant.name)) {
+		throw new Error(`DB accessor close participant already registered: ${participant.name}`);
+	}
+	closeParticipants.set(participant.name, participant);
+}
+
+/** Run registered cleanup in explicit dependency order. */
+export async function closeDbAccessorParticipants(dbPath: string | undefined): Promise<void> {
+	const participants = [...closeParticipants.values()].sort(
+		(left, right) => left.order - right.order || left.name.localeCompare(right.name),
+	);
+	for (const participant of participants) await participant.close(dbPath);
+}

--- a/platform/daemon/src/db-accessor-lifecycle.ts
+++ b/platform/daemon/src/db-accessor-lifecycle.ts
@@ -4,24 +4,46 @@ export interface DbAccessorCloseParticipant {
 	close(dbPath: string | undefined): void | Promise<void>;
 }
 
-const closeParticipants = new Map<string, DbAccessorCloseParticipant>();
+export interface DbAccessorLifecycle {
+	register(participant: DbAccessorCloseParticipant): void;
+	close(dbPath: string | undefined): Promise<void>;
+}
 
-/**
- * Register a daemon service whose state is coupled to the active database.
- * Foundational accessor code invokes this boundary without importing the
- * higher-level service itself.
- */
+/** Create an isolated close-participant registry for one accessor lifecycle. */
+export function createDbAccessorLifecycle(): DbAccessorLifecycle {
+	const closeParticipants = new Map<string, DbAccessorCloseParticipant>();
+	let closeStarted = false;
+
+	return {
+		register(participant: DbAccessorCloseParticipant): void {
+			if (closeStarted) {
+				throw new Error(`DB accessor close participant registered after close started: ${participant.name}`);
+			}
+			if (closeParticipants.has(participant.name)) {
+				throw new Error(`DB accessor close participant already registered: ${participant.name}`);
+			}
+			closeParticipants.set(participant.name, participant);
+		},
+
+		async close(dbPath: string | undefined): Promise<void> {
+			// Set the gate before the first await so a late module registration cannot
+			// race an in-progress close and be omitted from the participant snapshot.
+			closeStarted = true;
+			const participants = [...closeParticipants.values()].sort(
+				(left, right) => left.order - right.order || left.name.localeCompare(right.name),
+			);
+			for (const participant of participants) await participant.close(dbPath);
+		},
+	};
+}
+
+const defaultLifecycle = createDbAccessorLifecycle();
+
 export function registerDbAccessorCloseParticipant(participant: DbAccessorCloseParticipant): void {
-	if (closeParticipants.has(participant.name)) {
-		throw new Error(`DB accessor close participant already registered: ${participant.name}`);
-	}
-	closeParticipants.set(participant.name, participant);
+	defaultLifecycle.register(participant);
 }
 
 /** Run registered cleanup in explicit dependency order. */
 export async function closeDbAccessorParticipants(dbPath: string | undefined): Promise<void> {
-	const participants = [...closeParticipants.values()].sort(
-		(left, right) => left.order - right.order || left.name.localeCompare(right.name),
-	);
-	for (const participant of participants) await participant.close(dbPath);
+	await defaultLifecycle.close(dbPath);
 }

--- a/platform/daemon/src/db-accessor-lifecycle.ts
+++ b/platform/daemon/src/db-accessor-lifecycle.ts
@@ -36,9 +36,19 @@ export function createDbAccessorLifecycle(): DbAccessorLifecycle {
 			const participants = [...closeParticipants.values()].sort(
 				(left, right) => left.order - right.order || left.name.localeCompare(right.name),
 			);
-			closePromise = (async () => {
+			let resolveClose!: () => void;
+			let rejectClose!: (reason?: unknown) => void;
+			const pendingClose = new Promise<void>((resolve, reject) => {
+				resolveClose = resolve;
+				rejectClose = reject;
+			});
+			closePromise = pendingClose;
+			void (async () => {
 				try {
 					for (const participant of participants) await participant.close(dbPath);
+					resolveClose();
+				} catch (error) {
+					rejectClose(error);
 				} finally {
 					// The registry is process-scoped while accessors are replaceable. Keep
 					// the gate closed for this close operation, then allow the next
@@ -47,7 +57,7 @@ export function createDbAccessorLifecycle(): DbAccessorLifecycle {
 					closePromise = undefined;
 				}
 			})();
-			return closePromise;
+			return pendingClose;
 		},
 	};
 }

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -59,7 +59,7 @@ import {
 	type DbRuntimeMetrics,
 } from "./db-observability";
 import type { DbOwnerHealth } from "./db-owner-client";
-import { closeDbOwner } from "./db-owner-runtime";
+import { closeDbAccessorParticipants } from "./db-accessor-lifecycle";
 import { observeDbLatency } from "./runtime-pressure";
 import { resetFtsIndexState, setFtsIndexIncomplete } from "./fts-index-state";
 import {
@@ -3072,9 +3072,5 @@ export async function closeDbAccessor(): Promise<void> {
 	vecLoadError = null;
 	vecExtPath = undefined;
 	resetDbObservability();
-	await closeDbOwner(closingDbPath ?? undefined);
-	// The agent-scope cache may hold policies read from the closing database;
-	// a reinitialized accessor (same process, different DB) must never serve them.
-	const { invalidateAgentScopeCache } = await import("./agent-id");
-	invalidateAgentScopeCache();
+	await closeDbAccessorParticipants(closingDbPath ?? undefined);
 }

--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -18,7 +18,7 @@ describe("DB foundation dependency invariant", () => {
 	});
 
 	describe("close participant lifecycle", () => {
-		it("preserves owner-before-cache order and rejects late registration", async () => {
+		it("preserves owner-before-cache order and rejects registration during close", async () => {
 			const lifecycle = createDbAccessorLifecycle();
 			const closed: string[] = [];
 			let duringCloseError: unknown;
@@ -51,13 +51,24 @@ describe("DB foundation dependency invariant", () => {
 			expect(closed).toEqual(["db-owner", "agent-scope-cache"]);
 			expect(duringCloseError).toBeInstanceOf(Error);
 			expect((duringCloseError as Error).message).toContain("registered after close started");
-			expect(() =>
-				lifecycle.register({
-					name: "late-participant",
-					order: 300,
-					close: () => undefined,
-				}),
-			).toThrow("registered after close started");
+
+			// A later accessor lifecycle may load a participant after the previous
+			// close has completed; only registration during close is forbidden.
+			lifecycle.register({
+				name: "next-lifecycle-participant",
+				order: 300,
+				close: () => {
+					closed.push("next-lifecycle-participant");
+				},
+			});
+			await lifecycle.close(undefined);
+			expect(closed).toEqual([
+				"db-owner",
+				"agent-scope-cache",
+				"db-owner",
+				"agent-scope-cache",
+				"next-lifecycle-participant",
+			]);
 		});
 	});
 });

--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
+import { createDbAccessorLifecycle } from "./db-accessor-lifecycle";
 
 function source(relativePath: string): string {
 	return readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -14,5 +15,49 @@ describe("DB foundation dependency invariant", () => {
 		expect(accessor).not.toContain('import("./agent-id")');
 		expect(accessor).not.toContain('from "./db-vacuum-worker"');
 		expect(vacuum).not.toContain('from "./db-owner-runtime"');
+	});
+
+	describe("close participant lifecycle", () => {
+		it("preserves owner-before-cache order and rejects late registration", async () => {
+			const lifecycle = createDbAccessorLifecycle();
+			const closed: string[] = [];
+			let duringCloseError: unknown;
+			lifecycle.register({
+				name: "test-agent-scope-cache",
+				order: 200,
+				close: () => {
+					closed.push("agent-scope-cache");
+				},
+			});
+			lifecycle.register({
+				name: "test-db-owner",
+				order: 100,
+				close: () => {
+					closed.push("db-owner");
+					try {
+						lifecycle.register({
+							name: "during-close-participant",
+							order: 300,
+							close: () => undefined,
+						});
+					} catch (error) {
+						duringCloseError = error;
+					}
+				},
+			});
+
+			await lifecycle.close(undefined);
+
+			expect(closed).toEqual(["db-owner", "agent-scope-cache"]);
+			expect(duringCloseError).toBeInstanceOf(Error);
+			expect((duringCloseError as Error).message).toContain("registered after close started");
+			expect(() =>
+				lifecycle.register({
+					name: "late-participant",
+					order: 300,
+					close: () => undefined,
+				}),
+			).toThrow("registered after close started");
+		});
 	});
 });

--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -70,5 +70,27 @@ describe("DB foundation dependency invariant", () => {
 				"next-lifecycle-participant",
 			]);
 		});
+
+		it("reopens after a participant failure without caching the rejected close", async () => {
+			const lifecycle = createDbAccessorLifecycle();
+			let attempts = 0;
+			lifecycle.register({
+				name: "flaky-participant",
+				order: 100,
+				close: () => {
+					attempts += 1;
+					if (attempts === 1) throw new Error("simulated close failure");
+				},
+			});
+
+			await expect(lifecycle.close(undefined)).rejects.toThrow("simulated close failure");
+			lifecycle.register({
+				name: "reinitialized-participant",
+				order: 200,
+				close: () => undefined,
+			});
+			await lifecycle.close(undefined);
+			expect(attempts).toBe(2);
+		});
 	});
 });

--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function source(relativePath: string): string {
+	return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+describe("DB foundation dependency invariant", () => {
+	it("prevents accessor and vacuum primitives from importing owner orchestration", () => {
+		const accessor = source("./db-accessor.ts");
+		const vacuum = source("./db-vacuum.ts");
+
+		expect(accessor).not.toContain('from "./db-owner-runtime"');
+		expect(accessor).not.toContain('import("./agent-id")');
+		expect(accessor).not.toContain('from "./db-vacuum-worker"');
+		expect(vacuum).not.toContain('from "./db-owner-runtime"');
+	});
+});

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { vectorSearchWithMetadata } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { getDbAccessorPath, hasDbAccessor, resolveSqliteAgentsDir } from "./db-accessor";
+import { registerDbAccessorCloseParticipant } from "./db-accessor-lifecycle";
 import {
 	createDbOwnerClient,
 	DbOwnerAdmissionError,
@@ -591,3 +592,9 @@ export async function closeDbOwner(dbPath?: string): Promise<void> {
 	await Promise.all(entries.map((entry) => entry.owner.close()));
 	isolatedTestAccessor = null;
 }
+
+registerDbAccessorCloseParticipant({
+	name: "db-owner",
+	order: 100,
+	close: closeDbOwner,
+});

--- a/platform/daemon/src/db-vacuum-worker.ts
+++ b/platform/daemon/src/db-vacuum-worker.ts
@@ -20,7 +20,6 @@ import {
 import { logger } from "./logger";
 
 export interface IncrementalReclaimOptions {
-	readonly owner?: DbOwnerClient;
 	readonly batchPages?: number;
 	readonly maxBatches?: number;
 	readonly checkpointKey?: string;
@@ -35,7 +34,7 @@ export interface VacuumConversionHandle {
 
 /** Reclaim free pages in bounded batches with a real durable resume record. Conversion remains monolithic. */
 export async function reclaimIncrementalVacuum(
-	accessor: DbAccessor,
+	owner: DbOwnerClient,
 	opts: IncrementalReclaimOptions = {},
 ): Promise<{ readonly reclaimed: number; readonly remaining: number }> {
 	const batchPages = Math.max(1, Math.min(10_000, Math.trunc(opts.batchPages ?? 1_000)));
@@ -43,39 +42,32 @@ export async function reclaimIncrementalVacuum(
 	const key = opts.checkpointKey ?? "vacuum.incremental-reclaim";
 	let reclaimed = 0;
 	let remaining = 0;
-	if (opts.owner) {
-		await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.ensure", [
-			ownerRunStatement(
-				"CREATE TABLE IF NOT EXISTS db_vacuum_reclaim_checkpoints (checkpoint_key TEXT PRIMARY KEY, reclaimed INTEGER NOT NULL, remaining INTEGER NOT NULL, updated_at TEXT NOT NULL)",
-			),
-		]);
-		const saved = await ownerQueryOne<{ reclaimed: number; remaining: number }>(
-			opts.owner,
-			"maintenance.vacuum.checkpoint.read",
-			"SELECT reclaimed, remaining FROM db_vacuum_reclaim_checkpoints WHERE checkpoint_key = ?",
-			[key],
-		);
-		reclaimed = saved?.reclaimed ?? 0;
-		remaining = saved?.remaining ?? 0;
-	}
+	await ownerTransaction(owner, "maintenance.vacuum.checkpoint.ensure", [
+		ownerRunStatement(
+			"CREATE TABLE IF NOT EXISTS db_vacuum_reclaim_checkpoints (checkpoint_key TEXT PRIMARY KEY, reclaimed INTEGER NOT NULL, remaining INTEGER NOT NULL, updated_at TEXT NOT NULL)",
+		),
+	]);
+	const saved = await ownerQueryOne<{ reclaimed: number; remaining: number }>(
+		owner,
+		"maintenance.vacuum.checkpoint.read",
+		"SELECT reclaimed, remaining FROM db_vacuum_reclaim_checkpoints WHERE checkpoint_key = ?",
+		[key],
+	);
+	reclaimed = saved?.reclaimed ?? 0;
+	remaining = saved?.remaining ?? 0;
 	let previousRemaining: number | null = remaining > 0 ? remaining : null;
 	for (let batch = 0; batch < maxBatches; batch += 1) {
 		const before = previousRemaining;
-		if (opts.owner) remaining = await dbOwnerIncrementalVacuum(opts.owner, batchPages);
-		else {
-			if (!accessor.incrementalVacuumAsync) throw new Error("incremental vacuum operation is unavailable");
-			remaining = await accessor.incrementalVacuumAsync({ siteToken: "db-vacuum-worker.ts:incremental" });
-		}
+		remaining = await dbOwnerIncrementalVacuum(owner, batchPages);
 		const progressed = before === null ? Math.max(0, batchPages) : Math.max(0, before - remaining);
 		reclaimed += progressed;
 		previousRemaining = remaining;
-		if (opts.owner)
-			await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.write", [
-				ownerRunStatement(
-					"INSERT INTO db_vacuum_reclaim_checkpoints (checkpoint_key, reclaimed, remaining, updated_at) VALUES (?, ?, ?, datetime('now')) ON CONFLICT(checkpoint_key) DO UPDATE SET reclaimed=excluded.reclaimed, remaining=excluded.remaining, updated_at=excluded.updated_at",
-					[key, reclaimed, remaining],
-				),
-			]);
+		await ownerTransaction(owner, "maintenance.vacuum.checkpoint.write", [
+			ownerRunStatement(
+				"INSERT INTO db_vacuum_reclaim_checkpoints (checkpoint_key, reclaimed, remaining, updated_at) VALUES (?, ?, ?, datetime('now')) ON CONFLICT(checkpoint_key) DO UPDATE SET reclaimed=excluded.reclaimed, remaining=excluded.remaining, updated_at=excluded.updated_at",
+				[key, reclaimed, remaining],
+			),
+		]);
 		opts.onCheckpoint?.(reclaimed, remaining);
 		if (remaining <= 0 || progressed <= 0) break;
 		await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -90,7 +82,7 @@ export async function reclaimIncrementalVacuum(
  */
 export function startVacuumConversionWorker(
 	accessor: DbAccessor,
-	opts: { readonly startImmediately?: boolean; readonly owner?: DbOwnerClient } = {},
+	opts: { readonly owner: DbOwnerClient; readonly startImmediately?: boolean },
 ): VacuumConversionHandle {
 	let active = true;
 	let timer: ReturnType<typeof setTimeout> | null = null;
@@ -111,12 +103,7 @@ export function startVacuumConversionWorker(
 			});
 
 			try {
-				if (opts.owner !== undefined) {
-					await dbOwnerVacuumConversion(opts.owner);
-				} else {
-					if (!accessor.vacuumConversionAsync) throw new Error("VACUUM conversion operation is unavailable");
-					await accessor.vacuumConversionAsync({ siteToken: "db-vacuum-worker.ts:conversion" });
-				}
+				await dbOwnerVacuumConversion(opts.owner);
 				await markVacuumConversionCompleted(accessor);
 				logger.info("db-vacuum", "Post-ready conversion worker completed");
 			} catch (error) {

--- a/platform/daemon/src/db-vacuum-worker.ts
+++ b/platform/daemon/src/db-vacuum-worker.ts
@@ -1,0 +1,165 @@
+/**
+ * Post-readiness vacuum orchestration.
+ *
+ * This module may depend on the DB-owner runtime. Foundational vacuum state
+ * and SQLite primitives live in db-vacuum.ts so the accessor never imports
+ * this higher-level orchestration layer.
+ */
+
+import type { DbAccessor } from "./db-accessor";
+import type { DbOwnerClient } from "./db-owner-client";
+import { ownerQueryOne, ownerRunStatement, ownerTransaction } from "./db-owner-maintenance";
+import { dbOwnerIncrementalVacuum, dbOwnerVacuumConversion } from "./db-owner-runtime";
+import {
+	getVacuumConversionStatusAsync,
+	markVacuumConversionCompleted,
+	markVacuumConversionFailed,
+	markVacuumConversionRunning,
+	type VacuumConversionStatus,
+} from "./db-vacuum";
+import { logger } from "./logger";
+
+export interface IncrementalReclaimOptions {
+	readonly owner?: DbOwnerClient;
+	readonly batchPages?: number;
+	readonly maxBatches?: number;
+	readonly checkpointKey?: string;
+	readonly onCheckpoint?: (reclaimed: number, remaining: number) => void;
+}
+
+export interface VacuumConversionHandle {
+	readonly running: boolean;
+	stop(): void;
+	run(): Promise<VacuumConversionStatus>;
+}
+
+/** Reclaim free pages in bounded batches with a real durable resume record. Conversion remains monolithic. */
+export async function reclaimIncrementalVacuum(
+	accessor: DbAccessor,
+	opts: IncrementalReclaimOptions = {},
+): Promise<{ readonly reclaimed: number; readonly remaining: number }> {
+	const batchPages = Math.max(1, Math.min(10_000, Math.trunc(opts.batchPages ?? 1_000)));
+	const maxBatches = Math.max(1, Math.min(100_000, Math.trunc(opts.maxBatches ?? 100_000)));
+	const key = opts.checkpointKey ?? "vacuum.incremental-reclaim";
+	let reclaimed = 0;
+	let remaining = 0;
+	if (opts.owner) {
+		await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.ensure", [
+			ownerRunStatement(
+				"CREATE TABLE IF NOT EXISTS db_vacuum_reclaim_checkpoints (checkpoint_key TEXT PRIMARY KEY, reclaimed INTEGER NOT NULL, remaining INTEGER NOT NULL, updated_at TEXT NOT NULL)",
+			),
+		]);
+		const saved = await ownerQueryOne<{ reclaimed: number; remaining: number }>(
+			opts.owner,
+			"maintenance.vacuum.checkpoint.read",
+			"SELECT reclaimed, remaining FROM db_vacuum_reclaim_checkpoints WHERE checkpoint_key = ?",
+			[key],
+		);
+		reclaimed = saved?.reclaimed ?? 0;
+		remaining = saved?.remaining ?? 0;
+	}
+	let previousRemaining: number | null = remaining > 0 ? remaining : null;
+	for (let batch = 0; batch < maxBatches; batch += 1) {
+		const before = previousRemaining;
+		if (opts.owner) remaining = await dbOwnerIncrementalVacuum(opts.owner, batchPages);
+		else {
+			if (!accessor.incrementalVacuumAsync) throw new Error("incremental vacuum operation is unavailable");
+			remaining = await accessor.incrementalVacuumAsync({ siteToken: "db-vacuum-worker.ts:incremental" });
+		}
+		const progressed = before === null ? Math.max(0, batchPages) : Math.max(0, before - remaining);
+		reclaimed += progressed;
+		previousRemaining = remaining;
+		if (opts.owner)
+			await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.write", [
+				ownerRunStatement(
+					"INSERT INTO db_vacuum_reclaim_checkpoints (checkpoint_key, reclaimed, remaining, updated_at) VALUES (?, ?, ?, datetime('now')) ON CONFLICT(checkpoint_key) DO UPDATE SET reclaimed=excluded.reclaimed, remaining=excluded.remaining, updated_at=excluded.updated_at",
+					[key, reclaimed, remaining],
+				),
+			]);
+		opts.onCheckpoint?.(reclaimed, remaining);
+		if (remaining <= 0 || progressed <= 0) break;
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+	}
+	return { reclaimed, remaining };
+}
+
+/**
+ * Start the post-ready one-shot conversion worker. The timer yields once so
+ * the listening callback can return and readiness can be recorded before work
+ * begins.
+ */
+export function startVacuumConversionWorker(
+	accessor: DbAccessor,
+	opts: { readonly startImmediately?: boolean; readonly owner?: DbOwnerClient } = {},
+): VacuumConversionHandle {
+	let active = true;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let inFlight: Promise<VacuumConversionStatus> | null = null;
+
+	async function run(): Promise<VacuumConversionStatus> {
+		if (inFlight) return inFlight;
+		const cycle = (async (): Promise<VacuumConversionStatus> => {
+			const before = await getVacuumConversionStatusAsync(accessor);
+			if (before.state !== "pending" || before.attempts >= before.maxAttempts) return before;
+
+			await markVacuumConversionRunning(accessor);
+			const running = await getVacuumConversionStatusAsync(accessor);
+			if (running.state !== "running") return running;
+			logger.info("db-vacuum", "Post-ready conversion worker started", {
+				attempt: running.attempts,
+				maxAttempts: running.maxAttempts,
+			});
+
+			try {
+				if (opts.owner !== undefined) {
+					await dbOwnerVacuumConversion(opts.owner);
+				} else {
+					if (!accessor.vacuumConversionAsync) throw new Error("VACUUM conversion operation is unavailable");
+					await accessor.vacuumConversionAsync({ siteToken: "db-vacuum-worker.ts:conversion" });
+				}
+				await markVacuumConversionCompleted(accessor);
+				logger.info("db-vacuum", "Post-ready conversion worker completed");
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				await markVacuumConversionFailed(accessor, message);
+				logger.error(
+					"db-vacuum",
+					"Post-ready conversion worker failed; retry is available on a later startup while the attempt budget remains",
+					error instanceof Error ? error : undefined,
+				);
+			}
+			return await getVacuumConversionStatusAsync(accessor);
+		})();
+		inFlight = cycle;
+		void cycle.then(
+			() => {
+				if (inFlight === cycle) inFlight = null;
+			},
+			() => {
+				if (inFlight === cycle) inFlight = null;
+			},
+		);
+		return cycle;
+	}
+
+	if (opts.startImmediately !== false) {
+		timer = setTimeout(() => {
+			if (!active) return;
+			void run().catch((error) => {
+				logger.error("db-vacuum", "Post-ready conversion worker crashed", error instanceof Error ? error : undefined);
+			});
+		}, 0);
+	}
+
+	return {
+		get running(): boolean {
+			return active;
+		},
+		stop(): void {
+			active = false;
+			if (timer) clearTimeout(timer);
+			timer = null;
+		},
+		run,
+	};
+}

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -22,9 +22,8 @@ import {
 	DbSpacePreflightError,
 	getFreePageRatio,
 	getVacuumConversionStatus,
-	reclaimIncrementalVacuum,
-	startVacuumConversionWorker,
 } from "./db-vacuum";
+import { reclaimIncrementalVacuum, startVacuumConversionWorker } from "./db-vacuum-worker";
 
 // The functions accept a narrower interface; bun:sqlite.Database satisfies it.
 type PragmaDb = Parameters<typeof convertToIncrementalVacuum>[0];

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -15,7 +15,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { createDbOwnerClient } from "./db-owner-client";
+import { createDbOwnerClient, type DbOwnerClient } from "./db-owner-client";
 import { getSyncDbAccessor } from "../legacy-sync/db-accessor-sync";
 import {
 	convertToIncrementalVacuum,
@@ -292,12 +292,17 @@ describe("deferred vacuum conversion (#1493)", () => {
 		const db = legacyDbPath();
 		dir = db.dir;
 		initDbAccessor(db.path);
-		const worker = startVacuumConversionWorker(getDbAccessor(), { startImmediately: false });
-
-		const completed = await worker.run();
-		expect(completed.state).toBe("completed");
-		expect(completed.attempts).toBe(1);
-		expect(await worker.run()).toMatchObject({ state: "completed", attempts: 1 });
+		const owner = createDbOwnerClient({ dbPath: db.path });
+		await owner.start();
+		try {
+			const worker = startVacuumConversionWorker(getDbAccessor(), { owner, startImmediately: false });
+			const completed = await worker.run();
+			expect(completed.state).toBe("completed");
+			expect(completed.attempts).toBe(1);
+			expect(await worker.run()).toMatchObject({ state: "completed", attempts: 1 });
+		} finally {
+			await owner.close();
+		}
 
 		const markerCount = getSyncDbAccessor().withReadDb(
 			(readDb) =>
@@ -384,14 +389,13 @@ describe("deferred vacuum conversion (#1493)", () => {
 		initDbAccessor(db.path);
 		expect(getVacuumConversionStatus(getDbAccessor())).toMatchObject({ state: "pending", attempts: 1 });
 
-		const accessor = getDbAccessor();
-		const originalConversion = accessor.vacuumConversionAsync;
-		accessor.vacuumConversionAsync = async () => {
-			throw new Error("simulated conversion failure");
-		};
-		const worker = startVacuumConversionWorker(accessor, { startImmediately: false });
+		const failure = new Error("simulated conversion failure");
+		const failingOwner = {
+			submit: () => ({ result: Promise.reject(failure), cancel: () => undefined }),
+			awaitResult: async <Result>(handle: { readonly result: Promise<Result> }) => await handle.result,
+		} as unknown as DbOwnerClient;
+		const worker = startVacuumConversionWorker(getDbAccessor(), { owner: failingOwner, startImmediately: false });
 		const failed = await worker.run();
-		accessor.vacuumConversionAsync = originalConversion;
 		expect(failed).toMatchObject({ state: "failed", attempts: 2, lastError: "simulated conversion failure" });
 
 		closeDbAccessor();
@@ -421,13 +425,11 @@ describe("integrated incremental reclaim resume (#1667)", () => {
 		expect(freeBefore).toBeGreaterThan(2);
 
 		const owner = createDbOwnerClient({ dbPath });
-		const accessor = {} as Parameters<typeof reclaimIncrementalVacuum>[0];
 		const checkpoints: Array<{ reclaimed: number; remaining: number }> = [];
 		let killed = false;
 		try {
 			await owner.start();
-			await reclaimIncrementalVacuum(accessor, {
-				owner,
+			await reclaimIncrementalVacuum(owner, {
 				batchPages: 1,
 				checkpointKey: "test.integrated-reclaim",
 				maxBatches: 1,
@@ -457,8 +459,7 @@ describe("integrated incremental reclaim resume (#1667)", () => {
 		const resumedOwner = createDbOwnerClient({ dbPath });
 		try {
 			await resumedOwner.start();
-			const resumed = await reclaimIncrementalVacuum(accessor, {
-				owner: resumedOwner,
+			const resumed = await reclaimIncrementalVacuum(resumedOwner, {
 				batchPages: 1,
 				checkpointKey: "test.integrated-reclaim",
 				maxBatches: 200,

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -330,14 +330,14 @@ export function getVacuumConversionStatus(accessor: DbAccessor): VacuumConversio
 	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 	return accessor.withReadDb(
 		(db: import("./db-accessor").ReadDb) => readStatusFromDb(toPragmaReadDb(db)),
-		"db-vacuum.ts:340",
+		"db-vacuum.ts:331",
 	);
 }
 
 /** Async durable conversion-state lookup for background workers. */
 export async function getVacuumConversionStatusAsync(accessor: DbAccessor): Promise<VacuumConversionStatus> {
 	return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {
-		siteToken: "db-vacuum.ts:348",
+		siteToken: "db-vacuum.ts:339",
 		operation: "maintenance.vacuum.status",
 	});
 }
@@ -358,7 +358,7 @@ export async function markVacuumConversionRunning(accessor: DbAccessor): Promise
 				lastError: null,
 			});
 		},
-		{ siteToken: "db-vacuum.ts:mark-running", operation: "maintenance.vacuum.mark-running" },
+		{ siteToken: "db-vacuum.ts:347", operation: "maintenance.vacuum.mark-running" },
 	);
 }
 
@@ -377,7 +377,7 @@ export async function markVacuumConversionCompleted(accessor: DbAccessor): Promi
 				lastError: null,
 			});
 		},
-		{ siteToken: "db-vacuum.ts:mark-completed", operation: "maintenance.vacuum.mark-completed" },
+		{ siteToken: "db-vacuum.ts:367", operation: "maintenance.vacuum.mark-completed" },
 	);
 }
 
@@ -396,7 +396,7 @@ export async function markVacuumConversionFailed(accessor: DbAccessor, message: 
 				lastError: message.slice(0, 500),
 			});
 		},
-		{ siteToken: "db-vacuum.ts:mark-failed", operation: "maintenance.vacuum.mark-failed" },
+		{ siteToken: "db-vacuum.ts:386", operation: "maintenance.vacuum.mark-failed" },
 	);
 }
 

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -12,9 +12,6 @@
 import { statSync, statfsSync } from "node:fs";
 import { dirname } from "node:path";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
-import type { DbOwnerClient } from "./db-owner-client";
-import { ownerQueryOne, ownerTransaction, ownerRunStatement } from "./db-owner-maintenance";
-import { dbOwnerIncrementalVacuum, dbOwnerVacuumConversion } from "./db-owner-runtime";
 import { logger } from "./logger";
 
 /** Marker table name for the one-time VACUUM conversion. */
@@ -131,12 +128,6 @@ export interface VacuumConversionStatus {
 	readonly completedAt: string | null;
 	readonly updatedAt: string | null;
 	readonly lastError: string | null;
-}
-
-export interface VacuumConversionHandle {
-	readonly running: boolean;
-	stop(): void;
-	run(): Promise<VacuumConversionStatus>;
 }
 
 const STATE_TABLE_SQL = `
@@ -351,6 +342,64 @@ export async function getVacuumConversionStatusAsync(accessor: DbAccessor): Prom
 	});
 }
 
+/** Claim one pending conversion attempt before dispatching the owner job. */
+export async function markVacuumConversionRunning(accessor: DbAccessor): Promise<void> {
+	await accessor.withWriteTxAsync(
+		(db) => {
+			const state = stateFromRow(
+				toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
+			);
+			if (state.state !== "pending") return;
+			writeState(toPragmaDb(db), "running", {
+				attempts: state.attempts + 1,
+				requestedAt: state.requestedAt ?? now(),
+				startedAt: now(),
+				completedAt: null,
+				lastError: null,
+			});
+		},
+		{ siteToken: "db-vacuum.ts:mark-running", operation: "maintenance.vacuum.mark-running" },
+	);
+}
+
+/** Persist successful completion after the owner finishes the conversion. */
+export async function markVacuumConversionCompleted(accessor: DbAccessor): Promise<void> {
+	await accessor.withWriteTxAsync(
+		(db) => {
+			const state = stateFromRow(
+				toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
+			);
+			writeState(toPragmaDb(db), "completed", {
+				attempts: state.attempts,
+				requestedAt: state.requestedAt ?? now(),
+				startedAt: state.startedAt,
+				completedAt: now(),
+				lastError: null,
+			});
+		},
+		{ siteToken: "db-vacuum.ts:mark-completed", operation: "maintenance.vacuum.mark-completed" },
+	);
+}
+
+/** Persist a bounded failure message for startup retry policy. */
+export async function markVacuumConversionFailed(accessor: DbAccessor, message: string): Promise<void> {
+	await accessor.withWriteTxAsync(
+		(db) => {
+			const state = stateFromRow(
+				toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
+			);
+			writeState(toPragmaDb(db), "failed", {
+				attempts: state.attempts,
+				requestedAt: state.requestedAt ?? now(),
+				startedAt: state.startedAt,
+				completedAt: null,
+				lastError: message.slice(0, 500),
+			});
+		},
+		{ siteToken: "db-vacuum.ts:mark-failed", operation: "maintenance.vacuum.mark-failed" },
+	);
+}
+
 /** Get the free-page ratio (freelist_count / page_count). */
 export function getFreePageRatio(db: PragmaReadDb): number {
 	const freelist = db.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
@@ -416,188 +465,4 @@ export function convertToIncrementalVacuum(db: PragmaDb, options: VacuumConversi
 	db.exec(`CREATE TABLE IF NOT EXISTS ${VACUUM_CONVERSION_TABLE} (converted_at TEXT)`);
 	db.prepare(`INSERT INTO ${VACUUM_CONVERSION_TABLE} (converted_at) VALUES (?)`).run(now());
 	return true;
-}
-
-export interface IncrementalReclaimOptions {
-	readonly owner?: DbOwnerClient;
-	readonly batchPages?: number;
-	readonly maxBatches?: number;
-	readonly checkpointKey?: string;
-	readonly onCheckpoint?: (reclaimed: number, remaining: number) => void;
-}
-
-/** Reclaim free pages in bounded batches with a real durable resume record. Conversion remains monolithic. */
-export async function reclaimIncrementalVacuum(
-	accessor: DbAccessor,
-	opts: IncrementalReclaimOptions = {},
-): Promise<{ readonly reclaimed: number; readonly remaining: number }> {
-	const batchPages = Math.max(1, Math.min(10_000, Math.trunc(opts.batchPages ?? 1_000)));
-	const maxBatches = Math.max(1, Math.min(100_000, Math.trunc(opts.maxBatches ?? 100_000)));
-	const key = opts.checkpointKey ?? "vacuum.incremental-reclaim";
-	let reclaimed = 0;
-	let remaining = 0;
-	if (opts.owner) {
-		await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.ensure", [
-			ownerRunStatement(
-				"CREATE TABLE IF NOT EXISTS db_vacuum_reclaim_checkpoints (checkpoint_key TEXT PRIMARY KEY, reclaimed INTEGER NOT NULL, remaining INTEGER NOT NULL, updated_at TEXT NOT NULL)",
-			),
-		]);
-		const saved = await ownerQueryOne<{ reclaimed: number; remaining: number }>(
-			opts.owner,
-			"maintenance.vacuum.checkpoint.read",
-			"SELECT reclaimed, remaining FROM db_vacuum_reclaim_checkpoints WHERE checkpoint_key = ?",
-			[key],
-		);
-		reclaimed = saved?.reclaimed ?? 0;
-		remaining = saved?.remaining ?? 0;
-	}
-	let previousRemaining: number | null = remaining > 0 ? remaining : null;
-	for (let batch = 0; batch < maxBatches; batch += 1) {
-		const before = previousRemaining;
-		if (opts.owner) remaining = await dbOwnerIncrementalVacuum(opts.owner, batchPages);
-		else {
-			if (!accessor.incrementalVacuumAsync) throw new Error("incremental vacuum operation is unavailable");
-			remaining = await accessor.incrementalVacuumAsync({ siteToken: "db-vacuum.ts:460" });
-		}
-		const progressed = before === null ? Math.max(0, batchPages) : Math.max(0, before - remaining);
-		reclaimed += progressed;
-		previousRemaining = remaining;
-		if (opts.owner)
-			await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.write", [
-				ownerRunStatement(
-					"INSERT INTO db_vacuum_reclaim_checkpoints (checkpoint_key, reclaimed, remaining, updated_at) VALUES (?, ?, ?, datetime('now')) ON CONFLICT(checkpoint_key) DO UPDATE SET reclaimed=excluded.reclaimed, remaining=excluded.remaining, updated_at=excluded.updated_at",
-					[key, reclaimed, remaining],
-				),
-			]);
-		opts.onCheckpoint?.(reclaimed, remaining);
-		if (remaining <= 0 || progressed <= 0) break;
-		await new Promise<void>((resolve) => setTimeout(resolve, 0));
-	}
-	return { reclaimed, remaining };
-}
-
-/**
- * Start the post-ready one-shot conversion worker. The timer yields once so
- * the listening callback can return and readiness can be recorded before work
- * begins.
- */
-export function startVacuumConversionWorker(
-	accessor: DbAccessor,
-	opts: { readonly startImmediately?: boolean; readonly owner?: DbOwnerClient } = {},
-): VacuumConversionHandle {
-	let active = true;
-	let timer: ReturnType<typeof setTimeout> | null = null;
-	let inFlight: Promise<VacuumConversionStatus> | null = null;
-
-	async function run(): Promise<VacuumConversionStatus> {
-		if (inFlight) return inFlight;
-		const cycle = (async (): Promise<VacuumConversionStatus> => {
-			const before = await getVacuumConversionStatusAsync(accessor);
-			if (before.state !== "pending" || before.attempts >= before.maxAttempts) return before;
-
-			await accessor.withWriteTxAsync(
-				(db) => {
-					const state = stateFromRow(
-						toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
-					);
-					if (state.state !== "pending") return;
-					const requestedAt = state.requestedAt ?? now();
-					writeState(toPragmaDb(db), "running", {
-						attempts: state.attempts + 1,
-						requestedAt,
-						startedAt: now(),
-						completedAt: null,
-						lastError: null,
-					});
-				},
-				{ siteToken: "db-vacuum.ts:498", operation: "maintenance.vacuum.mark-running" },
-			);
-
-			const running = await getVacuumConversionStatusAsync(accessor);
-			if (running.state !== "running") return running;
-			logger.info("db-vacuum", "Post-ready conversion worker started", {
-				attempt: running.attempts,
-				maxAttempts: running.maxAttempts,
-			});
-
-			try {
-				if (opts.owner !== undefined) {
-					await dbOwnerVacuumConversion(opts.owner);
-				} else {
-					if (!accessor.vacuumConversionAsync) throw new Error("VACUUM conversion operation is unavailable");
-					await accessor.vacuumConversionAsync({ siteToken: "db-vacuum.ts:528" });
-				}
-				await accessor.withWriteTxAsync(
-					(db) => {
-						const state = stateFromRow(
-							toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
-						);
-						writeState(toPragmaDb(db), "completed", {
-							attempts: state.attempts,
-							requestedAt: state.requestedAt ?? now(),
-							startedAt: state.startedAt,
-							completedAt: now(),
-							lastError: null,
-						});
-					},
-					{ siteToken: "db-vacuum.ts:530", operation: "maintenance.vacuum.mark-completed" },
-				);
-				logger.info("db-vacuum", "Post-ready conversion worker completed");
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				await accessor.withWriteTxAsync(
-					(db) => {
-						const state = stateFromRow(
-							toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
-						);
-						writeState(toPragmaDb(db), "failed", {
-							attempts: state.attempts,
-							requestedAt: state.requestedAt ?? now(),
-							startedAt: state.startedAt,
-							completedAt: null,
-							lastError: message.slice(0, 500),
-						});
-					},
-					{ siteToken: "db-vacuum.ts:548", operation: "maintenance.vacuum.mark-failed" },
-				);
-				logger.error(
-					"db-vacuum",
-					"Post-ready conversion worker failed; retry is available on a later startup while the attempt budget remains",
-					error instanceof Error ? error : undefined,
-				);
-			}
-			return await getVacuumConversionStatusAsync(accessor);
-		})();
-		inFlight = cycle;
-		void cycle.then(
-			() => {
-				if (inFlight === cycle) inFlight = null;
-			},
-			() => {
-				if (inFlight === cycle) inFlight = null;
-			},
-		);
-		return cycle;
-	}
-
-	if (opts.startImmediately !== false) {
-		timer = setTimeout(() => {
-			if (!active) return;
-			void run().catch((error) => {
-				logger.error("db-vacuum", "Post-ready conversion worker crashed", error instanceof Error ? error : undefined);
-			});
-		}, 0);
-	}
-
-	return {
-		get running(): boolean {
-			return active;
-		},
-		stop(): void {
-			active = false;
-			if (timer) clearTimeout(timer);
-			timer = null;
-		},
-		run,
-	};
 }

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -12,7 +12,6 @@
 import type { DbAccessor } from "../db-accessor";
 import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import { ownerQueryAll, ownerQueryOne } from "../db-owner-maintenance";
-import { getFreePageRatio } from "../db-vacuum";
 import { reclaimIncrementalVacuum } from "../db-vacuum-worker";
 import type { DiagnosticsReport, ProviderTracker } from "../diagnostics";
 import { getDiagnostics } from "../diagnostics";
@@ -517,27 +516,20 @@ export function startMaintenanceWorker(
 		// Only run when the free-page ratio is high and the system is not under pressure.
 		try {
 			const owner = deps.ownerMaintenance;
-			const ratio = owner
-				? await (async (): Promise<number> => {
-						const freelist = await ownerQueryOne<{ freelist_count: number }>(
-							owner.owner,
-							"pipeline/maintenance-worker.freelist-count",
-							"PRAGMA freelist_count",
-						);
-						const pages = await ownerQueryOne<{ page_count: number }>(
-							owner.owner,
-							"pipeline/maintenance-worker.page-count",
-							"PRAGMA page_count",
-						);
-						const free = freelist?.freelist_count ?? 0;
-						const total = pages?.page_count ?? 0;
-						return total > 0 ? free / total : 0;
-					})()
-				: await accessor.withReadDbAsync(async (db) => getFreePageRatio(db), {
-						siteToken: "pipeline/maintenance-worker.ts:535",
-					});
-			if (ratio >= 0.2) {
-				await reclaimIncrementalVacuum(accessor, { owner: deps.ownerMaintenance?.owner });
+			if (owner) {
+				const freelist = await ownerQueryOne<{ freelist_count: number }>(
+					owner.owner,
+					"pipeline/maintenance-worker.freelist-count",
+					"PRAGMA freelist_count",
+				);
+				const pages = await ownerQueryOne<{ page_count: number }>(
+					owner.owner,
+					"pipeline/maintenance-worker.page-count",
+					"PRAGMA page_count",
+				);
+				const free = freelist?.freelist_count ?? 0;
+				const total = pages?.page_count ?? 0;
+				if (total > 0 && free / total >= 0.2) await reclaimIncrementalVacuum(owner.owner);
 			}
 		} catch {
 			// Non-fatal — vacuum should never interrupt the maintenance cycle

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -12,7 +12,8 @@
 import type { DbAccessor } from "../db-accessor";
 import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import { ownerQueryAll, ownerQueryOne } from "../db-owner-maintenance";
-import { getFreePageRatio, reclaimIncrementalVacuum } from "../db-vacuum";
+import { getFreePageRatio } from "../db-vacuum";
+import { reclaimIncrementalVacuum } from "../db-vacuum-worker";
 import type { DiagnosticsReport, ProviderTracker } from "../diagnostics";
 import { getDiagnostics } from "../diagnostics";
 import { isActiveEmbeddingConfig } from "../embedding-index-state";

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(931);
+	expect(baseline).toHaveLength(928);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(104);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(191);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(190);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,16 +353,16 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 931 sites");
-	expect(report).toContain("65 synchronous writes, 104 synchronous reads, and 246 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 244");
+	expect(report).toContain("Exact ledger inventory: 928 sites");
+	expect(report).toContain("65 synchronous writes, 104 synchronous reads, and 243 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 241");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 244 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 241 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 415");
-	expect(report).toContain("ON-PARENT callback execution: 413");
+	expect(report).toContain("Database accessor sites classified: 412");
+	expect(report).toContain("ON-PARENT callback execution: 410");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -914,63 +914,49 @@
     },
     {
       "path": "db-vacuum.ts",
-      "line": 80,
+      "line": 77,
       "api": "statSync",
       "source": "const dbBytes = deps.statSync(dbPath).size;",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 82,
+      "line": 79,
       "api": "statfsSync",
       "source": "const stats = deps.statfsSync(directory);",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 340,
+      "line": 331,
       "api": "withReadDb",
       "source": "return accessor.withReadDb(",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 348,
+      "line": 339,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 460,
-      "api": "incrementalVacuumAsync",
-      "source": "remaining = await accessor.incrementalVacuumAsync({ siteToken: \"db-vacuum.ts:460\" });",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 498,
+      "line": 347,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 528,
-      "api": "vacuumConversionAsync",
-      "source": "await accessor.vacuumConversionAsync({ siteToken: \"db-vacuum.ts:528\" });",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 530,
+      "line": 367,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 548,
+      "line": 386,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
       "category": "hot-path"
@@ -3059,13 +3045,6 @@
       "line": 485,
       "api": "withReadDbAsync",
       "source": ": await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/maintenance-worker.ts",
-      "line": 535,
-      "api": "withReadDbAsync",
-      "source": ": await accessor.withReadDbAsync(async (db) => getFreePageRatio(db), {",
       "category": "hot-path"
     },
     {


### PR DESCRIPTION
## Summary

Makes the DB accessor a foundational module again by removing its upward dependencies on daemon owner shutdown, agent-cache invalidation, and post-readiness VACUUM orchestration.

The measured largest daemon runtime strongly connected component falls from 29 modules to 15. Production behavior is preserved, while the non-owner vacuum compatibility paths are removed so maintenance cannot silently fall back to blocking the daemon process.

## Changes

- Add an explicit, ordered DB-accessor close-participant boundary; owner runtime and agent-scope cache register their own cleanup.
- Move post-readiness VACUUM worker/reclaim orchestration into `db-vacuum-worker.ts`.
- Keep SQLite VACUUM primitives and durable conversion state in `db-vacuum.ts` without importing the owner runtime.
- Require a `DbOwnerClient` for conversion and incremental reclaim; when owner maintenance is unavailable, reclaim is skipped instead of executing SQLite work on the parent event loop.
- Tighten the event-loop ledger from 413 to 410 ON-PARENT DB callbacks and update the generated audit report.
- Add a named dependency invariant preventing foundational DB modules from regaining those upward imports.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard — build verification only; no surface change
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no feature/spec change
- [x] Agent scoping verified on all new/changed data queries — query behavior is unchanged
- [x] Input/config validation and bounds checks added — no input/config changes
- [x] Error handling and fallback paths tested (no silent swallow) — owner conversion failure, SIGKILL recovery, and retry paths pass
- [x] Security checks applied to admin/mutation endpoints — no endpoint changes
- [x] Docs updated for API/spec/status changes — no public behavior change
- [x] Regression tests added for each bug fix — not a bug fix; a named architecture invariant was added
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test platform/daemon/src/db-foundation-boundary.test.ts platform/daemon/src/agent-scope-cache-lifecycle.test.ts`
- [x] `bun test platform/daemon/src/db-vacuum.test.ts platform/daemon/src/pipeline/maintenance-worker.test.ts` — 30 pass
- [x] `bun scripts/audit-event-loop-contract.ts` — 928 sites, 410 ON-PARENT / 2 OFF-PARENT
- [x] `bun test scripts/audit-event-loop-contract.test.ts platform/daemon/src/db-foundation-boundary.test.ts` — 24 pass
- [x] `bun run --filter '@signet/daemon' typecheck`
- [x] `bun run --filter '@signet/daemon' build`
- [x] targeted Biome and diff checks
- [ ] Tested against running daemon — no installed runtime behavior changed

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

This is a bounded dependency-inversion slice from the broader stability program in #1748. It does not claim the remaining 15-module owner/Dreaming runtime knot is resolved.
