### PR TITLE
refactor(daemon): move owner-local Dreaming execution

### DIFF
--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -16,89 +16,90 @@ describe("DB foundation dependency invariant", () => {
 		expect(accessor).not.toContain('from "./db-vacuum-worker"');
 		expect(vacuum).not.toContain('from "./db-owner-runtime"');
 	});
+});
 
-	describe("close participant lifecycle", () => {
-		it("preserves owner-before-cache order and rejects registration during close", async () => {
-			const lifecycle = createDbAccessorLifecycle();
-			const closed: string[] = [];
-			let duringCloseError: unknown;
-			lifecycle.register({
-				name: "test-agent-scope-cache",
-				order: 200,
-				close: () => {
-					closed.push("agent-scope-cache");
-				},
-			});
-			lifecycle.register({
-				name: "test-db-owner",
-				order: 100,
-				close: () => {
-					closed.push("db-owner");
-					try {
-						lifecycle.register({
-							name: "during-close-participant",
-							order: 300,
-							close: () => undefined,
-						});
-					} catch (error) {
-						duringCloseError = error;
-					}
-				},
-			});
-
-			await lifecycle.close(undefined);
-
-			expect(closed).toEqual(["db-owner", "agent-scope-cache"]);
-			expect(duringCloseError).toBeInstanceOf(Error);
-			expect((duringCloseError as Error).message).toContain("registered after close started");
-
-			// A later accessor lifecycle may load a participant after the previous
-			// close has completed; only registration during close is forbidden.
-			lifecycle.register({
-				name: "next-lifecycle-participant",
-				order: 300,
-				close: () => {
-					closed.push("next-lifecycle-participant");
-				},
-			});
-			await lifecycle.close(undefined);
-			expect(closed).toEqual([
-				"db-owner",
-				"agent-scope-cache",
-				"db-owner",
-				"agent-scope-cache",
-				"next-lifecycle-participant",
-			]);
+describe("close participant lifecycle", () => {
+	it("preserves owner-before-cache order and rejects registration during close", async () => {
+		const lifecycle = createDbAccessorLifecycle();
+		const closed: string[] = [];
+		let duringCloseError: unknown;
+		lifecycle.register({
+			name: "test-agent-scope-cache",
+			order: 200,
+			close: () => {
+				closed.push("agent-scope-cache");
+			},
+		});
+		lifecycle.register({
+			name: "test-db-owner",
+			order: 100,
+			close: () => {
+				closed.push("db-owner");
+				try {
+					lifecycle.register({
+						name: "during-close-participant",
+						order: 300,
+						close: () => undefined,
+					});
+				} catch (error) {
+					duringCloseError = error;
+				}
+			},
 		});
 
-		it("reopens after a participant failure without caching the rejected close", async () => {
-			const lifecycle = createDbAccessorLifecycle();
-			let attempts = 0;
-			lifecycle.register({
-				name: "flaky-participant",
-				order: 100,
-				close: () => {
-					attempts += 1;
-					if (attempts === 1) throw new Error("simulated close failure");
-				},
-			});
+		await lifecycle.close(undefined);
 
-			await expect(lifecycle.close(undefined)).rejects.toThrow("simulated close failure");
-			lifecycle.register({
-				name: "reinitialized-participant",
-				order: 200,
-				close: () => undefined,
-			});
-			await lifecycle.close(undefined);
-			expect(attempts).toBe(2);
-			});
-			});
+		expect(closed).toEqual(["db-owner", "agent-scope-cache"]);
+		expect(duringCloseError).toBeInstanceOf(Error);
+		expect((duringCloseError as Error).message).toContain("registered after close started");
 
-			describe("owner transport purity", () => {
-			it("keeps DB owner transport independent of Dreaming implementations", () => {
-			const runtime = source("./db-owner-runtime.ts");
+		// A later accessor lifecycle may load a participant after the previous
+		// close has completed; only registration during close is forbidden.
+		lifecycle.register({
+			name: "next-lifecycle-participant",
+			order: 300,
+			close: () => {
+				closed.push("next-lifecycle-participant");
+			},
+		});
+		await lifecycle.close(undefined);
+		expect(closed).toEqual([
+			"db-owner",
+			"agent-scope-cache",
+			"db-owner",
+			"agent-scope-cache",
+			"next-lifecycle-participant",
+		]);
+	});
 
-			expect(runtime).not.toContain('"./knowledge-graph-hygiene"');
-			expect(runtime).not.toContain('"./pipeline/dreaming');
-			});
-			});
+	it("reopens after a participant failure without caching the rejected close", async () => {
+		const lifecycle = createDbAccessorLifecycle();
+		let attempts = 0;
+		lifecycle.register({
+			name: "flaky-participant",
+			order: 100,
+			close: () => {
+				attempts += 1;
+				if (attempts === 1) throw new Error("simulated close failure");
+			},
+		});
+
+		await expect(lifecycle.close(undefined)).rejects.toThrow("simulated close failure");
+		lifecycle.register({
+			name: "reinitialized-participant",
+			order: 200,
+			close: () => undefined,
+		});
+		await lifecycle.close(undefined);
+		expect(attempts).toBe(2);
+	});
+});
+
+describe("owner transport purity", () => {
+	it("keeps DB owner transport independent of Dreaming implementations", () => {
+		const runtime = source("./db-owner-runtime.ts");
+
+		expect(runtime).not.toContain('"./knowledge-graph-hygiene"');
+		expect(runtime).not.toContain('"./pipeline/dreaming');
+	});
+});

--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -92,5 +92,10 @@ describe("DB foundation dependency invariant", () => {
 			await lifecycle.close(undefined);
 			expect(attempts).toBe(2);
 		});
+	it("keeps DB owner transport independent of Dreaming implementations", () => {
+		const runtime = source("./db-owner-runtime.ts");
+
+		expect(runtime).not.toContain('"./knowledge-graph-hygiene"');
+		expect(runtime).not.toContain('"./pipeline/dreaming');
 	});
 });

