### PR TITLE
fix(daemon): defer plugin persistence to startup

### DIFF
--- a/platform/daemon/src/daemon-refactor.test.ts
+++ b/platform/daemon/src/daemon-refactor.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isSessionCleanupRunning, stopSessionCleanup } from "./session-tracker";
@@ -58,6 +58,33 @@ describe("daemon route extraction refactor", () => {
 				uncaughtException: 0,
 				unhandledRejection: 0,
 			});
+		} finally {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not persist plugin registry state when imported for routes", () => {
+		const testDir = join(tmpdir(), `signet-daemon-plugin-import-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		try {
+			const daemonUrl = new URL("./daemon.ts", import.meta.url).href;
+			const registryPath = join(testDir, ".daemon", "plugins", "registry-v1.json");
+			const script = `
+				const { existsSync } = await import("node:fs");
+				await import(${JSON.stringify(daemonUrl)});
+				process.stdout.write("DAEMON_PLUGIN_REGISTRY=" + String(existsSync(${JSON.stringify(registryPath)})) + "\\n");
+				process.exit(0);
+			`;
+			const child = Bun.spawnSync({
+				cmd: [process.execPath, "-e", script],
+				env: { ...process.env, SIGNET_DAEMON_ENTRYPOINT: "0", SIGNET_PATH: testDir },
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(child.exitCode).toBe(0);
+			const output = new TextDecoder().decode(child.stdout);
+			expect(output).toContain("DAEMON_PLUGIN_REGISTRY=false");
+			expect(existsSync(registryPath)).toBe(false);
 		} finally {
 			rmSync(testDir, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -278,6 +278,7 @@ import { registerOntologyRoutes } from "./routes/ontology-routes.js";
 import { mountOsAgentRoutes } from "./routes/os-agent.js";
 import { mountOsChatRoutes } from "./routes/os-chat.js";
 import { registerPipelineRoutes } from "./routes/pipeline-routes.js";
+import { getDefaultPluginHost } from "./plugins/index.js";
 import { registerPluginRoutes } from "./routes/plugins-routes.js";
 import { registerQueueDiagnosticsRoutes } from "./routes/queue-diagnostics.js";
 import { registerReflectionRoutes } from "./routes/reflection-routes.js";
@@ -2261,6 +2262,10 @@ async function main() {
 	process.on("exit", () => {
 		releaseSingleInstanceLock(lock);
 	});
+
+	// Plugin discovery reads and persists daemon-owned registry state. Initialize
+	// it only after this process owns the daemon lock; route imports stay pure.
+	getDefaultPluginHost();
 
 	const previousLifecycle = readDaemonLifecycle(AGENTS_DIR);
 	lifecycleStartedAt = new Date().toISOString();

--- a/platform/daemon/src/routes/plugins-routes.ts
+++ b/platform/daemon/src/routes/plugins-routes.ts
@@ -5,7 +5,9 @@ import type { PluginHostV1 } from "../plugins/index.js";
 import { getDefaultPluginHost } from "../plugins/index.js";
 import { authConfig } from "./state.js";
 
-export function registerPluginRoutes(app: Hono, host: PluginHostV1 = getDefaultPluginHost()): void {
+export function registerPluginRoutes(app: Hono, host?: PluginHostV1): void {
+	const resolveHost = (): PluginHostV1 => host ?? getDefaultPluginHost();
+
 	// Permission guards
 	app.use("/api/plugins", async (c, next) => {
 		return requirePermission("admin", authConfig)(c, next);
@@ -15,11 +17,11 @@ export function registerPluginRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/plugins", (c) => {
-		return c.json({ plugins: host.list() });
+		return c.json({ plugins: resolveHost().list() });
 	});
 
 	app.get("/api/plugins/prompt-contributions", (c) => {
-		const contributions = host.promptContributions();
+		const contributions = resolveHost().promptContributions();
 		return c.json({ contributions, activeCount: contributions.length });
 	});
 
@@ -36,13 +38,13 @@ export function registerPluginRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/plugins/:id/diagnostics", (c) => {
-		const plugin = host.diagnostics(c.req.param("id"));
+		const plugin = resolveHost().diagnostics(c.req.param("id"));
 		if (!plugin) return c.json({ error: "Plugin not found" }, 404);
 		return c.json({ plugin });
 	});
 
 	app.get("/api/plugins/:id", (c) => {
-		const plugin = host.get(c.req.param("id"));
+		const plugin = resolveHost().get(c.req.param("id"));
 		if (!plugin) return c.json({ error: "Plugin not found" }, 404);
 		return c.json(plugin);
 	});
@@ -52,26 +54,10 @@ export function registerPluginRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 		if (!body) return c.json({ error: "Invalid JSON body" }, 400);
 		const enabled = parseOptionalBoolean(body.enabled);
 		if (enabled === undefined) return c.json({ error: "enabled is required" }, 400);
-		const plugin = host.setEnabled(c.req.param("id"), enabled);
+		const plugin = resolveHost().setEnabled(c.req.param("id"), enabled);
 		if (!plugin) return c.json({ error: "Plugin not found" }, 404);
 		return c.json({ plugin });
 	});
-}
-
-async function readJsonObject(req: Request): Promise<Record<string, unknown> | null> {
-	const raw = await req.text();
-	if (!raw.trim()) return {};
-	try {
-		const parsed: unknown = JSON.parse(raw);
-		if (!isRecord(parsed)) return null;
-		return parsed;
-	} catch {
-		return null;
-	}
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseOptionalBoolean(value: unknown): boolean | undefined {

--- a/platform/daemon/src/routes/secrets-routes.ts
+++ b/platform/daemon/src/routes/secrets-routes.ts
@@ -86,7 +86,9 @@ async function resolveOnePasswordToken(explicitToken?: string): Promise<string> 
 	return getSecret(ONEPASSWORD_SERVICE_ACCOUNT_SECRET);
 }
 
-export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultPluginHost()): void {
+export function registerSecretRoutes(app: Hono, host?: PluginHostV1): void {
+	const resolveHost = (): PluginHostV1 => host ?? getDefaultPluginHost();
+
 	// Permission guards
 	app.use("/api/secrets", async (c, next) => {
 		return requirePermission("admin", authConfig)(c, next);
@@ -96,7 +98,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/secrets", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:list"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:list"]);
 		if (denied) return denied;
 		try {
 			const names = await listSecrets();
@@ -109,7 +111,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/secrets/bitwarden/status", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:list"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:list"]);
 		if (denied) return denied;
 		const activeProvider = (await getActiveSecretProvider()) === "bitwarden";
 		try {
@@ -124,7 +126,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/bitwarden/connect", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:configure"]);
 		if (denied) return denied;
 		try {
 			const body = await readOptionalJsonObject(c);
@@ -152,7 +154,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.delete("/api/secrets/bitwarden/connect", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:configure"]);
 		if (denied) return denied;
 		try {
 			const sessionDeleted = await deleteSecret(BITWARDEN_SESSION_SECRET);
@@ -172,7 +174,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/bitwarden/provider", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:configure"]);
 		if (denied) return denied;
 		const body = await readOptionalJsonObject(c);
 		if (!body) return c.json({ error: "Invalid JSON body" }, 400);
@@ -192,7 +194,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/secrets/bitwarden/folders", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:list"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:list"]);
 		if (denied) return denied;
 		try {
 			const session = await getSecret(BITWARDEN_SESSION_SECRET);
@@ -206,7 +208,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/bitwarden/migrate", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:configure"]);
 		if (denied) return denied;
 		try {
 			const body = await readOptionalJsonObject(c);
@@ -236,7 +238,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/secrets/1password/status", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:list"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:list"]);
 		if (denied) return denied;
 		try {
 			const configured = hasSecret(ONEPASSWORD_SERVICE_ACCOUNT_SECRET);
@@ -265,7 +267,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/1password/connect", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:configure"]);
 		if (denied) return denied;
 		try {
 			const body = await readOptionalJsonObject(c);
@@ -299,7 +301,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.delete("/api/secrets/1password/connect", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:configure"]);
 		if (denied) return denied;
 		try {
 			const deleted = await deleteSecret(ONEPASSWORD_SERVICE_ACCOUNT_SECRET);
@@ -312,7 +314,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/secrets/1password/vaults", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:list"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:list"]);
 		if (denied) return denied;
 		try {
 			const token = await resolveOnePasswordToken();
@@ -326,7 +328,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/1password/import", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:providers:configure"]);
 		if (denied) return denied;
 		try {
 			const body = await readOptionalJsonObject(c);
@@ -364,7 +366,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/exec", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:exec"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:exec"]);
 		if (denied) return denied;
 		try {
 			const body = (await c.req.json()) as {
@@ -403,7 +405,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.get("/api/secrets/exec/:jobId", (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:exec"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:exec"]);
 		if (denied) return denied;
 		const job = getSecretExecJob(c.req.param("jobId"));
 		if (!job) return c.json({ error: "secret exec job not found" }, 404);
@@ -411,7 +413,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/:name/exec", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:exec"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:exec"]);
 		if (denied) return denied;
 		const { name } = c.req.param();
 		try {
@@ -447,7 +449,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.post("/api/secrets/:name", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:write"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:write"]);
 		if (denied) return denied;
 		const { name } = c.req.param();
 		try {
@@ -466,7 +468,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 	});
 
 	app.delete("/api/secrets/:name", async (c) => {
-		const denied = rejectIfCapabilityDenied(c, host, ["secrets:delete"]);
+		const denied = rejectIfCapabilityDenied(c, resolveHost(), ["secrets:delete"]);
 		if (denied) return denied;
 		const { name } = c.req.param();
 		try {


### PR DESCRIPTION
## Summary

Stops route registration from discovering bundled plugins, emitting plugin lifecycle events, and persisting `.daemon/plugins/registry-v1.json` merely because `daemon.ts` was imported.

The default plugin host is still initialized during real daemon startup, but only after the process has acquired the single-instance daemon lock. Plugin and secret route modules now resolve the default host lazily when no explicit test host is supplied.

This PR is stacked on #1755 and continues the bounded composition-root import-purity work.

## Reproduction

Before this change, importing `daemon.ts` with its entry point disabled in a new temporary `SIGNET_PATH`:

- logged discovery for `signet.secrets` and `signet.graphiq`;
- emitted prompt-contribution lifecycle events; and
- created `.daemon/plugins/registry-v1.json`.

That hidden write also made a pre-existing daemon import test fail in restricted environments.

## Changes

- Make plugin and secret route registration lazy with respect to the default plugin host.
- Initialize the persistent default host explicitly in `main()` after the daemon lock is acquired.
- Add a child-process regression proving route-only imports do not create plugin registry state.
- Remove two unused parser helpers from the plugin route module.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard — build verification only; no surface change
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no feature/spec change
- [x] Agent scoping verified on all new/changed data queries — no data queries changed
- [x] Input/config validation and bounds checks added — no input/config changes
- [x] Error handling and fallback paths tested (no silent swallow) — plugin initialization remains explicit and fail-loud during startup
- [x] Security checks applied to admin/mutation endpoints — route permission and capability checks are unchanged
- [x] Docs updated for API/spec/status changes — no public contract change
- [x] Regression tests added for each bug fix — child-process plugin-registry import-purity regression added
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test platform/daemon/src/daemon-refactor.test.ts platform/daemon/src/routes/plugins-routes.test.ts platform/daemon/src/routes/secrets-routes.test.ts` — 19 pass
- [x] `bun scripts/audit-event-loop-contract.ts` — 928 sites, 410 ON-PARENT / 2 OFF-PARENT; no baseline regeneration
- [x] `bun run --cwd platform/daemon typecheck`
- [x] `bun run --cwd platform/daemon build`
- [x] targeted Biome and diff checks

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

This does not claim that all daemon imports are side-effect-free. Route construction and other module initialization remain to be audited. It removes the verified filesystem mutation and makes persistent plugin discovery an explicit composition-root action.
