### PR TITLE
refactor(daemon): stabilize DB attribution IDs

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -1,6 +1,6 @@
 # Event-loop synchronous contract audit
 
-This report is generated from the deterministic migration ledger in `scripts/event-loop-contract-baseline.json`. Phase A enforces the type boundary structurally: production code receives an async-only `DbAccessor`, while the synchronous compatibility module lives outside the daemon production `src/` tree and is rejected by the production TypeScript project's `rootDir`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching.
+This report is generated from the deterministic migration ledger in `scripts/event-loop-contract-baseline.json`. Phase A enforces the type boundary structurally: production code receives an async-only `DbAccessor`, while the synchronous compatibility module lives outside the daemon production `src/` tree and is rejected by the production TypeScript project's `rootDir`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching. Migrated DB sites use unique `db:domain.operation.action` IDs as their durable identity; file and line remain diagnostic metadata.
 
 ## Current inventory
 
@@ -60,11 +60,11 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `database-integrity.ts:712` (withReadDbAsync)
 - `database-integrity.ts:830` (withReadDbAsync)
 - `db-accessor.ts:3031` (withWriteTxAsync)
-- `db-vacuum.ts:331` (withReadDb)
-- `db-vacuum.ts:339` (withReadDbAsync)
-- `db-vacuum.ts:347` (withWriteTxAsync)
-- `db-vacuum.ts:367` (withWriteTxAsync)
-- `db-vacuum.ts:386` (withWriteTxAsync)
+- `db:vacuum.conversion-status.sync-read` (withReadDb)
+- `db:vacuum.conversion-status.read` (withReadDbAsync)
+- `db:vacuum.conversion-state.mark-running` (withWriteTxAsync)
+- `db:vacuum.conversion-state.mark-completed` (withWriteTxAsync)
+- `db:vacuum.conversion-state.mark-failed` (withWriteTxAsync)
 - `discord-desktop-cache-source.ts:484` (withReadDbAsync)
 - `discord-desktop-cache-source.ts:497` (withWriteTxAsync)
 - `discord-source-provider.ts:573` (withReadDbAsync)
@@ -217,9 +217,9 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `pipeline/dreaming-worker.ts:227` (withReadDbAsync)
 - `pipeline/dreaming-worker.ts:247` (withReadDbAsync)
 - `pipeline/graph-traversal.ts:92` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:148` (withReadDbAsync)
+- `db:maintenance.graph-agent-scopes.read` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:485` (withReadDbAsync)
+- `db:maintenance.dead-memory-count.read` (withReadDbAsync)
 - `pipeline/prospective-index.ts:284` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:300` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:336` (withWriteTxAsync)

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -330,14 +330,14 @@ export function getVacuumConversionStatus(accessor: DbAccessor): VacuumConversio
 	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 	return accessor.withReadDb(
 		(db: import("./db-accessor").ReadDb) => readStatusFromDb(toPragmaReadDb(db)),
-		"db-vacuum.ts:331",
+		"db:vacuum.conversion-status.sync-read",
 	);
 }
 
 /** Async durable conversion-state lookup for background workers. */
 export async function getVacuumConversionStatusAsync(accessor: DbAccessor): Promise<VacuumConversionStatus> {
 	return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {
-		siteToken: "db-vacuum.ts:339",
+		siteToken: "db:vacuum.conversion-status.read",
 		operation: "maintenance.vacuum.status",
 	});
 }
@@ -358,7 +358,7 @@ export async function markVacuumConversionRunning(accessor: DbAccessor): Promise
 				lastError: null,
 			});
 		},
-		{ siteToken: "db-vacuum.ts:347", operation: "maintenance.vacuum.mark-running" },
+		{ siteToken: "db:vacuum.conversion-state.mark-running", operation: "maintenance.vacuum.mark-running" },
 	);
 }
 
@@ -377,7 +377,7 @@ export async function markVacuumConversionCompleted(accessor: DbAccessor): Promi
 				lastError: null,
 			});
 		},
