### PR TITLE
fix(daemon): defer process handlers to startup

### DIFF
--- a/platform/daemon/src/daemon-refactor.test.ts
+++ b/platform/daemon/src/daemon-refactor.test.ts
@@ -24,6 +24,45 @@ describe("daemon route extraction refactor", () => {
 		expect(isSessionCleanupRunning()).toBe(false);
 	});
 
+	it("does not install process failure handlers when imported as a library", () => {
+		const testDir = join(tmpdir(), `signet-daemon-import-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		try {
+			const daemonUrl = new URL("./daemon.ts", import.meta.url).href;
+			const script = `
+				const events = ["SIGINT", "SIGTERM", "uncaughtException", "unhandledRejection"];
+				await import(${JSON.stringify(daemonUrl)});
+				const handlers = Object.fromEntries(events.map((event) => [
+					event,
+					process.listeners(event).filter((listener) => listener.name.startsWith("onDaemon")).length,
+				]));
+				process.stdout.write("DAEMON_PROCESS_HANDLERS=" + JSON.stringify(handlers) + "\\n");
+				process.exit(0);
+			`;
+			const child = Bun.spawnSync({
+				cmd: [process.execPath, "-e", script],
+				env: { ...process.env, SIGNET_DAEMON_ENTRYPOINT: "0", SIGNET_PATH: testDir },
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(child.exitCode).toBe(0);
+			const output = new TextDecoder().decode(child.stdout);
+			const record = output
+				.split("\n")
+				.find((line) => line.startsWith("DAEMON_PROCESS_HANDLERS="))
+				?.slice("DAEMON_PROCESS_HANDLERS=".length);
+			expect(record).toBeDefined();
+			expect(JSON.parse(record as string)).toEqual({
+				SIGINT: 0,
+				SIGTERM: 0,
+				uncaughtException: 0,
+				unhandledRejection: 0,
+			});
+		} finally {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
 	it("reloadAuthState is idempotent and produces consistent auth state", async () => {
 		const state = await import("./routes/state.js");
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2201,40 +2201,44 @@ function requestShutdown(reason: string, exitCode: number, error?: unknown, runC
 		});
 }
 
-process.on("SIGINT", () => {
+function onDaemonSigint(): void {
 	requestShutdown("signal:SIGINT", 0);
-});
+}
 
-process.on("SIGTERM", () => {
+function onDaemonSigterm(): void {
 	requestShutdown("signal:SIGTERM", 0);
-});
+}
 
-process.on("uncaughtException", (err) => {
-	logger.error("daemon", "Uncaught exception", err);
-	// Sanitized crash report: truncated message, home-stripped stack frames,
-	// uptime. No memory content. Joinable to the install's heartbeat context.
-	telemetryRef?.record("error.occurred", sanitizeCrashError(err, process.uptime() * 1000));
-	requestShutdown("error:uncaughtException", 1, err);
-});
+function onDaemonUncaughtException(error: Error): void {
+	logger.error("daemon", "Uncaught exception", error);
+	telemetryRef?.record("error.occurred", sanitizeCrashError(error, process.uptime() * 1000));
+	requestShutdown("error:uncaughtException", 1, error);
+}
 
-process.on("unhandledRejection", (reason) => {
+function onDaemonUnhandledRejection(reason: unknown): void {
 	logger.error(
 		"daemon",
 		"Unhandled rejection",
 		reason instanceof Error ? reason : undefined,
 		reason instanceof Error ? undefined : { reason: String(reason) },
 	);
-	// Sanitized crash report for rejections too (primitives degrade to a
-	// truncated string).
 	telemetryRef?.record("error.occurred", sanitizeCrashError(reason, process.uptime() * 1000));
 	requestShutdown("error:unhandledRejection", 1, reason);
-});
+}
+
+function installDaemonProcessHandlers(): void {
+	process.on("SIGINT", onDaemonSigint);
+	process.on("SIGTERM", onDaemonSigterm);
+	process.on("uncaughtException", onDaemonUncaughtException);
+	process.on("unhandledRejection", onDaemonUnhandledRejection);
+}
 
 // ============================================================================
 // Main
 // ============================================================================
 
 async function main() {
+	installDaemonProcessHandlers();
 	logger.info("daemon", "Signet Daemon starting");
 	logger.info("daemon", `File logging to ${logger.logFilePath}`);
 	logger.info("daemon", "Agents directory", { path: AGENTS_DIR });


### PR DESCRIPTION
## Summary

Makes importing `daemon.ts` as a library side-effect-safe with respect to Signet’s process-wide shutdown and fatal-error handlers.

At least 13 daemon tests import the module for route or helper access. Previously, every such import registered Signet handlers for SIGINT, SIGTERM, uncaught exceptions, and unhandled rejections, allowing a route test to mutate process-wide failure behavior merely by loading the module.

This PR is stacked on #1754. Its `daemon.ts` line movement also exercises the stable audit-identity behavior introduced there: the event-loop ledger remains green without generated baseline churn.

## Changes

- Replace four top-level `process.on(...)` calls with named daemon handler functions.
- Install those handlers explicitly at the start of the daemon `main()` composition path.
- Add a child-process regression that imports `daemon.ts` with main disabled and proves no Signet daemon handlers were registered.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard — build verification only; no surface change
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no feature/spec change
- [x] Agent scoping verified on all new/changed data queries — no data queries changed
- [x] Input/config validation and bounds checks added — no input/config changes
- [x] Error handling and fallback paths tested (no silent swallow) — production handlers retain the same shutdown path
- [x] Security checks applied to admin/mutation endpoints — no endpoint changes
- [x] Docs updated for API/spec/status changes — no public contract change
- [x] Regression tests added for each bug fix — child-process import-purity regression added
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test platform/daemon/src/daemon-refactor.test.ts -t "does not install process failure handlers"`
- [x] `bun scripts/audit-event-loop-contract.ts` — 928 sites, 410 ON-PARENT / 2 OFF-PARENT; no baseline regeneration
- [x] `bun run --cwd platform/daemon typecheck`
- [x] `bun run --cwd platform/daemon build`
- [x] targeted Biome and diff checks
- [ ] Full `daemon-refactor.test.ts` in the restricted local sandbox — its pre-existing route-import test attempts to persist the default plugin registry under `~/.agents`; CI has the normal writable test environment

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

This is the first bounded composition-root cleanup from the lifecycle audit. `daemon.ts` still owns 29 mutable top-level bindings; this PR removes a process-global import side effect without attempting a broad lifecycle rewrite.