--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -91,11 +91,14 @@ describe("DB foundation dependency invariant", () => {
 			});
 			await lifecycle.close(undefined);
 			expect(attempts).toBe(2);
-		});
-	it("keeps DB owner transport independent of Dreaming implementations", () => {
-		const runtime = source("./db-owner-runtime.ts");
+			});
+			});
 
-		expect(runtime).not.toContain('"./knowledge-graph-hygiene"');
-		expect(runtime).not.toContain('"./pipeline/dreaming');
-	});
-});
+			describe("owner transport purity", () => {
+			it("keeps DB owner transport independent of Dreaming implementations", () => {
+			const runtime = source("./db-owner-runtime.ts");
+
+			expect(runtime).not.toContain('"./knowledge-graph-hygiene"');
+			expect(runtime).not.toContain('"./pipeline/dreaming');
+			});
+			});

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -64,7 +64,11 @@ function inlineStatement(db: ReadDb | WriteDb, statement: DbOwnerStatement): unk
 	return prepared.run(...params);
 }
 
-async function inlineRequest(accessor: DbAccessor, request: DbOwnerRequest): Promise<unknown> {
+function unreachableInlineRequest(request: never): never {
+	throw new Error(`Unreachable inline DB owner request: ${String(request)}`);
+}
+
+async function executeInlineOwnerRequest(accessor: DbAccessor, request: DbOwnerRequest): Promise<unknown> {
 	if (request.kind === "query") {
 		if (request.statement.result === "run") {
 			return invokeAccessor(accessor, "withWriteTx", (db) => inlineStatement(db, request.statement));
@@ -193,10 +197,32 @@ async function inlineRequest(accessor: DbAccessor, request: DbOwnerRequest): Pro
 			vectorSearchWithMetadata(db as never, new Float32Array(request.payload.queryEmbedding), request.payload.options),
 		);
 	}
-	throw new Error(`Unsupported isolated owner request: ${request.kind}`);
+	switch (request.kind) {
+		case "initialize":
+		case "recall":
+		case "source_snapshot_import":
+		case "source_graph_index":
+		case "source_graph_file_purge":
+		case "source_graph_purge":
+		case "source_artifact_index":
+		case "source_native_memory_index":
+		case "source_artifact_purge":
+		case "source_artifact_upsert":
+		case "source_artifact_upsert_batch":
+		case "embedding_migration_progress":
+		case "health_ready":
+		case "diagnostics":
+		case "vector_backfill":
+		case "vacuum_conversion":
+		case "incremental_vacuum":
+		case "sleep":
+			throw new Error(`Unsupported inline owner request: ${request.kind}`);
+		default:
+			return unreachableInlineRequest(request);
+	}
 }
 
-function isolatedOwner(accessor: DbAccessor): DbOwnerClient {
+function inlineOwner(accessor: DbAccessor): DbOwnerClient {
 	const submit = <Result>(request: DbOwnerRequest, options: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> => {
 		const now = Date.now();
 		const job: DbOwnerJob = {
@@ -210,7 +236,7 @@ function isolatedOwner(accessor: DbAccessor): DbOwnerClient {
 			cancellation: "pending",
 			request,
 		};
-		return { job, result: inlineRequest(accessor, request) as Promise<Result>, cancel: () => undefined };
+		return { job, result: executeInlineOwnerRequest(accessor, request) as Promise<Result>, cancel: () => undefined };
 	};
 	return {
 		start: async () => undefined,
@@ -302,18 +328,18 @@ export async function startDbRecallOwner(
 }
 
 async function getCurrentProcessOwner(): Promise<DbOwnerClient> {
-	if (isolatedTestAccessor !== null) return isolatedOwner(isolatedTestAccessor);
+	if (isolatedTestAccessor !== null) return inlineOwner(isolatedTestAccessor);
 	const { getDbAccessor } = await import("./db-accessor");
-	return isolatedOwner(getDbAccessor());
+	return inlineOwner(getDbAccessor());
 }
 
-/** Lazily start an isolated owner when the daemon has not registered its shared owner. */
+/** Resolve the process owner, or the in-process adapter used inside an owner worker. */
 export async function getDbOwner(dbPath?: string): Promise<DbOwnerClient> {
 	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return await getCurrentProcessOwner();
 	const registered = getDbOwnerMaintenance()?.owner;
 	if (registered !== undefined) return registered;
 	if (hasDbAccessor()) return await startDbOwner(getDbAccessorPath());
-	if (isolatedTestAccessor !== null) return isolatedOwner(isolatedTestAccessor);
+	if (isolatedTestAccessor !== null) return inlineOwner(isolatedTestAccessor);
 	return await startDbOwner(dbPath);
 }
 
@@ -321,7 +347,7 @@ export async function getDbOwner(dbPath?: string): Promise<DbOwnerClient> {
 export async function getDbRecallOwner(dbPath?: string): Promise<DbOwnerClient> {
 	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return await getCurrentProcessOwner();
 	if (hasDbAccessor()) return await startDbRecallOwner(getDbAccessorPath());
-	if (isolatedTestAccessor !== null) return isolatedOwner(isolatedTestAccessor);
+	if (isolatedTestAccessor !== null) return inlineOwner(isolatedTestAccessor);
 	return await startDbRecallOwner(dbPath);
 }
 
@@ -330,10 +356,10 @@ export async function getDbRecallOwner(dbPath?: string): Promise<DbOwnerClient> 
  * accessor without opening a second SQLite connection.
  */
 export async function getDbOwnerForAccessor(accessor: DbAccessor): Promise<DbOwnerClient> {
-	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return isolatedOwner(accessor);
+	if (process.env.SIGNET_DB_OWNER_WORKER === "1") return inlineOwner(accessor);
 	if (hasDbAccessor()) return await getDbOwner(getDbAccessorPath());
 	registerDbOwnerIsolatedTestAccessor(accessor);
-	return isolatedOwner(accessor);
+	return inlineOwner(accessor);
 }
 
 export interface DbOwnerSqlOptions {

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -24,7 +24,6 @@ import type {
 	DbOwnerNativeMemoryIndex,
 	DbOwnerSourceArtifactPurge,
 	DbOwnerSourceArtifactUpsert,
-	DbOwnerSourceEvidenceEligibility,
 	DbOwnerStatement,
 	DbOwnerWorkloadClass,
 } from "./db-owner-protocol";
@@ -64,6 +63,35 @@ function inlineStatement(db: ReadDb | WriteDb, statement: DbOwnerStatement): unk
 	return prepared.run(...params);
 }
 
+export interface InlineDbOwnerAccess {
+	readonly read: <Result>(callback: (db: ReadDb) => Result) => Result;
+	readonly write: <Result>(callback: (db: WriteDb) => Result) => Result;
+}
+
+export interface DbOwnerDomainOperation<Result> {
+	readonly runWithOwner: (owner: DbOwnerClient) => Promise<Result>;
+	readonly runInline: (access: InlineDbOwnerAccess) => Result | Promise<Result>;
+}
+
+function inlineDbOwnerAccess(accessor: DbAccessor): InlineDbOwnerAccess {
+	return {
+		read: <Result>(callback: (db: ReadDb) => Result): Result =>
+			invokeAccessor(accessor, "withReadDb", callback as (db: ReadDb | WriteDb) => Result),
+		write: <Result>(callback: (db: WriteDb) => Result): Result =>
+			invokeAccessor(accessor, "withWriteTx", callback as (db: ReadDb | WriteDb) => Result),
+	};
+}
+
+export async function runDbOwnerDomainOperation<Result>(
+	accessor: DbAccessor,
+	operation: DbOwnerDomainOperation<Result>,
+): Promise<Result> {
+	if (process.env.SIGNET_DB_OWNER_WORKER === "1" || !hasDbAccessor()) {
+		return await operation.runInline(inlineDbOwnerAccess(accessor));
+	}
+	return await operation.runWithOwner(await getDbOwner(getDbAccessorPath()));
+}
+
 function unreachableInlineRequest(request: never): never {
 	throw new Error(`Unreachable inline DB owner request: ${String(request)}`);
 }
@@ -96,102 +124,6 @@ async function executeInlineOwnerRequest(accessor: DbAccessor, request: DbOwnerR
 			return results;
 		});
 	}
-	if (request.kind === "source_evidence_eligibility") {
-		const { sourceHasEligibleUnconsumedEvidence } = await import("./pipeline/dreaming-evidence-consumption");
-		return await invokeAccessor(accessor, "withReadDb", (db) =>
-			sourceHasEligibleUnconsumedEvidence(
-				db as never,
-				request.input.agentId,
-				request.input.sourceEntryId,
-				request.input.legacyObsidianRoot,
-			),
-		);
-	}
-	if (request.kind === "dreaming_hygiene_attention") {
-		const { getDreamingHygieneCandidatesInDb } = await import("./knowledge-graph-hygiene");
-		const { enqueueDreamingAttentionInTx } = await import("./pipeline/dreaming-attention");
-		return invokeAccessor(accessor, "withWriteTx", (db) => {
-			const candidates = getDreamingHygieneCandidatesInDb(db as never, request.input);
-			for (const candidate of candidates)
-				enqueueDreamingAttentionInTx(db as never, {
-					...candidate,
-					agentId: request.input.agentId,
-					kind: "hygiene",
-					reopen: false,
-				});
-			return candidates.length;
-		});
-	}
-	if (request.kind === "dreaming_surprisal_attention") {
-		const { selectDreamingSurprisalInDb } = await import("./pipeline/dreaming-surprisal");
-		const { DREAMING_SURPRISAL_SELECTOR_VERSION } = await import("./pipeline/dreaming-surprisal");
-		const selection = invokeAccessor(accessor, "withReadDb", (db) =>
-			selectDreamingSurprisalInDb(db as never, request.input.agentId, request.input.config, null),
-		);
-		if (selection.candidates.length === 0) return selection;
-		await invokeAccessor(accessor, "withWriteTx", (db) => {
-			const { enqueueDreamingAttentionInTx } =
-				require("./pipeline/dreaming-attention") as typeof import("./pipeline/dreaming-attention");
-			for (const candidate of selection.candidates)
-				enqueueDreamingAttentionInTx(db as never, {
-					agentId: request.input.agentId,
-					kind: "surprisal",
-					subjectRef: `memory:${candidate.id}`,
-					details: {
-						selector: DREAMING_SURPRISAL_SELECTOR_VERSION,
-						score: candidate.score.toFixed(6),
-						rank: String(candidate.rank),
-						sampleSize: String(candidate.sampleSize),
-						dimensions: String(candidate.dimensions),
-						capturedAt: candidate.capturedAt,
-					},
-					priority: Math.round(60 + candidate.score * 40),
-					reopen: false,
-				});
-		});
-		return selection;
-	}
-	if (request.kind === "dreaming_episodic_backlog") {
-		const { getDreamingEpisodicTokenBacklogInDb } = await import("./pipeline/dreaming");
-		return await invokeAccessor(accessor, "withReadDb", (db) =>
-			getDreamingEpisodicTokenBacklogInDb(db as never, request.input.agentId, request.input.maxSources),
-		);
-	}
-	if (
-		request.kind === "dreaming_evidence_search" ||
-		request.kind === "dreaming_evidence_source" ||
-		request.kind === "dreaming_review_due"
-	) {
-		const capabilities = await import("./pipeline/dreaming-capabilities");
-		return await invokeAccessor(accessor, "withReadDb", (db) => {
-			if (request.kind === "dreaming_evidence_search")
-				return capabilities.searchDreamingEvidenceInDb(db as never, request.input);
-			if (request.kind === "dreaming_evidence_source")
-				return capabilities.readDreamingEvidenceSourceInDb(db as never, request.input);
-			return capabilities.collectDreamingReviewDueInDb(db as never, request.input);
-		});
-	}
-	if (request.kind === "dreaming_evidence_classify") {
-		const { collectRejectedDreamingEvidenceInDb } = await import("./pipeline/dreaming-evidence-retry");
-		return await invokeAccessor(accessor, "withReadDb", (db) =>
-			collectRejectedDreamingEvidenceInDb(
-				db as never,
-				request.input.agentId,
-				request.input.result as never,
-				request.input.operations as never,
-			),
-		);
-	}
-	if (request.kind === "dreaming_evidence_requeue") {
-		const { autoRequeueRepairedDreamingEvidenceInDb } = await import("./pipeline/dreaming-evidence-retry");
-		return await invokeAccessor(accessor, "withWriteTx", (db) =>
-			autoRequeueRepairedDreamingEvidenceInDb(db as never, request.input.policy, request.input.nowMs),
-		);
-	}
-	if (request.kind === "dreaming_pass_finalize") {
-		const { finalizeDreamingPassInDb } = await import("./pipeline/dreaming");
-		return invokeAccessor(accessor, "withWriteTx", (db) => finalizeDreamingPassInDb(db as never, request.input));
-	}
 	if (request.kind === "vector_search") {
 		return invokeAccessor(accessor, "withReadDb", (db) =>
 			vectorSearchWithMetadata(db as never, new Float32Array(request.payload.queryEmbedding), request.payload.options),
@@ -209,6 +141,15 @@ async function executeInlineOwnerRequest(accessor: DbAccessor, request: DbOwnerR
 		case "source_artifact_purge":
 		case "source_artifact_upsert":
 		case "source_artifact_upsert_batch":
+		case "dreaming_hygiene_attention":
+		case "dreaming_surprisal_attention":
+		case "dreaming_episodic_backlog":
+		case "dreaming_evidence_search":
+		case "dreaming_evidence_source":
+		case "dreaming_pass_finalize":
+		case "dreaming_review_due":
+		case "dreaming_evidence_classify":
+		case "dreaming_evidence_requeue":
 		case "embedding_migration_progress":
 		case "health_ready":
 		case "diagnostics":
@@ -514,18 +455,6 @@ export async function dbOwnerSourceArtifactUpsert(
 		owner,
 		{ kind: "source_artifact_upsert", input },
 		{ ...options, lane: options.lane ?? "write" },
-	);
-}
-
-export async function dbOwnerSourceEvidenceEligibility(
-	input: DbOwnerSourceEvidenceEligibility,
-	options: DbOwnerSqlOptions,
-): Promise<boolean> {
-	const owner = await getDbOwner();
-	return await submitWithAdmission<boolean>(
-		owner,
-		{ kind: "source_evidence_eligibility", input },
-		{ ...options, lane: "read" },
 	);
 }
 

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -16,6 +16,7 @@ import type {
 	DbOwnerJob,
 	DbOwnerParameter,
 	DbOwnerRequest,
+	DbOwnerSourceEvidenceEligibility,
 	DbOwnerSourceGraphFilePurge,
 	DbOwnerSourceGraphIndex,
 	DbOwnerSourceGraphPurge,
@@ -156,6 +157,7 @@ async function executeInlineOwnerRequest(accessor: DbAccessor, request: DbOwnerR
 		case "vector_backfill":
 		case "vacuum_conversion":
 		case "incremental_vacuum":
+		case "source_evidence_eligibility":
 		case "sleep":
 			throw new Error(`Unsupported inline owner request: ${request.kind}`);
 		default:
@@ -577,3 +579,15 @@ registerDbAccessorCloseParticipant({
 	order: 100,
 	close: closeDbOwner,
 });
+
+export async function dbOwnerSourceEvidenceEligibility(
+	input: DbOwnerSourceEvidenceEligibility,
+	options: DbOwnerSqlOptions,
+): Promise<boolean> {
+	const owner = await getDbOwner();
+	return await submitWithAdmission<boolean>(
+		owner,
+		{ kind: "source_evidence_eligibility", input },
+		{ ...options, lane: "read" },
+	);
+}

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -9,7 +9,7 @@
  */
 import { type Entity, type EntityAttribute, MEMORY_CONTENT_WITHHELD_NOTICE, scanMemoryContent } from "@signet/core";
 import { z } from "zod";
-import { getDbOwnerForAccessor } from "../db-owner-runtime";
+import { getDbOwnerForAccessor, runDbOwnerDomainOperation } from "../db-owner-runtime";
 import { ownerReadAll, ownerReadOne } from "../db-owner-sql";
 import type {
 	DbOwnerDreamingEvidenceSearch,
@@ -675,31 +675,36 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				chunkSize: z.number().finite().optional(),
 			}),
 			async ({ agentId: scopeId, query, since, before, kind, limit, sourceRef, offset, chunkSize }) => {
-				const owner = await getDbOwnerForAccessor(accessor);
-				const handle = owner.submit<DreamingCapabilityOutput>(
-					{
-						kind: "dreaming_evidence_search",
-						input: {
-							agentId: scopeId,
-							...(query === undefined ? {} : { query }),
-							...(since === undefined ? {} : { since }),
-							...(before === undefined ? {} : { before }),
-							...(kind === undefined ? {} : { kind }),
-							...(limit === undefined ? {} : { limit }),
-							...(sourceRef === undefined ? {} : { sourceRef }),
-							...(offset === undefined ? {} : { offset }),
-							...(chunkSize === undefined ? {} : { chunkSize }),
-						},
+				const input: DbOwnerDreamingEvidenceSearch = {
+					agentId: scopeId,
+					...(query === undefined ? {} : { query }),
+					...(since === undefined ? {} : { since }),
+					...(before === undefined ? {} : { before }),
+					...(kind === undefined ? {} : { kind }),
+					...(limit === undefined ? {} : { limit }),
+					...(sourceRef === undefined ? {} : { sourceRef }),
+					...(offset === undefined ? {} : { offset }),
+					...(chunkSize === undefined ? {} : { chunkSize }),
+				};
+				return await runDbOwnerDomainOperation(accessor, {
+					runWithOwner: async (owner) => {
+						const handle = owner.submit<DreamingCapabilityOutput>(
+							{
+								kind: "dreaming_evidence_search",
+								input,
+							},
+							{
+								operation: "dreaming.capabilities.search-evidence",
+								lane: "read",
+								workloadClass: "foreground",
+								deadlineMs: 30_000,
+								estimatedWorkUnits: 200,
+							},
+						);
+						return await handle.result;
 					},
-					{
-						operation: "dreaming.capabilities.search-evidence",
-						lane: "read",
-						workloadClass: "foreground",
-						deadlineMs: 30_000,
-						estimatedWorkUnits: 200,
-					},
-				);
-				return await handle.result;
+					runInline: ({ read }) => read((db) => searchDreamingEvidenceInDb(db, input)),
+				});
 			},
 		),
 		capability(
@@ -837,25 +842,30 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			async ({ agentId: scopeId, kind, status, limit }) => {
 				if (kind === "review_due") {
 					if (status === "resolved") return { ok: true, items: [] };
-					const owner = await getDbOwnerForAccessor(accessor);
-					const handle = owner.submit<ReturnType<typeof collectReviewDueClaims>>(
-						{
-							kind: "dreaming_review_due",
-							input: {
-								agentId: scopeId,
-								nowMs: Date.now(),
-								limit: bounded(limit, scopeId ? 50 : 100, scopeId ? 100 : 200),
-							},
+					const input: DbOwnerDreamingReviewDue = {
+						agentId: scopeId,
+						nowMs: Date.now(),
+						limit: bounded(limit, scopeId ? 50 : 100, scopeId ? 100 : 200),
+					};
+					const due = await runDbOwnerDomainOperation(accessor, {
+						runWithOwner: async (owner) => {
+							const handle = owner.submit<ReturnType<typeof collectReviewDueClaims>>(
+								{
+									kind: "dreaming_review_due",
+									input,
+								},
+								{
+									operation: "dreaming.capabilities.review-due",
+									lane: "read",
+									workloadClass: "foreground",
+									deadlineMs: 30_000,
+									estimatedWorkUnits: 100,
+								},
+							);
+							return await handle.result;
 						},
-						{
-							operation: "dreaming.capabilities.review-due",
-							lane: "read",
-							workloadClass: "foreground",
-							deadlineMs: 30_000,
-							estimatedWorkUnits: 100,
-						},
-					);
-					const due = await handle.result;
+						runInline: ({ read }) => read((db) => collectDreamingReviewDueInDb(db, input)),
+					});
 					return {
 						ok: true,
 						items: [

--- a/platform/daemon/src/pipeline/dreaming-evidence-retry.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-retry.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { getDbOwnerForAccessor } from "../db-owner-runtime";
+import { runDbOwnerDomainOperation } from "../db-owner-runtime";
 
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import {
@@ -156,18 +156,22 @@ export async function collectRejectedDreamingEvidence(
 	result: ApplyDreamingOperationsResult,
 	operations: readonly Pick<DreamingOperationRequest, "evidence">[],
 ): Promise<readonly RejectedDreamingEvidence[]> {
-	const owner = await getDbOwnerForAccessor(accessor);
-	const handle = owner.submit<readonly RejectedDreamingEvidence[]>(
-		{ kind: "dreaming_evidence_classify", input: { agentId, result, operations } },
-		{
-			operation: "dreaming.evidence.classify",
-			lane: "read",
-			workloadClass: "foreground",
-			deadlineMs: 30_000,
-			estimatedWorkUnits: 200,
+	return await runDbOwnerDomainOperation(accessor, {
+		runWithOwner: async (owner) => {
+			const handle = owner.submit<readonly RejectedDreamingEvidence[]>(
+				{ kind: "dreaming_evidence_classify", input: { agentId, result, operations } },
+				{
+					operation: "dreaming.evidence.classify",
+					lane: "read",
+					workloadClass: "foreground",
+					deadlineMs: 30_000,
+					estimatedWorkUnits: 200,
+				},
+			);
+			return await handle.result;
 		},
-	);
-	return await handle.result;
+		runInline: ({ read }) => read((db) => collectRejectedDreamingEvidenceInDb(db, agentId, result, operations)),
+	});
 }
 
 export function recordRejectedDreamingEvidenceInTx(
@@ -326,16 +330,21 @@ export async function autoRequeueRepairedDreamingEvidence(
 	const hourlyBudget = Math.max(0, Math.floor(policy.hourlyBudget));
 	const maxAttempts = Math.max(0, Math.floor(policy.maxAttempts));
 	if (hourlyBudget === 0 || maxAttempts === 0) return 0;
-	const owner = await getDbOwnerForAccessor(accessor);
-	const handle = owner.submit<number>(
-		{ kind: "dreaming_evidence_requeue", input: { nowMs, policy: { cooldownMs, hourlyBudget, maxAttempts } } },
-		{
-			operation: "dreaming.evidence.requeue",
-			lane: "write",
-			workloadClass: "foreground",
-			deadlineMs: 30_000,
-			estimatedWorkUnits: 500,
+	const boundedPolicy = { cooldownMs, hourlyBudget, maxAttempts };
+	return await runDbOwnerDomainOperation(accessor, {
+		runWithOwner: async (owner) => {
+			const handle = owner.submit<number>(
+				{ kind: "dreaming_evidence_requeue", input: { nowMs, policy: boundedPolicy } },
+				{
+					operation: "dreaming.evidence.requeue",
+					lane: "write",
+					workloadClass: "foreground",
+					deadlineMs: 30_000,
+					estimatedWorkUnits: 500,
+				},
+			);
+			return await handle.result;
 		},
-	);
-	return await handle.result;
+		runInline: ({ write }) => write((db) => autoRequeueRepairedDreamingEvidenceInDb(db, boundedPolicy, nowMs)),
+	});
 }

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -20,7 +20,13 @@ import type {
 	LlmUsage,
 } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
-import type { DbOwnerDreamingPassFinalize } from "../db-owner-protocol";
+import type {
+	DbOwnerDreamingEpisodicBacklog,
+	DbOwnerDreamingEvidenceSource,
+	DbOwnerDreamingHygieneAttention,
+	DbOwnerDreamingPassFinalize,
+	DbOwnerDreamingSurprisalAttention,
+} from "../db-owner-protocol";
 import {
 	ownerDreamingHygieneAttention,
 	ownerDreamingSurprisalAttention,
@@ -33,7 +39,7 @@ import {
 	type DbOwnerMaintenance,
 } from "../db-owner-maintenance";
 import { DB_OWNER_MAX_WORK_UNITS } from "../db-owner-protocol";
-import { getDbOwnerForAccessor } from "../db-owner-runtime";
+import { getDbOwnerForAccessor, runDbOwnerDomainOperation } from "../db-owner-runtime";
 import {
 	EPISODIC_CAPTURED_AT_FLOOR,
 	type EpisodicCursor,
@@ -43,7 +49,7 @@ import {
 	searchEpisodicSources,
 	timestampMillis,
 } from "../episodic-sources";
-import type { GraphHygieneCaps } from "../knowledge-graph-hygiene";
+import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
 import { upsertMemoryContentSafetyInTx } from "../memory-content-safety";
 import type { GraphWriteCaps } from "../ontology-proposals";
@@ -52,7 +58,7 @@ import { normalizePipelineCause, recordPipelineOperation } from "../pipeline-ope
 import { getActiveTelemetry } from "../telemetry";
 import { upsertThreadHead } from "../thread-heads";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
-import { getDreamingAttentionWorkloadDiagnostics } from "./dreaming-attention";
+import { enqueueDreamingAttentionInTx, getDreamingAttentionWorkloadDiagnostics } from "./dreaming-attention";
 import type { DreamingToolCallTrace } from "./dreaming-capabilities";
 import { renderDreamingEvidence } from "./dreaming-evidence";
 import { deliveredOffsetForSource, recordDreamingEvidenceConsumptionInTx } from "./dreaming-evidence-consumption";
@@ -66,7 +72,11 @@ import {
 	recordRejectedDreamingEvidenceInTx,
 } from "./dreaming-evidence-retry";
 import type { ApplyDreamingOperationsResult, DreamingOperationRequest } from "./dreaming-operations";
-import type { DreamingSurprisalSelection } from "./dreaming-surprisal";
+import {
+	DREAMING_SURPRISAL_SELECTOR_VERSION,
+	type DreamingSurprisalSelection,
+	selectDreamingSurprisalInDb,
+} from "./dreaming-surprisal";
 import { DreamingBacklogTokenCache, type DreamingBacklogTokenEntry } from "./dreaming-token-cache";
 import {
 	dreamingLiveEvents,
@@ -104,12 +114,25 @@ export async function enqueueDreamingHygieneAttention(
 	caps?: GraphHygieneCaps,
 	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<number> {
-	const owner = ownerMaintenance?.owner ?? (await getDbOwnerForAccessor(accessor));
-	return await ownerDreamingHygieneAttention(
-		owner,
-		{ agentId, limit, caps },
-		{ deadlineMs: 60_000, estimatedWorkUnits: 100 },
-	);
+	const input: DbOwnerDreamingHygieneAttention = { agentId, limit, caps };
+	const options = { deadlineMs: 60_000, estimatedWorkUnits: 100 };
+	if (ownerMaintenance) return await ownerMaintenance.dreamingHygieneAttention(input, options);
+	return await runDbOwnerDomainOperation(accessor, {
+		runWithOwner: async (owner) => await ownerDreamingHygieneAttention(owner, input, options),
+		runInline: ({ write }) =>
+			write((db) => {
+				const candidates = getDreamingHygieneCandidatesInDb(db, input);
+				for (const candidate of candidates) {
+					enqueueDreamingAttentionInTx(db, {
+						...candidate,
+						agentId: input.agentId,
+						kind: "hygiene",
+						reopen: false,
+					});
+				}
+				return candidates.length;
+			}),
+	});
 }
 
 /**
@@ -127,12 +150,37 @@ export async function enqueueDreamingSurprisalAttention(
 ): Promise<DreamingSurprisalSelection | null> {
 	const surprisal = cfg.surprisal;
 	if (!surprisal?.enabled) return null;
-	const owner = ownerMaintenance?.owner ?? (await getDbOwnerForAccessor(accessor));
-	const selection = await ownerDreamingSurprisalAttention(
-		owner,
-		{ agentId, config: surprisal },
-		{ deadlineMs: 60_000, estimatedWorkUnits: 500 },
-	);
+	const input: DbOwnerDreamingSurprisalAttention = { agentId, config: surprisal };
+	const options = { deadlineMs: 60_000, estimatedWorkUnits: 500 };
+	const selection = ownerMaintenance
+		? await ownerMaintenance.dreamingSurprisalAttention(input, options)
+		: await runDbOwnerDomainOperation(accessor, {
+				runWithOwner: async (owner) => await ownerDreamingSurprisalAttention(owner, input, options),
+				runInline: ({ read, write }) => {
+					const selected = read((db) => selectDreamingSurprisalInDb(db, input.agentId, input.config, null));
+					if (selected.candidates.length === 0) return selected;
+					write((db) => {
+						for (const candidate of selected.candidates) {
+							enqueueDreamingAttentionInTx(db, {
+								agentId: input.agentId,
+								kind: "surprisal",
+								subjectRef: `memory:${candidate.id}`,
+								details: {
+									selector: DREAMING_SURPRISAL_SELECTOR_VERSION,
+									score: candidate.score.toFixed(6),
+									rank: String(candidate.rank),
+									sampleSize: String(candidate.sampleSize),
+									dimensions: String(candidate.dimensions),
+									capturedAt: candidate.capturedAt,
+								},
+								priority: Math.round(60 + candidate.score * 40),
+								reopen: false,
+							});
+						}
+					});
+					return selected;
+				},
+			});
 	if (selection === null) return null;
 	logger.info("dreaming", "Embedding-surprisal attention sweep completed", {
 		agentId,
@@ -1522,18 +1570,23 @@ async function readDreamingEvidenceSource(
 	agentId: string,
 	sourceRef: string,
 ): Promise<EpisodicSourceRecord | null> {
-	const owner = await getDbOwnerForAccessor(accessor);
-	const handle = owner.submit<EpisodicSourceRecord | null>(
-		{ kind: "dreaming_evidence_source", input: { agentId, sourceRef } },
-		{
-			operation: "dreaming.evidence.source",
-			lane: "read",
-			workloadClass: "foreground",
-			deadlineMs: 30_000,
-			estimatedWorkUnits: 10,
+	const input: DbOwnerDreamingEvidenceSource = { agentId, sourceRef };
+	return await runDbOwnerDomainOperation(accessor, {
+		runWithOwner: async (owner) => {
+			const handle = owner.submit<EpisodicSourceRecord | null>(
+				{ kind: "dreaming_evidence_source", input },
+				{
+					operation: "dreaming.evidence.source",
+					lane: "read",
+					workloadClass: "foreground",
+					deadlineMs: 30_000,
+					estimatedWorkUnits: 10,
+				},
+			);
+			return await handle.result;
 		},
-	);
-	return await handle.result;
+		runInline: ({ read }) => read((db) => readEpisodicSource(db, { agentId: input.agentId, from: input.sourceRef })),
+	});
 }
 
 export async function runDreamingAgentPass(
@@ -1845,40 +1898,46 @@ export async function runDreamingAgentPass(
 				),
 			)
 		).flat();
-		const owner = await getDbOwnerForAccessor(accessor);
-		const finalize = owner.submit<null>(
-			{
-				kind: "dreaming_pass_finalize",
-				input: {
-					passId,
-					mode,
-					agentId,
-					scopes,
-					transcriptManifestEntries,
-					tokensConsumed,
-					inputTokens: usage?.inputTokens ?? null,
-					outputTokens: usage?.outputTokens ?? null,
-					cacheReadTokens: usage?.cacheReadTokens ?? null,
-					cacheCreationTokens: usage?.cacheCreationTokens ?? null,
-					totalCost: usage?.totalCost ?? null,
-					applied,
-					failed,
-					summary,
-					rejectedEvidence,
-					memoryHeadResult,
-					backlogByScope: [...backlogByScope].map(([scope, backlog]) => ({ scope, backlog })),
-					nextWatermarkByScope: [...nextWatermarkByScope].map(([scope, watermark]) => ({ scope, watermark })),
-				},
+		const finalizeInput: DbOwnerDreamingPassFinalize = {
+			passId,
+			mode,
+			agentId,
+			scopes,
+			transcriptManifestEntries,
+			tokensConsumed,
+			inputTokens: usage?.inputTokens ?? null,
+			outputTokens: usage?.outputTokens ?? null,
+			cacheReadTokens: usage?.cacheReadTokens ?? null,
+			cacheCreationTokens: usage?.cacheCreationTokens ?? null,
+			totalCost: usage?.totalCost ?? null,
+			applied,
+			failed,
+			summary,
+			rejectedEvidence,
+			memoryHeadResult,
+			backlogByScope: [...backlogByScope].map(([scope, backlog]) => ({ scope, backlog })),
+			nextWatermarkByScope: [...nextWatermarkByScope].map(([scope, watermark]) => ({ scope, watermark })),
+		};
+		await runDbOwnerDomainOperation(accessor, {
+			runWithOwner: async (owner) => {
+				const finalize = owner.submit<null>(
+					{ kind: "dreaming_pass_finalize", input: finalizeInput },
+					{
+						operation: "dreaming.pass.finalize",
+						lane: "write",
+						workloadClass: "foreground",
+						deadlineMs: 60_000,
+						estimatedWorkUnits: 500,
+					},
+				);
+				return await finalize.result;
 			},
-			{
-				operation: "dreaming.pass.finalize",
-				lane: "write",
-				workloadClass: "foreground",
-				deadlineMs: 60_000,
-				estimatedWorkUnits: 500,
-			},
-		);
-		await finalize.result;
+			runInline: ({ write }) =>
+				write((db) => {
+					finalizeDreamingPassInDb(db, finalizeInput);
+					return null;
+				}),
+		});
 		const outcome: DreamingPassOutcome =
 			failed > 0
 				? effects.usefulEffects === 0
@@ -2251,13 +2310,20 @@ export async function getDreamingEpisodicTokenBacklog(
 	agentId: string,
 	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<number> {
-	const owner = ownerMaintenance?.owner ?? (await getDbOwnerForAccessor(accessor));
 	const maxSources = ownerMaintenance === undefined ? undefined : DREAMING_SCHEDULE_BACKLOG_MAX_SOURCES;
-	return await ownerDreamingEpisodicBacklog(
-		owner,
-		{ agentId, ...(maxSources === undefined ? {} : { maxSources }) },
-		{ deadlineMs: 60_000, estimatedWorkUnits: maxSources === undefined ? DB_OWNER_MAX_WORK_UNITS : maxSources * 10 },
-	);
+	const input: DbOwnerDreamingEpisodicBacklog = {
+		agentId,
+		...(maxSources === undefined ? {} : { maxSources }),
+	};
+	const options = {
+		deadlineMs: 60_000,
+		estimatedWorkUnits: maxSources === undefined ? DB_OWNER_MAX_WORK_UNITS : maxSources * 10,
+	};
+	if (ownerMaintenance) return await ownerMaintenance.dreamingEpisodicBacklog(input, options);
+	return await runDbOwnerDomainOperation(accessor, {
+		runWithOwner: async (owner) => await ownerDreamingEpisodicBacklog(owner, input, options),
+		runInline: ({ read }) => read((db) => getDreamingEpisodicTokenBacklogInDb(db, input.agentId, input.maxSources)),
+	});
 }
 
 /** Read the last worker-computed value for synchronous dashboard metadata. */

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -3007,14 +3007,14 @@
     },
     {
       "path": "pipeline/dreaming.ts",
-      "line": 837,
+      "line": 885,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return { content: \"\", unreadable: false };",
       "category": "hot-path"
     },
     {
       "path": "pipeline/dreaming.ts",
-      "line": 839,
+      "line": 887,
       "api": "readFileSync",
       "source": "const raw = readFileSync(path, \"utf-8\").trim();",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

- add a typed domain-operation seam that requires both the owner-process request and its owner-local implementation at the domain call site
- remove every Dreaming implementation import from `db-owner-runtime.ts` and keep the generic inline dispatcher exhaustive
- route scheduled Dreaming work through the injected maintenance facade while retaining owner crash-retry behavior for ordinary production calls
- add a dependency invariant preventing owner transport from regaining Dreaming implementation imports
- preserve current-main's source-evidence owner helper while explicitly classifying that parent-only request as unsupported in nested inline dispatch

This PR includes the already-reviewed #1753 exhaustiveness commit. GitHub merged #1753 into the already-merged #1752 branch, so retargeting this combined stack to `main` is required for that code to actually ship.

## Measured result

- largest daemon runtime strongly connected component: **15 modules -> 6**
- modules removed from that cycle: DB owner transport, pipeline error/operation, Dreaming evidence retry/reviews/operations, system pressure, telemetry, and yielding writes
- production `as never` assertions: **49 -> 35**
- runtime-cycle count remains 3; this cuts the owner transport out of the primary knot rather than hiding the remaining six-module Dreaming/knowledge-graph cycle
- event-loop ledger remains at 899 sites, 164 legacy DB sites, 381 parent-process callbacks, and 2 off-parent callbacks on current main

## Verification

- daemon TypeScript check
- full daemon and dashboard build
- 23/23 event-loop architecture tests
- 17/17 Dreaming worker tests
- 8/8 foundation and surprisal tests
- 7 focused Dreaming evidence, backlog, hygiene, classification, and requeue tests
- 16/16 Dreaming agent-tool tests
- Biome and `git diff --check`

## Baseline finding kept separate

The oversized-evidence Dreaming regression test still exceeds its 15-second timeout. It reproduces identically on the #1753 base and this branch (about 21.2 seconds with pass starts roughly eight seconds apart), so this refactor did not introduce it. Existing tracking: #1715.

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no feature or spec contract changed
- [x] Agent scoping verified on all new/changed data queries — existing typed inputs and `agentId` flow are preserved
- [x] Input/config validation and bounds checks added — no new external input; existing bounded inputs are unchanged
- [x] Error handling and fallback paths tested (no silent swallow) — owner crash retry and explicit unsupported inline cases are preserved
- [x] Security checks applied to admin/mutation endpoints — no endpoint or authorization change
- [x] Docs updated for API/spec/status changes — no public API/spec/status change; architecture findings are tracked in #1748
- [x] Regression tests added for each bug fix — dependency invariant and existing maintenance-routing regression cover the repaired paths
- [x] Lint/typecheck/tests pass locally