-		{ siteToken: "db-vacuum.ts:367", operation: "maintenance.vacuum.mark-completed" },
+		{ siteToken: "db:vacuum.conversion-state.mark-completed", operation: "maintenance.vacuum.mark-completed" },
 	);
 }
 
@@ -396,7 +396,7 @@ export async function markVacuumConversionFailed(accessor: DbAccessor, message: 
 				lastError: message.slice(0, 500),
 			});
 		},
-		{ siteToken: "db-vacuum.ts:386", operation: "maintenance.vacuum.mark-failed" },
+		{ siteToken: "db:vacuum.conversion-state.mark-failed", operation: "maintenance.vacuum.mark-failed" },
 	);
 }
 

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -9,7 +9,7 @@
  * another cycle starts.
  */
 
-import type { DbAccessor } from "../db-accessor";
+import type { DbAccessor, SyncDbCallSiteToken } from "../db-accessor";
 import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import { ownerQueryAll, ownerQueryOne } from "../db-owner-maintenance";
 import { reclaimIncrementalVacuum } from "../db-vacuum-worker";
@@ -146,7 +146,7 @@ async function getGraphAgentIds(
 				sql,
 			)
 		: await accessor.withReadDbAsync((db) => db.prepare(sql).all() as Array<{ agent_id: string | null }>, {
-				siteToken: "pipeline/maintenance-worker.ts:148",
+				siteToken: "db:maintenance.graph-agent-scopes.read",
 			});
 	const ids = rows.flatMap((row) =>
 		typeof row.agent_id === "string" && row.agent_id.length > 0 ? [row.agent_id] : [],
@@ -338,7 +338,7 @@ export function startMaintenanceWorker(
 	};
 
 	async function doTick(): Promise<MaintenanceCycleResult> {
-		const readDiagnostics = async (siteToken: string): Promise<DiagnosticsReport> =>
+		const readDiagnostics = async (siteToken: SyncDbCallSiteToken): Promise<DiagnosticsReport> =>
 			deps.ownerMaintenance
 				? await deps.ownerMaintenance.diagnostics(tracker.stats)
 				: // Each caller supplies the original static token for this compatibility fallback.
@@ -499,7 +499,7 @@ export function startMaintenanceWorker(
 										DEAD_MEMORY_DEFAULT_ACCESS_DAYS,
 									) as { n: number }
 							).n,
-						{ siteToken: "pipeline/maintenance-worker.ts:485" },
+						{ siteToken: "db:maintenance.dead-memory-count.read" },
 					);
 			const count = typeof countRow === "number" ? countRow : (countRow?.n ?? 0);
 			if (count > 100) {

--- a/platform/daemon/src/sync-db-attribution.test.ts
+++ b/platform/daemon/src/sync-db-attribution.test.ts
@@ -33,6 +33,13 @@ describe("sync DB attribution", () => {
 		void token;
 	});
 
+	test("latches a stable semantic ID without a source line", () => {
+		const token = beginSyncDbCall("withReadDb", 1_000, "db:vacuum.status.read");
+
+		expect(getSyncDbCallSitesForWindow(1_000, 2_000)).toEqual(["withReadDb@db:vacuum.status.read"]);
+		void token;
+	});
+
 	test("keeps an invalid site token explicitly unattributed", () => {
 		const token = beginSyncDbCall("withReadDb", 1_000, "not-a-site");
 		endSyncDbCall(token, 1_051);

--- a/platform/daemon/src/sync-db-attribution.ts
+++ b/platform/daemon/src/sync-db-attribution.ts
@@ -10,6 +10,10 @@
  * retained.
  */
 
+import { classifySyncDbSiteToken, type SyncDbCallSiteToken } from "./sync-db-site-token";
+
+export type { SyncDbCallSiteToken } from "./sync-db-site-token";
+
 export type SyncDbCallKind =
 	| "withReadDb"
 	| "withWriteTx"
@@ -19,8 +23,6 @@ export type SyncDbCallKind =
 	| "checkpointWalAsync"
 	| "incrementalVacuumAsync"
 	| "vacuumConversionAsync";
-export type SyncDbCallSiteToken = string;
-
 export interface SyncDbCallToken {
 	readonly sequence: number;
 	readonly siteId: string;
@@ -136,8 +138,9 @@ function resolveSiteToken(siteToken: SyncDbCallSiteToken | undefined): string {
 	if (siteToken === undefined) return UNATTRIBUTED_SITE;
 	const cached = siteTokenCache.get(siteToken);
 	if (cached !== undefined) return cached;
-	if (!/^[^:]+(?:\/[^:]+)*:\d+$/.test(siteToken)) return UNATTRIBUTED_SITE;
-	const resolved = `${SITE_TOKEN_PREFIX}${siteToken}`;
+	const kind = classifySyncDbSiteToken(siteToken);
+	if (kind === null) return UNATTRIBUTED_SITE;
+	const resolved = kind === "semantic" ? siteToken : `${SITE_TOKEN_PREFIX}${siteToken}`;
 	siteTokenCache.set(siteToken, resolved);
 	return resolved;
 }
@@ -255,7 +258,8 @@ export function captureSyncDbCallSiteToken(): SyncDbCallSiteToken | undefined {
 	const site = captureCallerSite();
 	if (site === UNATTRIBUTED_SITE) return undefined;
 	const prefixIndex = site.lastIndexOf(SITE_TOKEN_PREFIX);
-	return prefixIndex >= 0 ? site.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : site;
+	const token = prefixIndex >= 0 ? site.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : site;
+	return classifySyncDbSiteToken(token) === null ? undefined : (token as SyncDbCallSiteToken);
 }
 
 /** Return site ids whose synchronous interval overlapped the observed stall. */

--- a/platform/daemon/src/sync-db-site-token.ts
+++ b/platform/daemon/src/sync-db-site-token.ts
@@ -1,0 +1,18 @@
+export type SyncDbSourceLocationToken = `${string}:${number}`;
+export type SyncDbSemanticSiteToken = `db:${string}.${string}.${string}`;
+export type SyncDbCallSiteToken = SyncDbSourceLocationToken | SyncDbSemanticSiteToken;
+
+const SOURCE_LOCATION_TOKEN = /^[^:\s]+(?:\/[^:\s]+)*:\d+$/;
+const SEMANTIC_TOKEN = /^db:[a-z0-9]+(?:[.-][a-z0-9]+){2,}$/;
+
+export type SyncDbSiteTokenKind = "source-location" | "semantic";
+
+export function classifySyncDbSiteToken(token: string): SyncDbSiteTokenKind | null {
+	if (SOURCE_LOCATION_TOKEN.test(token)) return "source-location";
+	if (SEMANTIC_TOKEN.test(token)) return "semantic";
+	return null;
+}
+
+export function isSemanticSyncDbSiteToken(token: string | null): token is SyncDbSemanticSiteToken {
+	return token !== null && classifySyncDbSiteToken(token) === "semantic";
+}

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -24,10 +24,10 @@ test("the deterministic ledger retains the exact current source inventory", () =
 	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(190);
 });
 
-test("the event-loop ledger exactly equals the current source inventory", () => {
+test("the event-loop ledger exactly matches the current source identities", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const result = runAudit({ sourceRoot: resolve("platform/daemon/src"), baselineSites: baseline });
-	expect(result.sites).toEqual(baseline);
+	expect(occurrenceKeys(result.sites)).toEqual(occurrenceKeys(baseline));
 });
 
 test("classifies database callbacks by execution home rather than async API spelling", () => {
@@ -152,6 +152,38 @@ test("a tokenless async-named DB call fails the attribution coverage rule", () =
 		expect(violation?.path).toBe("missing-token.ts");
 		expect(violation?.api).toBe("withReadDbAsync");
 		expect(violation?.message).toContain('"missing-token.ts:1"');
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("stable semantic DB tokens survive line movement and remain globally unique", () => {
+	const root = mkdtempSync(join(tmpdir(), "signet-semantic-site-token-"));
+	try {
+		writeFileSync(
+			join(root, "semantic.ts"),
+			['getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });', "", ""].join("\n"),
+		);
+		let result = runAudit({ sourceRoot: root });
+		expect(result.violations.filter((item) => item.kind === "missing-async-db-site-token")).toEqual([]);
+		const baseline = result.sites;
+		const originalKeys = occurrenceKeys(result.sites);
+		writeFileSync(
+			join(root, "semantic.ts"),
+			'\n\ngetDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
+		);
+		result = runAudit({ sourceRoot: root, baselineSites: baseline });
+		expect(occurrenceKeys(result.sites)).toEqual(originalKeys);
+		expect(result.violations.filter((item) => item.kind === "new-parent-execution-site")).toEqual([]);
+
+		writeFileSync(
+			join(root, "duplicate.ts"),
+			'getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
+		);
+		result = runAudit({ sourceRoot: root });
+		const duplicate = result.violations.find((item) => item.kind === "duplicate-db-site-token");
+		expect(duplicate?.message).toContain("semantic.ts:3");
+		expect(duplicate?.message).toContain("duplicate.ts:1");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -364,6 +396,8 @@ test("the generated report describes the type boundary and transitional counts",
 	expect(report).toContain("Database accessor sites classified: 412");
 	expect(report).toContain("ON-PARENT callback execution: 410");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
+	expect(report).toContain("durable identity; file and line remain diagnostic metadata");
+	expect(report).toContain("`db:vacuum.conversion-status.read` (withReadDbAsync)");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).toContain("type boundary");

--- a/scripts/audit-event-loop-contract.ts
+++ b/scripts/audit-event-loop-contract.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import ts from "typescript";
+import { isSemanticSyncDbSiteToken } from "../platform/daemon/src/sync-db-site-token";
 
 /** The synchronous APIs recorded in the migration ledger. */
 export const SYNC_APIS = [
@@ -54,6 +55,8 @@ export interface AuditSite {
 	readonly api: SyncApi;
 	readonly source: string;
 	readonly category: SiteCategory;
+	/** Stable identity for migrated DB sites; path and line remain diagnostic metadata. */
+	readonly siteToken?: string;
 }
 
 /** A database site classified by the process that executes its callback. */
@@ -123,6 +126,15 @@ export interface MissingAsyncDbSiteTokenViolation {
 	readonly message: string;
 }
 
+/** A semantic attribution ID reused by more than one database call site. */
+export interface DuplicateDbSiteTokenViolation {
+	readonly kind: "duplicate-db-site-token";
+	readonly path: string;
+	readonly line: number;
+	readonly token: string;
+	readonly message: string;
+}
+
 /** Committed marker-count snapshot; the ratchet fails when the live count grows past it. */
 export interface LegacyDbCountBaseline {
 	readonly version: 1;
@@ -150,6 +162,7 @@ export interface AuditResult {
 		| UnmarkedLegacyDbAccessViolation
 		| MissingLegacyDbSiteTokenViolation
 		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
 	)[];
 	readonly legacyDbAccess: LegacyDbAccessCounts;
 	readonly executionHomeSites: readonly ExecutionHomeSite[];
@@ -404,11 +417,26 @@ function findImportBoundaryViolations(
 function findLegacyDbAccessSites(sourceRoot: string): {
 	readonly sites: AuditSite[];
 	readonly unmarked: UnmarkedCallSite[];
-	readonly missingSiteTokens: (MissingLegacyDbSiteTokenViolation | MissingAsyncDbSiteTokenViolation)[];
+	readonly siteTokenViolations: (
+		| MissingLegacyDbSiteTokenViolation
+		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
+	)[];
 } {
 	const sites: AuditSite[] = [];
 	const unmarked: UnmarkedCallSite[] = [];
-	const missingSiteTokens: (MissingLegacyDbSiteTokenViolation | MissingAsyncDbSiteTokenViolation)[] = [];
+	const siteTokenViolations: (
+		| MissingLegacyDbSiteTokenViolation
+		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
+	)[] = [];
+	const semanticTokenSites = new Map<string, Array<{ readonly path: string; readonly line: number }>>();
+	const recordSemanticToken = (token: string | null, path: string, line: number): void => {
+		if (!isSemanticSyncDbSiteToken(token)) return;
+		const locations = semanticTokenSites.get(token) ?? [];
+		locations.push({ path, line });
+		semanticTokenSites.set(token, locations);
+	};
 	for (const path of walk(sourceRoot)) {
 		const source = readFileSync(path, "utf8");
 		const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
@@ -439,13 +467,7 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 						? expression.name.getStart(sourceFile)
 						: expression.getStart(sourceFile);
 					const line = lineNumber(sourceFile, position);
-					sites.push({
-						path: relativePath,
-						line,
-						api: api as SyncApi,
-						source: lines[line - 1]?.trim() ?? "",
-						category: "hot-path",
-					});
+					let semanticSiteToken: string | undefined;
 					if (isLegacyDbMemberAccess && LEGACY_DB_APIS.includes(api as LegacyDbApi)) {
 						let marked = false;
 						for (let candidate = line - 1; candidate >= Math.max(1, line - MARKER_WINDOW_LINES); candidate--) {
@@ -459,13 +481,15 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 							const tokenArgument = node.arguments[1];
 							const token = tokenArgument === undefined ? null : staticStringValue(tokenArgument, bindings);
 							const expected = `${relativePath}:${line}`;
-							if (token !== expected) {
-								missingSiteTokens.push({
+							recordSemanticToken(token, relativePath, line);
+							if (isSemanticSyncDbSiteToken(token)) semanticSiteToken = token;
+							if (token !== expected && !isSemanticSyncDbSiteToken(token)) {
+								siteTokenViolations.push({
 									kind: "missing-legacy-db-site-token",
 									path: relativePath,
 									line,
 									api: api as LegacyDbApi,
-									message: `${relativePath}:${line} ${api}() must pass its static site token ${JSON.stringify(expected)}; unattributed in-flight DB calls are not allowed`,
+									message: `${relativePath}:${line} ${api}() must pass ${JSON.stringify(expected)} or a unique stable semantic token such as "db:vacuum.status.read"; unattributed in-flight DB calls are not allowed`,
 								});
 							}
 						}
@@ -475,27 +499,49 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 						if (!isLegacy) {
 							const expected = `${relativePath}:${line}`;
 							const token = staticAsyncSiteToken(node, bindings, api as Exclude<AttributedDbApi, LegacyDbApi>);
+							recordSemanticToken(token, relativePath, line);
+							if (isSemanticSyncDbSiteToken(token)) semanticSiteToken = token;
 							const dynamicTokenBoundary = lines
 								.slice(Math.max(0, line - 3), line)
 								.some((candidate) => candidate.includes("DYNAMIC_SITE_TOKEN"));
-							if (!dynamicTokenBoundary && token !== expected) {
-								missingSiteTokens.push({
+							if (!dynamicTokenBoundary && token !== expected && !isSemanticSyncDbSiteToken(token)) {
+								siteTokenViolations.push({
 									kind: "missing-async-db-site-token",
 									path: relativePath,
 									line,
 									api: api as Exclude<AttributedDbApi, LegacyDbApi>,
-									message: `${relativePath}:${line} ${api}() must pass its static site token ${JSON.stringify(expected)}; unattributed in-flight DB calls are not allowed`,
+									message: `${relativePath}:${line} ${api}() must pass ${JSON.stringify(expected)} or a unique stable semantic token such as "db:vacuum.status.read"; unattributed in-flight DB calls are not allowed`,
 								});
 							}
 						}
 					}
+					sites.push({
+						path: relativePath,
+						line,
+						api: api as SyncApi,
+						source: lines[line - 1]?.trim() ?? "",
+						category: "hot-path",
+						...(semanticSiteToken === undefined ? {} : { siteToken: semanticSiteToken }),
+					});
 				}
 			}
 			ts.forEachChild(node, visit);
 		};
 		visit(sourceFile);
 	}
-	return { sites, unmarked, missingSiteTokens };
+	for (const [token, locations] of semanticTokenSites) {
+		if (locations.length < 2) continue;
+		const first = locations[0];
+		if (first === undefined) continue;
+		siteTokenViolations.push({
+			kind: "duplicate-db-site-token",
+			path: first.path,
+			line: first.line,
+			token,
+			message: `stable DB site token ${JSON.stringify(token)} is reused at ${locations.map((site) => `${site.path}:${site.line}`).join(", ")}; semantic tokens must identify exactly one call site`,
+		});
+	}
+	return { sites, unmarked, siteTokenViolations };
 }
 
 /**
@@ -528,7 +574,8 @@ export interface UnmarkedCallSite {
 	readonly api: LegacyDbApi;
 }
 
-function siteKey(site: Pick<AuditSite, "path" | "api" | "source">): string {
+function siteKey(site: Pick<AuditSite, "path" | "api" | "source" | "siteToken">): string {
+	if (site.siteToken !== undefined) return `semantic\u0000${site.api}\u0000${site.siteToken}`;
 	return `${site.path}\u0000${site.api}\u0000${site.source}`;
 }
 
@@ -697,7 +744,7 @@ export function writeCountBaseline(
 }
 
 export function runAudit(options: AuditOptions): AuditResult {
-	const { sites, unmarked, missingSiteTokens } = findLegacyDbAccessSites(options.sourceRoot);
+	const { sites, unmarked, siteTokenViolations } = findLegacyDbAccessSites(options.sourceRoot);
 	const baselineSites = options.baselineSites ?? [];
 	const executionHomeSites = classifyExecutionHomes(sites);
 	return {
@@ -707,7 +754,7 @@ export function runAudit(options: AuditOptions): AuditResult {
 			...findNewLegacyDbAccessViolations(sites, baselineSites),
 			...findNewParentExecutionSiteViolations(executionHomeSites, baselineSites),
 			...findUnmarkedLegacyDbAccess(unmarked),
-			...missingSiteTokens,
+			...siteTokenViolations,
 		],
 		legacyDbAccess: countLegacyDbAccess(options.sourceRoot),
 		executionHomeSites,
@@ -748,11 +795,11 @@ export function renderReport(baselineSites: readonly AuditSite[], legacyDbAccess
 		const sites = executionHomeSites.filter((site) => site.executionHome === home);
 		return sites.length === 0
 			? "- None"
-			: sites.map((site) => `- \`${site.path}:${site.line}\` (${site.api})`).join("\n");
+			: sites.map((site) => `- \`${site.siteToken ?? `${site.path}:${site.line}`}\` (${site.api})`).join("\n");
 	};
 	return `# Event-loop synchronous contract audit
 
-This report is generated from the deterministic migration ledger in \`scripts/event-loop-contract-baseline.json\`. Phase A enforces the type boundary structurally: production code receives an async-only \`DbAccessor\`, while the synchronous compatibility module lives outside the daemon production \`src/\` tree and is rejected by the production TypeScript project's \`rootDir\`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching.
+This report is generated from the deterministic migration ledger in \`scripts/event-loop-contract-baseline.json\`. Phase A enforces the type boundary structurally: production code receives an async-only \`DbAccessor\`, while the synchronous compatibility module lives outside the daemon production \`src/\` tree and is rejected by the production TypeScript project's \`rootDir\`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching. Migrated DB sites use unique \`db:domain.operation.action\` IDs as their durable identity; file and line remain diagnostic metadata.
 
 ## Current inventory
 

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -931,35 +931,40 @@
       "line": 331,
       "api": "withReadDb",
       "source": "return accessor.withReadDb(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-status.sync-read"
     },
     {
       "path": "db-vacuum.ts",
       "line": 339,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-status.read"
     },
     {
       "path": "db-vacuum.ts",
       "line": 347,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-running"
     },
     {
       "path": "db-vacuum.ts",
       "line": 367,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-completed"
     },
     {
       "path": "db-vacuum.ts",
       "line": 386,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-failed"
     },
     {
       "path": "discord-desktop-cache-source.ts",
@@ -3031,7 +3036,8 @@
       "line": 148,
       "api": "withReadDbAsync",
       "source": ": await accessor.withReadDbAsync((db) => db.prepare(sql).all() as Array<{ agent_id: string | null }>, {",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:maintenance.graph-agent-scopes.read"
     },
     {
       "path": "pipeline/maintenance-worker.ts",
@@ -3045,7 +3051,8 @@
       "line": 485,
       "api": "withReadDbAsync",
       "source": ": await accessor.withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:maintenance.dead-memory-count.read"
     },
     {
       "path": "pipeline/prospective-index.ts",


### PR DESCRIPTION
## Summary

Replaces mutable source-line attribution as the only DB-call identity with an incrementally adoptable semantic ID contract.

The event-loop audit failure on #1752 demonstrated the blast radius: moving otherwise unchanged VACUUM code forced coordinated line-token, ledger, and generated-report edits. This slice allows stable `db:domain.operation.action` IDs, makes them the durable ledger key, and retains file/line only as live diagnostic metadata.

This PR is stacked on #1752 because it migrates the VACUUM and maintenance sites changed there.

## Changes

- Add one shared, template-literal-typed DB site-token contract used by runtime attribution and the static audit.
- Accept legacy `path:line` tokens during incremental migration and strict lowercase semantic IDs for migrated sites.
- Reject duplicate semantic IDs across the production daemon source tree.
- Key ledger comparisons by semantic ID so moving a migrated call does not authorize a new parent execution site or require ledger churn.
- Render semantic IDs in the generated execution-home inventory.
- Migrate the seven VACUUM and maintenance sites that exposed the line-number blast radius.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard — build verification only; no surface change
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no feature/spec change
- [x] Agent scoping verified on all new/changed data queries — query behavior is unchanged
- [x] Input/config validation and bounds checks added — semantic tokens are runtime-validated and audit-validated
- [x] Error handling and fallback paths tested (no silent swallow) — invalid tokens remain explicitly unattributed; duplicates fail the audit
- [x] Security checks applied to admin/mutation endpoints — no endpoint changes
- [x] Docs updated for API/spec/status changes — generated event-loop contract report updated
- [x] Regression tests added for each bug fix — named architecture invariant proves line movement preserves identity and duplicate IDs fail
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun scripts/audit-event-loop-contract.ts` — 928 sites, 410 ON-PARENT / 2 OFF-PARENT
- [x] `bun test scripts/audit-event-loop-contract.test.ts platform/daemon/src/sync-db-attribution.test.ts platform/daemon/src/db-foundation-boundary.test.ts` — 30 pass
- [x] `bun test platform/daemon/src/db-vacuum.test.ts platform/daemon/src/pipeline/maintenance-worker.test.ts` — 30 pass
- [x] `bun run --cwd platform/daemon typecheck`
- [x] `bun run --cwd platform/daemon build`
- [x] targeted Biome and diff checks
- [ ] Tested against running daemon — telemetry identity changes only; the installed daemon remains on the released stability build

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

This is a bounded audit-infrastructure slice from the architecture-erosion program in #1748. Existing source-line tokens remain valid so migration can proceed with touched code rather than a risky 400-site rewrite.
