### PR TITLE
refactor(daemon): make inline owner dispatch exhaustive

### DIFF
--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -63,7 +63,11 @@ function inlineStatement(db: ReadDb | WriteDb, statement: DbOwnerStatement): unk
 	return prepared.run(...params);
 }
 
-async function inlineRequest(accessor: DbAccessor, request: DbOwnerRequest): Promise<unknown> {
+function unreachableInlineRequest(request: never): never {
+	throw new Error(`Unreachable inline DB owner request: ${String(request)}`);
+}
+
+async function executeInlineOwnerRequest(accessor: DbAccessor, request: DbOwnerRequest): Promise<unknown> {
 	if (request.kind === "query") {
 		if (request.statement.result === "run") {
 			return invokeAccessor(accessor, "withWriteTx", (db) => inlineStatement(db, request.statement));
@@ -181,10 +185,32 @@ async function inlineRequest(accessor: DbAccessor, request: DbOwnerRequest): Pro
 			vectorSearchWithMetadata(db as never, new Float32Array(request.payload.queryEmbedding), request.payload.options),
 		);
 	}
-	throw new Error(`Unsupported isolated owner request: ${request.kind}`);
+	switch (request.kind) {
+		case "initialize":
+		case "recall":
+		case "source_snapshot_import":
+		case "source_graph_index":
+		case "source_graph_file_purge":
+		case "source_graph_purge":
+		case "source_artifact_index":
+		case "source_native_memory_index":
+		case "source_artifact_purge":
+		case "source_artifact_upsert":
+		case "source_artifact_upsert_batch":
+		case "embedding_migration_progress":
+		case "health_ready":
+		case "diagnostics":
+		case "vector_backfill":
+		case "vacuum_conversion":
+		case "incremental_vacuum":
+		case "sleep":
+			throw new Error(`Unsupported inline owner request: ${request.kind}`);
+		default:
+			return unreachableInlineRequest(request);
+	}
 }
 
-function isolatedOwner(accessor: DbAccessor): DbOwnerClient {
+function inlineOwner(accessor: DbAccessor): DbOwnerClient {
 	const submit = <Result>(request: DbOwnerRequest, options: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> => {
 		const now = Date.now();
 		const job: DbOwnerJob = {
@@ -198,7 +224,7 @@ function isolatedOwner(accessor: DbAccessor): DbOwnerClient {
 			cancellation: "pending",
 			request,
 		};
-		return { job, result: inlineRequest(accessor, request) as Promise<Result>, cancel: () => undefined };
+		return { job, result: executeInlineOwnerRequest(accessor, request) as Promise<Result>, cancel: () => undefined };
 	};
 	return {
 		start: async () => undefined,
@@ -290,18 +316,18 @@ export async function startDbRecallOwner(
 }
 
 async function getCurrentProcessOwner(): Promise<DbOwnerClient> {
-	if (isolatedTestAccessor !== null) return isolatedOwner(isolatedTestAccessor);
+	if (isolatedTestAccessor !== null) return inlineOwner(isolatedTestAccessor);
 	const { getDbAccessor } = await import("./db-accessor");
-	return isolatedOwner(getDbAccessor());
+	return inlineOwner(getDbAccessor());
 }
 
-/** Lazily start an isolated owner when the daemon has not registered its shared owner. */
+/** Resolve the process owner, or the in-process adapter used inside an owner worker. */
 export async function getDbOwner(dbPath?: string): Promise<DbOwnerClient> {
 	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return await getCurrentProcessOwner();
 	const registered = getDbOwnerMaintenance()?.owner;
 	if (registered !== undefined) return registered;
 	if (hasDbAccessor()) return await startDbOwner(getDbAccessorPath());
-	if (isolatedTestAccessor !== null) return isolatedOwner(isolatedTestAccessor);
+	if (isolatedTestAccessor !== null) return inlineOwner(isolatedTestAccessor);
 	return await startDbOwner(dbPath);
 }
 
@@ -309,7 +335,7 @@ export async function getDbOwner(dbPath?: string): Promise<DbOwnerClient> {
 export async function getDbRecallOwner(dbPath?: string): Promise<DbOwnerClient> {
 	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return await getCurrentProcessOwner();
 	if (hasDbAccessor()) return await startDbRecallOwner(getDbAccessorPath());
-	if (isolatedTestAccessor !== null) return isolatedOwner(isolatedTestAccessor);
+	if (isolatedTestAccessor !== null) return inlineOwner(isolatedTestAccessor);
 	return await startDbRecallOwner(dbPath);
 }
 
@@ -318,10 +344,10 @@ export async function getDbRecallOwner(dbPath?: string): Promise<DbOwnerClient> 
  * accessor without opening a second SQLite connection.
  */
 export async function getDbOwnerForAccessor(accessor: DbAccessor): Promise<DbOwnerClient> {
-	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return isolatedOwner(accessor);
+	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return inlineOwner(accessor);
 	if (hasDbAccessor()) return await getDbOwner(getDbAccessorPath());
 	registerDbOwnerIsolatedTestAccessor(accessor);
-	return isolatedOwner(accessor);
+	return inlineOwner(accessor);
 }
 
 export interface DbOwnerSqlOptions {


### PR DESCRIPTION
## Summary

Makes the in-process DB-owner dispatcher compile-time exhaustive so a newly added protocol request cannot silently fall through to a production-only runtime error.

This closes the structural hole that allowed nested `vector_search` to compile without an inline implementation before #1749.

## Changes

- Rename the production-used adapter from `isolatedOwner`/`inlineRequest` to `inlineOwner`/`executeInlineOwnerRequest`.
- Explicitly classify every request kind that is unsupported in-process.
- Route the final branch through a `never` assertion so adding a new `DbOwnerRequest` kind fails typecheck until the inline policy is updated.
- Clarify the resolver comment: this adapter is owner-worker behavior, not only a test seam.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard — build verification only
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — protocol behavior is unchanged
- [x] Agent scoping verified on all new/changed data queries — no query changes
- [x] Input/config validation and bounds checks added — no input/config changes
- [x] Error handling and fallback paths tested (no silent swallow) — unsupported kinds remain loud and are now explicitly classified
- [x] Security checks applied to admin/mutation endpoints — no endpoint changes
- [x] Docs updated for API/spec/status changes — no public API change
- [x] Regression tests added for each bug fix — existing nested owner regression covers the prior failure; this PR adds a compile-time invariant
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun run --filter '@signet/daemon' typecheck`
- [x] nested recall-owner vector-search regression passes
- [x] `bun run --filter '@signet/daemon' build`
- [x] targeted Biome and diff checks
- [ ] Tested against running daemon — no installed runtime behavior changed

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

The next architectural step is still to separate owner transport from owner-local domain execution. This PR first makes protocol drift fail at compile time rather than at runtime.
