### PR TITLE
refactor(daemon): isolate Dreaming backlog cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to Signet are documented here.
 Surface summary of the most recent release dates. See the release ledger below for exact version-by-version history.
 
 ### 2026-08-31
-- Bug fixes: resolve wave-5 + foundation merge — realign contract inventory to 899/219/217/383; make lifecycle close recovery robust; reopen accessor lifecycle between closes; close DB lifecycle registrations atomically; require DB owner for vacuum work; realign contract test assertions to wave-5 inventory (902/220/384); L1 wave 5 — routes clusters owner-routed (memory/sources/misc + imported-source-outcome); repair compiled first-use path.
-- Refactoring: isolate DB foundation lifecycle; isolate migration contract.
+- Bug fixes: repair boundary test structure after rebase (balanced describes); restore wave-5 source-evidence helper + classify it in inline dispatch; repair boundary test structure; resolve wave-5 + foundation merge — realign contract inventory to 899/219/217/383; make lifecycle close recovery robust; reopen accessor lifecycle between closes; close DB lifecycle registrations atomically; require DB owner for vacuum work; realign contract test assertions to wave-5 inventory (902/220/384); L1 wave 5 — routes clusters owner-routed (memory/sources/misc + imported-source-outcome); repair compiled first-use path.
+- Refactoring: move owner-local Dreaming execution; make inline owner dispatch exhaustive; isolate DB foundation lifecycle; isolate migration contract.
 
 ### 2026-08-30
 - Bug fixes: preserve low-volume scheduling fallback; realign memory-search site tokens after wave-4 relocation; L1 wave 4 owner-routing + audit realignment; track detached boot descendants; close boot-wedge gate review gaps; route pipeline reads through owner; harden boot wedge measurements; route telemetry identity through owner; route extraction retirement to owner; route startup DB work to owner.
@@ -32,6 +32,21 @@ Surface summary of the most recent release dates. See the release ledger below f
 - Bug fixes: rebase site tokens after vacuum space-guard edit; allow unknown migration backup space; harden vector backfill and migration cursors; validate backup cursors and quarantine only malformed vectors; legacy backup classification and quarantined backfill; verifiable bridge state and equipped backfill; ordered verdicts, blocked children, yielding backfill; process-wide corruption block and recoverable verification; progress-capable backfill and corruption-safe maintenance; pre-init corruption gate and owner-spanning backfill; fail-close corrupt writes and defer heavy backfill; gate runtime writers and vacuum on verification outcome; preserve unverified rollback points and bound backfill; admissible scan budgets and regular-file backup inventory; uncapped size budgets, staged startup fencing, safe destinations; unblock runtime on scheduled verify and test production deadline; honest scan exclusion and crash-safe backup resume; monotonic corruption latch and verified backup resume; serialize verify maintenance and keep backup lifecycle honest; keep corruption verdicts and startup budgets honest; scope verify outcomes honestly and confirm prune results; severity-merge integrity states and retry verify gate setup; bind migration budgets to owner deadline and surface verify failures; harden migration backup recovery status; close migration startup races; upgrade checkpoint attempt_count column before first reference; preserve unverified rollback point and scope verify checkpoint per generation; lint-clean probe handles; no non-null assertions; complete r6 bounded-verify and absolute-deadline fixes; make post-migration verification full-equivalent and resume admission-closed; scope artifact verification and close probe write gap; close admission gaps flagged in review of #1709; bound startup migration work behind admission guarantees.
 
 ## Release Ledger
+
+## [0.214.36] - 2026-08-31
+
+Release summary: 2 bug fixes and 2 refactors.
+Tag range: `v0.214.35..v0.214.36`.
+
+### Bug Fixes
+
+- **test**: repair boundary test structure after rebase (balanced describes)
+- **rebase**: restore wave-5 source-evidence helper + classify it in inline dispatch; repair boundary test structure
+
+### Refactoring
+
+- **daemon**: move owner-local Dreaming execution
+- **daemon**: make inline owner dispatch exhaustive
 
 ## [0.214.35] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to Signet are documented here.
 Surface summary of the most recent release dates. See the release ledger below for exact version-by-version history.
 
 ### 2026-08-31
-- Bug fixes: repair boundary test structure after rebase (balanced describes); restore wave-5 source-evidence helper + classify it in inline dispatch; repair boundary test structure; resolve wave-5 + foundation merge — realign contract inventory to 899/219/217/383; make lifecycle close recovery robust; reopen accessor lifecycle between closes; close DB lifecycle registrations atomically; require DB owner for vacuum work; realign contract test assertions to wave-5 inventory (902/220/384); L1 wave 5 — routes clusters owner-routed (memory/sources/misc + imported-source-outcome); repair compiled first-use path.
-- Refactoring: move owner-local Dreaming execution; make inline owner dispatch exhaustive; isolate DB foundation lifecycle; isolate migration contract.
+- Bug fixes: bound sync DB site token matching; repair boundary test structure after rebase (balanced describes); restore wave-5 source-evidence helper + classify it in inline dispatch; repair boundary test structure; resolve wave-5 + foundation merge — realign contract inventory to 899/219/217/383; make lifecycle close recovery robust; reopen accessor lifecycle between closes; close DB lifecycle registrations atomically; require DB owner for vacuum work; realign contract test assertions to wave-5 inventory (902/220/384); L1 wave 5 — routes clusters owner-routed (memory/sources/misc + imported-source-outcome); repair compiled first-use path.
+- Refactoring: route knowledge graph reads through db owner; stabilize DB attribution IDs; move owner-local Dreaming execution; make inline owner dispatch exhaustive; isolate DB foundation lifecycle; isolate migration contract.
 
 ### 2026-08-30
 - Bug fixes: preserve low-volume scheduling fallback; realign memory-search site tokens after wave-4 relocation; L1 wave 4 owner-routing + audit realignment; track detached boot descendants; close boot-wedge gate review gaps; route pipeline reads through owner; harden boot wedge measurements; route telemetry identity through owner; route extraction retirement to owner; route startup DB work to owner.
@@ -32,6 +32,20 @@ Surface summary of the most recent release dates. See the release ledger below f
 - Bug fixes: rebase site tokens after vacuum space-guard edit; allow unknown migration backup space; harden vector backfill and migration cursors; validate backup cursors and quarantine only malformed vectors; legacy backup classification and quarantined backfill; verifiable bridge state and equipped backfill; ordered verdicts, blocked children, yielding backfill; process-wide corruption block and recoverable verification; progress-capable backfill and corruption-safe maintenance; pre-init corruption gate and owner-spanning backfill; fail-close corrupt writes and defer heavy backfill; gate runtime writers and vacuum on verification outcome; preserve unverified rollback points and bound backfill; admissible scan budgets and regular-file backup inventory; uncapped size budgets, staged startup fencing, safe destinations; unblock runtime on scheduled verify and test production deadline; honest scan exclusion and crash-safe backup resume; monotonic corruption latch and verified backup resume; serialize verify maintenance and keep backup lifecycle honest; keep corruption verdicts and startup budgets honest; scope verify outcomes honestly and confirm prune results; severity-merge integrity states and retry verify gate setup; bind migration budgets to owner deadline and surface verify failures; harden migration backup recovery status; close migration startup races; upgrade checkpoint attempt_count column before first reference; preserve unverified rollback point and scope verify checkpoint per generation; lint-clean probe handles; no non-null assertions; complete r6 bounded-verify and absolute-deadline fixes; make post-migration verification full-equivalent and resume admission-closed; scope artifact verification and close probe write gap; close admission gaps flagged in review of #1709; bound startup migration work behind admission guarantees.
 
 ## Release Ledger
+
+## [0.214.37] - 2026-08-31
+
+Release summary: 1 bug fix and 2 refactors.
+Tag range: `v0.214.36..v0.214.37`.
+
+### Bug Fixes
+
+- **daemon**: bound sync DB site token matching
+
+### Refactoring
+
+- **daemon**: route knowledge graph reads through db owner
+- **daemon**: stabilize DB attribution IDs
 
 ## [0.214.36] - 2026-08-31
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "dist/signetai": {
       "name": "signetai",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -27,27 +27,27 @@
     },
     "dist/signetai-darwin-arm64": {
       "name": "signetai-darwin-arm64",
-      "version": "0.214.36",
+      "version": "0.214.37",
     },
     "dist/signetai-darwin-x64": {
       "name": "signetai-darwin-x64",
-      "version": "0.214.36",
+      "version": "0.214.37",
     },
     "dist/signetai-linux-arm64": {
       "name": "signetai-linux-arm64",
-      "version": "0.214.36",
+      "version": "0.214.37",
     },
     "dist/signetai-linux-x64": {
       "name": "signetai-linux-x64",
-      "version": "0.214.36",
+      "version": "0.214.37",
     },
     "dist/signetai-win32-x64": {
       "name": "signetai-win32-x64",
-      "version": "0.214.36",
+      "version": "0.214.37",
     },
     "integrations/claude-code/connector": {
       "name": "@signet/connector-claude-code",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-claude-code": "bin/install.js",
       },
@@ -62,7 +62,7 @@
     },
     "integrations/codex/connector": {
       "name": "@signet/connector-codex",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-codex": "bin/install.js",
       },
@@ -77,7 +77,7 @@
     },
     "integrations/codex/plugin": {
       "name": "@signet/codex-plugin",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-codex-plugin": "bin/install.js",
       },
@@ -88,7 +88,7 @@
     },
     "integrations/forge/connector": {
       "name": "@signet/connector-forge",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-forge": "bin/install.js",
       },
@@ -103,7 +103,7 @@
     },
     "integrations/gemini/connector": {
       "name": "@signet/connector-gemini",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-gemini": "bin/install.js",
       },
@@ -118,7 +118,7 @@
     },
     "integrations/hermes-agent/connector": {
       "name": "@signet/connector-hermes-agent",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-hermes-agent": "bin/install.js",
       },
@@ -133,7 +133,7 @@
     },
     "integrations/kimi/connector": {
       "name": "@signet/connector-kimi",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-kimi": "bin/install.js",
       },
@@ -148,7 +148,7 @@
     },
     "integrations/oh-my-pi/connector": {
       "name": "@signet/connector-oh-my-pi",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-oh-my-pi": "bin/install.js",
       },
@@ -163,7 +163,7 @@
     },
     "integrations/oh-my-pi/extension": {
       "name": "@signet/oh-my-pi-extension",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -176,7 +176,7 @@
     },
     "integrations/openclaw/connector": {
       "name": "@signet/connector-openclaw",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-openclaw": "bin/install.js",
       },
@@ -191,7 +191,7 @@
     },
     "integrations/openclaw/memory-adapter": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -209,7 +209,7 @@
     },
     "integrations/opencode/connector": {
       "name": "@signet/connector-opencode",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-opencode": "bin/install.js",
       },
@@ -225,7 +225,7 @@
     },
     "integrations/opencode/plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -241,7 +241,7 @@
     },
     "integrations/pi/connector": {
       "name": "@signet/connector-pi",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-connector-pi": "bin/install.js",
       },
@@ -256,7 +256,7 @@
     },
     "integrations/pi/extension": {
       "name": "@signet/pi-extension",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -270,7 +270,7 @@
     },
     "integrations/pi/extension-base": {
       "name": "@signet/pi-extension-base",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/lifecycle-proof": "workspace:*",
@@ -278,11 +278,11 @@
     },
     "integrations/unreal/plugin": {
       "name": "@signet/unreal-plugin",
-      "version": "0.214.36",
+      "version": "0.214.37",
     },
     "libs/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@signet/core": "0.204.4",
         "json5": "^2.2.3",
@@ -295,11 +295,11 @@
     },
     "libs/lifecycle-proof": {
       "name": "@signet/lifecycle-proof",
-      "version": "0.214.36",
+      "version": "0.214.37",
     },
     "libs/sdk": {
       "name": "@signet/sdk",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "devDependencies": {
         "@signet/core": "workspace:*",
         "@types/react": "^19.0.0",
@@ -339,7 +339,7 @@
     },
     "platform/core": {
       "name": "@signet/core",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@napi-rs/keyring": "1.3.0",
         "libsodium-wrappers": "^0.8.2",
@@ -364,7 +364,7 @@
     },
     "platform/daemon": {
       "name": "@signet/daemon",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -407,14 +407,14 @@
     },
     "platform/native": {
       "name": "@signet/native",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
       },
     },
     "surfaces/browser-extension": {
       "name": "@signet/extension",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -422,7 +422,7 @@
     },
     "surfaces/cli": {
       "name": "@signet/cli",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@earendil-works/pi-ai": "0.83.0",
@@ -489,7 +489,7 @@
     },
     "surfaces/desktop": {
       "name": "@signet/desktop",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/tray": "workspace:*",
@@ -504,7 +504,7 @@
     },
     "surfaces/tray": {
       "name": "@signet/tray",
-      "version": "0.214.36",
+      "version": "0.214.37",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "dist/signetai": {
       "name": "signetai",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -27,27 +27,27 @@
     },
     "dist/signetai-darwin-arm64": {
       "name": "signetai-darwin-arm64",
-      "version": "0.214.35",
+      "version": "0.214.36",
     },
     "dist/signetai-darwin-x64": {
       "name": "signetai-darwin-x64",
-      "version": "0.214.35",
+      "version": "0.214.36",
     },
     "dist/signetai-linux-arm64": {
       "name": "signetai-linux-arm64",
-      "version": "0.214.35",
+      "version": "0.214.36",
     },
     "dist/signetai-linux-x64": {
       "name": "signetai-linux-x64",
-      "version": "0.214.35",
+      "version": "0.214.36",
     },
     "dist/signetai-win32-x64": {
       "name": "signetai-win32-x64",
-      "version": "0.214.35",
+      "version": "0.214.36",
     },
     "integrations/claude-code/connector": {
       "name": "@signet/connector-claude-code",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-claude-code": "bin/install.js",
       },
@@ -62,7 +62,7 @@
     },
     "integrations/codex/connector": {
       "name": "@signet/connector-codex",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-codex": "bin/install.js",
       },
@@ -77,7 +77,7 @@
     },
     "integrations/codex/plugin": {
       "name": "@signet/codex-plugin",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-codex-plugin": "bin/install.js",
       },
@@ -88,7 +88,7 @@
     },
     "integrations/forge/connector": {
       "name": "@signet/connector-forge",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-forge": "bin/install.js",
       },
@@ -103,7 +103,7 @@
     },
     "integrations/gemini/connector": {
       "name": "@signet/connector-gemini",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-gemini": "bin/install.js",
       },
@@ -118,7 +118,7 @@
     },
     "integrations/hermes-agent/connector": {
       "name": "@signet/connector-hermes-agent",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-hermes-agent": "bin/install.js",
       },
@@ -133,7 +133,7 @@
     },
     "integrations/kimi/connector": {
       "name": "@signet/connector-kimi",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-kimi": "bin/install.js",
       },
@@ -148,7 +148,7 @@
     },
     "integrations/oh-my-pi/connector": {
       "name": "@signet/connector-oh-my-pi",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-oh-my-pi": "bin/install.js",
       },
@@ -163,7 +163,7 @@
     },
     "integrations/oh-my-pi/extension": {
       "name": "@signet/oh-my-pi-extension",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -176,7 +176,7 @@
     },
     "integrations/openclaw/connector": {
       "name": "@signet/connector-openclaw",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-openclaw": "bin/install.js",
       },
@@ -191,7 +191,7 @@
     },
     "integrations/openclaw/memory-adapter": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -209,7 +209,7 @@
     },
     "integrations/opencode/connector": {
       "name": "@signet/connector-opencode",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-opencode": "bin/install.js",
       },
@@ -225,7 +225,7 @@
     },
     "integrations/opencode/plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -241,7 +241,7 @@
     },
     "integrations/pi/connector": {
       "name": "@signet/connector-pi",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-connector-pi": "bin/install.js",
       },
@@ -256,7 +256,7 @@
     },
     "integrations/pi/extension": {
       "name": "@signet/pi-extension",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -270,7 +270,7 @@
     },
     "integrations/pi/extension-base": {
       "name": "@signet/pi-extension-base",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/lifecycle-proof": "workspace:*",
@@ -278,11 +278,11 @@
     },
     "integrations/unreal/plugin": {
       "name": "@signet/unreal-plugin",
-      "version": "0.214.35",
+      "version": "0.214.36",
     },
     "libs/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@signet/core": "0.204.4",
         "json5": "^2.2.3",
@@ -295,11 +295,11 @@
     },
     "libs/lifecycle-proof": {
       "name": "@signet/lifecycle-proof",
-      "version": "0.214.35",
+      "version": "0.214.36",
     },
     "libs/sdk": {
       "name": "@signet/sdk",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "devDependencies": {
         "@signet/core": "workspace:*",
         "@types/react": "^19.0.0",
@@ -339,7 +339,7 @@
     },
     "platform/core": {
       "name": "@signet/core",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@napi-rs/keyring": "1.3.0",
         "libsodium-wrappers": "^0.8.2",
@@ -364,7 +364,7 @@
     },
     "platform/daemon": {
       "name": "@signet/daemon",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -407,14 +407,14 @@
     },
     "platform/native": {
       "name": "@signet/native",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
       },
     },
     "surfaces/browser-extension": {
       "name": "@signet/extension",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -422,7 +422,7 @@
     },
     "surfaces/cli": {
       "name": "@signet/cli",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@earendil-works/pi-ai": "0.83.0",
@@ -489,7 +489,7 @@
     },
     "surfaces/desktop": {
       "name": "@signet/desktop",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/tray": "workspace:*",
@@ -504,7 +504,7 @@
     },
     "surfaces/tray": {
       "name": "@signet/tray",
-      "version": "0.214.35",
+      "version": "0.214.36",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/dist/signetai-darwin-arm64/package.json
+++ b/dist/signetai-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-arm64",
-  "version": "0.214.36",
+  "version": "0.214.37",
   "description": "Signet native binary for macOS arm64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-arm64/package.json
+++ b/dist/signetai-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-arm64",
-  "version": "0.214.35",
+  "version": "0.214.36",
   "description": "Signet native binary for macOS arm64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-x64/package.json
+++ b/dist/signetai-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-x64",
-  "version": "0.214.36",
+  "version": "0.214.37",
   "description": "Signet native binary for macOS x64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-x64/package.json
+++ b/dist/signetai-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-x64",
-  "version": "0.214.35",
+  "version": "0.214.36",
   "description": "Signet native binary for macOS x64",
   "os": [
     "darwin"

--- a/dist/signetai-linux-arm64/package.json
+++ b/dist/signetai-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-arm64",
-  "version": "0.214.36",
+  "version": "0.214.37",
   "description": "Signet native binary for Linux arm64",
   "os": [
     "linux"

--- a/dist/signetai-linux-arm64/package.json
+++ b/dist/signetai-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-arm64",
-  "version": "0.214.35",
+  "version": "0.214.36",
   "description": "Signet native binary for Linux arm64",
   "os": [
     "linux"

--- a/dist/signetai-linux-x64/package.json
+++ b/dist/signetai-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-x64",
-  "version": "0.214.36",
+  "version": "0.214.37",
   "description": "Signet native binary for Linux x64",
   "os": [
     "linux"

--- a/dist/signetai-linux-x64/package.json
+++ b/dist/signetai-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-x64",
-  "version": "0.214.35",
+  "version": "0.214.36",
   "description": "Signet native binary for Linux x64",
   "os": [
     "linux"

--- a/dist/signetai-win32-x64/package.json
+++ b/dist/signetai-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-win32-x64",
-  "version": "0.214.35",
+  "version": "0.214.36",
   "description": "Signet native binary for Windows x64",
   "os": [
     "win32"

--- a/dist/signetai-win32-x64/package.json
+++ b/dist/signetai-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-win32-x64",
-  "version": "0.214.36",
+  "version": "0.214.37",
   "description": "Signet native binary for Windows x64",
   "os": [
     "win32"

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai",
-  "version": "0.214.35",
+  "version": "0.214.36",
   "description": "Signet native CLI installer wrapper",
   "type": "module",
   "bin": {

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai",
-  "version": "0.214.36",
+  "version": "0.214.37",
   "description": "Signet native CLI installer wrapper",
   "type": "module",
   "bin": {

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 902 sites
+- Exact ledger inventory: 882 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 222
-- Async-named ON-PARENT DB sites: 220
+- Async-named DB sites: 202
+- Async-named ON-PARENT DB sites: 200
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 902-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 222 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 220 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 882-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 386
-- ON-PARENT callback execution: 384
+- Database accessor sites classified: 366
+- ON-PARENT callback execution: 364
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -98,28 +98,8 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `imported-source-outcome.ts:16` (withWriteTx)
 - `imported-source-outcome.ts:62` (withReadDb)
 - `knowledge-graph-hygiene.ts:428` (withReadDb)
-- `knowledge-graph.ts:193` (withReadDbAsync)
-- `knowledge-graph.ts:218` (withReadDbAsync)
-- `knowledge-graph.ts:243` (withReadDbAsync)
-- `knowledge-graph.ts:271` (withReadDbAsync)
-- `knowledge-graph.ts:287` (withReadDbAsync)
-- `knowledge-graph.ts:312` (withReadDbAsync)
-- `knowledge-graph.ts:340` (withReadDbAsync)
-- `knowledge-graph.ts:422` (withReadDbAsync)
-- `knowledge-graph.ts:605` (withReadDbAsync)
-- `knowledge-graph.ts:783` (withReadDbAsync)
-- `knowledge-graph.ts:814` (withReadDbAsync)
-- `knowledge-graph.ts:841` (withReadDbAsync)
-- `knowledge-graph.ts:994` (withReadDbAsync)
-- `knowledge-graph.ts:1058` (withReadDbAsync)
-- `knowledge-graph.ts:1140` (withReadDbAsync)
-- `knowledge-graph.ts:1204` (withReadDbAsync)
-- `knowledge-graph.ts:1291` (withReadDbAsync)
-- `knowledge-graph.ts:1401` (withReadDbAsync)
-- `knowledge-graph.ts:1418` (withReadDbAsync)
-- `knowledge-graph.ts:1463` (withReadDbAsync)
-- `knowledge-graph.ts:1602` (withReadDbAsync)
-- `knowledge-graph.ts:1984` (withReadDbAsync)
+- `db:knowledge.entity-knowledge-tree.read` (withReadDbAsync)
+- `db:knowledge.graph-constellation.read` (withReadDbAsync)
 - `memory-candidates.ts:470` (withReadDb)
 - `memory-candidates.ts:511` (withReadDb)
 - `memory-head-curation.ts:31` (withReadDbAsync)

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -1,26 +1,26 @@
 # Event-loop synchronous contract audit
 
-This report is generated from the deterministic migration ledger in `scripts/event-loop-contract-baseline.json`. Phase A enforces the type boundary structurally: production code receives an async-only `DbAccessor`, while the synchronous compatibility module lives outside the daemon production `src/` tree and is rejected by the production TypeScript project's `rootDir`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching.
+This report is generated from the deterministic migration ledger in `scripts/event-loop-contract-baseline.json`. Phase A enforces the type boundary structurally: production code receives an async-only `DbAccessor`, while the synchronous compatibility module lives outside the daemon production `src/` tree and is rejected by the production TypeScript project's `rootDir`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching. Migrated DB sites use unique `db:domain.operation.action` IDs as their durable identity; file and line remain diagnostic metadata.
 
 ## Current inventory
 
-- Exact ledger inventory: 899 sites
+- Exact ledger inventory: 902 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 219
-- Async-named ON-PARENT DB sites: 217
+- Async-named DB sites: 222
+- Async-named ON-PARENT DB sites: 220
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 899-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 219 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 217 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 902-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 222 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 220 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 383
-- ON-PARENT callback execution: 381
+- Database accessor sites classified: 386
+- ON-PARENT callback execution: 384
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -60,11 +60,13 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `database-integrity.ts:712` (withReadDbAsync)
 - `database-integrity.ts:830` (withReadDbAsync)
 - `db-accessor.ts:3031` (withWriteTxAsync)
-- `db-vacuum.ts:331` (withReadDb)
-- `db-vacuum.ts:339` (withReadDbAsync)
-- `db-vacuum.ts:347` (withWriteTxAsync)
-- `db-vacuum.ts:367` (withWriteTxAsync)
-- `db-vacuum.ts:386` (withWriteTxAsync)
+- `db-vacuum.ts:340` (withReadDb)
+- `db-vacuum.ts:348` (withReadDbAsync)
+- `db-vacuum.ts:460` (incrementalVacuumAsync)
+- `db-vacuum.ts:498` (withWriteTxAsync)
+- `db-vacuum.ts:528` (vacuumConversionAsync)
+- `db-vacuum.ts:530` (withWriteTxAsync)
+- `db-vacuum.ts:548` (withWriteTxAsync)
 - `discord-desktop-cache-source.ts:484` (withReadDbAsync)
 - `discord-desktop-cache-source.ts:497` (withWriteTxAsync)
 - `discord-source-provider.ts:573` (withReadDbAsync)
@@ -217,9 +219,10 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `pipeline/dreaming-worker.ts:227` (withReadDbAsync)
 - `pipeline/dreaming-worker.ts:247` (withReadDbAsync)
 - `pipeline/graph-traversal.ts:92` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:148` (withReadDbAsync)
+- `db:maintenance.graph-agent-scopes.read` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:485` (withReadDbAsync)
+- `db:maintenance.dead-memory-count.read` (withReadDbAsync)
+- `pipeline/maintenance-worker.ts:535` (withReadDbAsync)
 - `pipeline/prospective-index.ts:284` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:300` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:336` (withWriteTxAsync)

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 882 sites
+- Exact ledger inventory: 879 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 202
-- Async-named ON-PARENT DB sites: 200
+- Async-named DB sites: 199
+- Async-named ON-PARENT DB sites: 197
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 882-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 879-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 199 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 197 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 366
-- ON-PARENT callback execution: 364
+- Database accessor sites classified: 363
+- ON-PARENT callback execution: 361
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -60,13 +60,11 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `database-integrity.ts:712` (withReadDbAsync)
 - `database-integrity.ts:830` (withReadDbAsync)
 - `db-accessor.ts:3031` (withWriteTxAsync)
-- `db-vacuum.ts:340` (withReadDb)
-- `db-vacuum.ts:348` (withReadDbAsync)
-- `db-vacuum.ts:460` (incrementalVacuumAsync)
-- `db-vacuum.ts:498` (withWriteTxAsync)
-- `db-vacuum.ts:528` (vacuumConversionAsync)
-- `db-vacuum.ts:530` (withWriteTxAsync)
-- `db-vacuum.ts:548` (withWriteTxAsync)
+- `db-vacuum.ts:331` (withReadDb)
+- `db-vacuum.ts:339` (withReadDbAsync)
+- `db-vacuum.ts:347` (withWriteTxAsync)
+- `db-vacuum.ts:367` (withWriteTxAsync)
+- `db-vacuum.ts:386` (withWriteTxAsync)
 - `discord-desktop-cache-source.ts:484` (withReadDbAsync)
 - `discord-desktop-cache-source.ts:497` (withWriteTxAsync)
 - `discord-source-provider.ts:573` (withReadDbAsync)
@@ -202,7 +200,6 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `db:maintenance.graph-agent-scopes.read` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
 - `db:maintenance.dead-memory-count.read` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:535` (withReadDbAsync)
 - `pipeline/prospective-index.ts:284` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:300` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:336` (withWriteTxAsync)

--- a/integrations/claude-code/connector/package.json
+++ b/integrations/claude-code/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-claude-code",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for Claude Code (Anthropic CLI)",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/claude-code/connector/package.json
+++ b/integrations/claude-code/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-claude-code",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for Claude Code (Anthropic CLI)",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/codex/connector/package.json
+++ b/integrations/codex/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-codex",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for Codex CLI",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/codex/connector/package.json
+++ b/integrations/codex/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-codex",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for Codex CLI",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/codex/plugin/package.json
+++ b/integrations/codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/codex-plugin",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Native Codex plugin installer for Signet",
 	"type": "module",
 	"bin": {
@@ -13,8 +13,8 @@
 		"test": "node bin/install.js --help >/dev/null"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/connector-codex": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/connector-codex": "0.214.36"
 	},
 	"keywords": [
 		"signet",

--- a/integrations/codex/plugin/package.json
+++ b/integrations/codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/codex-plugin",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Native Codex plugin installer for Signet",
 	"type": "module",
 	"bin": {
@@ -13,8 +13,8 @@
 		"test": "node bin/install.js --help >/dev/null"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/connector-codex": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/connector-codex": "0.214.37"
 	},
 	"keywords": [
 		"signet",

--- a/integrations/forge/connector/package.json
+++ b/integrations/forge/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-forge",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/forge/connector/package.json
+++ b/integrations/forge/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-forge",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/gemini/connector/package.json
+++ b/integrations/gemini/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-gemini",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for Gemini CLI",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/gemini/connector/package.json
+++ b/integrations/gemini/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-gemini",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for Gemini CLI",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/hermes-agent/connector/package.json
+++ b/integrations/hermes-agent/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-hermes-agent",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/hermes-agent/connector/package.json
+++ b/integrations/hermes-agent/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-hermes-agent",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/kimi/connector/package.json
+++ b/integrations/kimi/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-kimi",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for Kimi CLI / Kimi Code",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/kimi/connector/package.json
+++ b/integrations/kimi/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-kimi",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for Kimi CLI / Kimi Code",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,8 +24,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/connector/package.json
+++ b/integrations/oh-my-pi/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-oh-my-pi",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for Oh My Pi",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/connector/package.json
+++ b/integrations/oh-my-pi/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-oh-my-pi",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for Oh My Pi",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/extension/package.json
+++ b/integrations/oh-my-pi/extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/oh-my-pi-extension",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet runtime extension for Oh My Pi — session lifecycle hooks and memory recall",
 	"type": "module",
 	"main": "dist/signet-oh-my-pi.mjs",

--- a/integrations/oh-my-pi/extension/package.json
+++ b/integrations/oh-my-pi/extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/oh-my-pi-extension",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet runtime extension for Oh My Pi — session lifecycle hooks and memory recall",
 	"type": "module",
 	"main": "dist/signet-oh-my-pi.mjs",

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-openclaw",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for OpenClaw - configures workspace and memory hooks",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"test": "bun test"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-openclaw",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for OpenClaw - configures workspace and memory hooks",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"test": "bun test"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signetai/signet-memory-openclaw",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet adapter for OpenClaw — runtime plugin for AI agent memory",
 	"type": "module",
 	"main": "dist/index.js",

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signetai/signet-memory-openclaw",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet adapter for OpenClaw — runtime plugin for AI agent memory",
 	"type": "module",
 	"main": "dist/index.js",

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-opencode",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for OpenCode - installs hooks and generates config",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36",
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37",
 		"jsonc-parser": "3.3.1"
 	},
 	"devDependencies": {

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-opencode",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for OpenCode - installs hooks and generates config",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35",
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36",
 		"jsonc-parser": "3.3.1"
 	},
 	"devDependencies": {

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/opencode-plugin",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet runtime plugin for OpenCode — memory tools and session lifecycle hooks",
 	"type": "module",
 	"main": "dist/signet.mjs",

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/opencode-plugin",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet runtime plugin for OpenCode — memory tools and session lifecycle hooks",
 	"type": "module",
 	"main": "dist/signet.mjs",

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-pi",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet connector for pi",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.35",
-		"@signet/core": "0.214.35"
+		"@signet/connector-base": "0.214.36",
+		"@signet/core": "0.214.36"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-pi",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet connector for pi",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -25,8 +25,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/connector-base": "0.214.36",
-		"@signet/core": "0.214.36"
+		"@signet/connector-base": "0.214.37",
+		"@signet/core": "0.214.37"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/pi-extension-base",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Shared runtime utilities for Signet harness extensions (helpers, transcript, types, lifecycle, session state)",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/pi-extension-base",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Shared runtime utilities for Signet harness extensions (helpers, transcript, types, lifecycle, session state)",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/integrations/pi/extension/package.json
+++ b/integrations/pi/extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/pi-extension",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Signet runtime extension for pi — session lifecycle hooks and memory recall",
 	"type": "module",
 	"main": "dist/signet-pi.mjs",

--- a/integrations/pi/extension/package.json
+++ b/integrations/pi/extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/pi-extension",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Signet runtime extension for pi — session lifecycle hooks and memory recall",
 	"type": "module",
 	"main": "dist/signet-pi.mjs",

--- a/integrations/unreal/plugin/package.json
+++ b/integrations/unreal/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/unreal-plugin",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"private": true,
 	"description": "Signet Unreal Engine plugin manifest and source checks",
 	"type": "module",

--- a/integrations/unreal/plugin/package.json
+++ b/integrations/unreal/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/unreal-plugin",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"private": true,
 	"description": "Signet Unreal Engine plugin manifest and source checks",
 	"type": "module",

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-base",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "Base class for Signet harness connectors",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -26,7 +26,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/core": "0.214.35",
+		"@signet/core": "0.214.36",
 		"json5": "^2.2.3",
 		"jsonc-parser": "3.3.1"
 	},

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/connector-base",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "Base class for Signet harness connectors",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -26,7 +26,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@signet/core": "0.214.36",
+		"@signet/core": "0.214.37",
 		"json5": "^2.2.3",
 		"jsonc-parser": "3.3.1"
 	},

--- a/libs/lifecycle-proof/package.json
+++ b/libs/lifecycle-proof/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/lifecycle-proof",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"private": true,
 	"description": "Cross-harness lifecycle invariant proof helpers",
 	"type": "module",

--- a/libs/lifecycle-proof/package.json
+++ b/libs/lifecycle-proof/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/lifecycle-proof",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"private": true,
 	"description": "Cross-harness lifecycle invariant proof helpers",
 	"type": "module",

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/sdk",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"license": "Apache-2.0",
 	"description": "HTTP client SDK for the Signet daemon API",
 	"type": "module",

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/sdk",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"license": "Apache-2.0",
 	"description": "HTTP client SDK for the Signet daemon API",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "signet",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"private": true,
 	"packageManager": "bun@1.3.11",
 	"description": "Local-first identity, memory, and secrets for AI agents",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "signet",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"private": true,
 	"packageManager": "bun@1.3.11",
 	"description": "Local-first identity, memory, and secrets for AI agents",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/core",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"license": "Apache-2.0",
 	"description": "Core library for Signet - portable AI agent identity",
 	"type": "module",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/core",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"license": "Apache-2.0",
 	"description": "Core library for Signet - portable AI agent identity",
 	"type": "module",

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/daemon",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"license": "Apache-2.0",
 	"description": "Background daemon for Signet - serves dashboard, API, and memory system",
 	"type": "module",

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/daemon",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"license": "Apache-2.0",
 	"description": "Background daemon for Signet - serves dashboard, API, and memory system",
 	"type": "module",

--- a/platform/daemon/src/db-foundation-boundary.test.ts
+++ b/platform/daemon/src/db-foundation-boundary.test.ts
@@ -102,4 +102,10 @@ describe("owner transport purity", () => {
 		expect(runtime).not.toContain('"./knowledge-graph-hygiene"');
 		expect(runtime).not.toContain('"./pipeline/dreaming');
 	});
+
+	it("keeps the knowledge graph independent of Dreaming composition", () => {
+		const graph = source("./knowledge-graph.ts");
+
+		expect(graph).not.toContain('from "./pipeline/dreaming"');
+	});
 });

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -186,7 +186,7 @@ function rowToTaskMeta(r: Record<string, unknown>): TaskMeta {
 // ---------------------------------------------------------------------------
 
 export async function getAspectsForEntity(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAspect[]> {
@@ -209,7 +209,7 @@ export async function getAspectsForEntity(
 // ---------------------------------------------------------------------------
 
 export async function getAttributesForAspect(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	aspectId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
@@ -232,7 +232,7 @@ export async function getAttributesForAspect(
  * This is the query that enforces the "constraints always surface" invariant.
  */
 export async function getConstraintsForEntity(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
@@ -259,7 +259,7 @@ export async function getConstraintsForEntity(
 // ---------------------------------------------------------------------------
 
 export async function getEntityDependencyById(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: { readonly id: string; readonly agentId: string },
 ): Promise<EntityDependency | null> {
 	const row = await dbOwnerQuery<Record<string, unknown> | null>(
@@ -274,7 +274,7 @@ export async function getEntityDependencyById(
 }
 
 export async function getDependenciesFrom(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
@@ -297,7 +297,7 @@ export async function getDependenciesFrom(
 }
 
 export async function getDependenciesTo(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
@@ -324,7 +324,7 @@ export async function getDependenciesTo(
 // ---------------------------------------------------------------------------
 
 export async function getPinnedEntities(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	agentId: string,
 ): Promise<ReadonlyArray<PinnedEntitySummary>> {
 	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
@@ -398,7 +398,7 @@ export async function upsertTaskMeta(accessor: DbAccessor, params: UpsertTaskMet
 	});
 }
 
-export async function getTaskMeta(accessor: DbAccessor, entityId: string, agentId: string): Promise<TaskMeta | null> {
+export async function getTaskMeta(_accessor: DbAccessor, entityId: string, agentId: string): Promise<TaskMeta | null> {
 	const row = await dbOwnerQuery<Record<string, unknown> | null>(
 		{
 			sql: "SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?",
@@ -573,7 +573,7 @@ export interface EntityKnowledgeTree {
 }
 
 export async function resolveNamedEntity(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	input: {
 		readonly agentId: string;
 		readonly name: string;
@@ -762,7 +762,7 @@ export async function getKnowledgeEntityByName(
 }
 
 export async function listEntityAliases(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly entityId: string;
@@ -1165,7 +1165,7 @@ export async function listEntityAttributesByPath(
 }
 
 export async function listKnowledgeEntities(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly type?: string;

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -22,7 +22,7 @@ import type {
 } from "@signet/core";
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import { getDbAccessorPath, type DbAccessor, type ReadDb } from "./db-accessor";
-import { getDbOwner } from "./db-owner-runtime";
+import { dbOwnerQuery, getDbOwner } from "./db-owner-runtime";
 import { ownerReadOne } from "./db-owner-sql";
 import { runWriteTxAsync } from "./db-accessor";
 import { getDreamingEpisodicTokenBacklogCached } from "./pipeline/dreaming";
@@ -190,20 +190,18 @@ export async function getAspectsForEntity(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAspect[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT * FROM entity_aspects
-				 WHERE entity_id = ? AND agent_id = ?
-				   AND COALESCE(status, 'active') = 'active'
-				 ORDER BY weight DESC`,
-				)
-				.all(entityId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToAspect);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT * FROM entity_aspects
+			 WHERE entity_id = ? AND agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
+			 ORDER BY weight DESC`,
+			params: [entityId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:193" },
+		{ operation: "db:knowledge.aspects-for-entity.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAspect);
 }
 
 // ---------------------------------------------------------------------------
@@ -215,19 +213,17 @@ export async function getAttributesForAspect(
 	aspectId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT * FROM entity_attributes
-				 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
-				 ORDER BY importance DESC`,
-				)
-				.all(aspectId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToAttribute);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT * FROM entity_attributes
+			 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
+			 ORDER BY importance DESC`,
+			params: [aspectId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:218" },
+		{ operation: "db:knowledge.attributes-for-aspect.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAttribute);
 }
 
 /**
@@ -240,24 +236,22 @@ export async function getConstraintsForEntity(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT ea.* FROM entity_attributes ea
-				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
-				 WHERE asp.entity_id = ? AND asp.agent_id = ?
-				   AND ea.agent_id = ?
-				   AND COALESCE(asp.status, 'active') = 'active'
-				   AND ea.kind = 'constraint'
-				   AND ea.status = 'active'
-				 ORDER BY ea.importance DESC`,
-				)
-				.all(entityId, agentId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToAttribute);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT ea.* FROM entity_attributes ea
+			 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+			 WHERE asp.entity_id = ? AND asp.agent_id = ?
+			   AND ea.agent_id = ?
+			   AND COALESCE(asp.status, 'active') = 'active'
+			   AND ea.kind = 'constraint'
+			   AND ea.status = 'active'
+			 ORDER BY ea.importance DESC`,
+			params: [entityId, agentId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:243" },
+		{ operation: "db:knowledge.constraints-for-entity.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAttribute);
 }
 
 // ---------------------------------------------------------------------------
@@ -268,15 +262,15 @@ export async function getEntityDependencyById(
 	accessor: DbAccessor,
 	params: { readonly id: string; readonly agentId: string },
 ): Promise<EntityDependency | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const row = db
-				.prepare("SELECT * FROM entity_dependencies WHERE id = ? AND agent_id = ?")
-				.get(params.id, params.agentId) as Record<string, unknown> | undefined;
-			return row === undefined ? null : rowToDependency(row);
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT * FROM entity_dependencies WHERE id = ? AND agent_id = ?",
+			params: [params.id, params.agentId],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:271" },
+		{ operation: "db:knowledge.dependency-by-id.read", deadlineMs: 2_000 },
 	);
+	return row === null ? null : rowToDependency(row);
 }
 
 export async function getDependenciesFrom(
@@ -284,24 +278,22 @@ export async function getDependenciesFrom(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT dep.*
-				 FROM entity_dependencies dep
-				 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
-				 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
-				 WHERE dep.source_entity_id = ? AND dep.agent_id = ?
-				   AND COALESCE(dep.status, 'active') = 'active'
-				   AND COALESCE(src.status, 'active') = 'active'
-				   AND COALESCE(dst.status, 'active') = 'active'`,
-				)
-				.all(entityId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToDependency);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT dep.*
+			 FROM entity_dependencies dep
+			 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+			 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+			 WHERE dep.source_entity_id = ? AND dep.agent_id = ?
+			   AND COALESCE(dep.status, 'active') = 'active'
+			   AND COALESCE(src.status, 'active') = 'active'
+			   AND COALESCE(dst.status, 'active') = 'active'`,
+			params: [entityId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:287" },
+		{ operation: "db:knowledge.dependencies-from.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToDependency);
 }
 
 export async function getDependenciesTo(
@@ -309,24 +301,22 @@ export async function getDependenciesTo(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT dep.*
-				 FROM entity_dependencies dep
-				 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
-				 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
-				 WHERE dep.target_entity_id = ? AND dep.agent_id = ?
-				   AND COALESCE(dep.status, 'active') = 'active'
-				   AND COALESCE(src.status, 'active') = 'active'
-				   AND COALESCE(dst.status, 'active') = 'active'`,
-				)
-				.all(entityId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToDependency);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT dep.*
+			 FROM entity_dependencies dep
+			 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+			 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+			 WHERE dep.target_entity_id = ? AND dep.agent_id = ?
+			   AND COALESCE(dep.status, 'active') = 'active'
+			   AND COALESCE(src.status, 'active') = 'active'
+			   AND COALESCE(dst.status, 'active') = 'active'`,
+			params: [entityId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:312" },
+		{ operation: "db:knowledge.dependencies-to.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToDependency);
 }
 
 // ---------------------------------------------------------------------------
@@ -337,33 +327,23 @@ export async function getPinnedEntities(
 	accessor: DbAccessor,
 	agentId: string,
 ): Promise<ReadonlyArray<PinnedEntitySummary>> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT id, name, pinned_at
-				 FROM entities
-				 WHERE agent_id = ?
-				   AND pinned = 1
-				   AND COALESCE(status, 'active') = 'active'
-				 ORDER BY pinned_at DESC, updated_at DESC, name ASC`,
-				)
-				.all(agentId) as Array<Record<string, unknown>>;
-			return rows.flatMap((row) => {
-				if (typeof row.id !== "string" || typeof row.name !== "string") {
-					return [];
-				}
-				return [
-					{
-						id: row.id,
-						name: row.name,
-						pinnedAt: typeof row.pinned_at === "string" ? row.pinned_at : "",
-					},
-				];
-			});
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT id, name, pinned_at
+			 FROM entities
+			 WHERE agent_id = ?
+			   AND pinned = 1
+			   AND COALESCE(status, 'active') = 'active'
+			 ORDER BY pinned_at DESC, updated_at DESC, name ASC`,
+			params: [agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:340" },
+		{ operation: "db:knowledge.pinned-entities.read", deadlineMs: 2_000 },
 	);
+	return rows.flatMap((row) => {
+		if (typeof row.id !== "string" || typeof row.name !== "string") return [];
+		return [{ id: row.id, name: row.name, pinnedAt: typeof row.pinned_at === "string" ? row.pinned_at : "" }];
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -419,15 +399,15 @@ export async function upsertTaskMeta(accessor: DbAccessor, params: UpsertTaskMet
 }
 
 export async function getTaskMeta(accessor: DbAccessor, entityId: string, agentId: string): Promise<TaskMeta | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const row = db.prepare("SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?").get(entityId, agentId) as
-				| Record<string, unknown>
-				| undefined;
-			return row ? rowToTaskMeta(row) : null;
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?",
+			params: [entityId, agentId],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:422" },
+		{ operation: "db:knowledge.task-meta.read", deadlineMs: 2_000 },
 	);
+	return row ? rowToTaskMeta(row) : null;
 }
 
 export async function updateTaskStatus(
@@ -602,14 +582,18 @@ export async function resolveNamedEntity(
 	const canonical = toCanonicalName(input.name);
 	if (canonical.length === 0) return null;
 
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const escaped = canonical.replace(/\\/g, "\\\\").replace(/[%_]/g, "\\$&");
-			const starts = `${escaped}%`;
-			const contains = `%${escaped}%`;
-			const rows = db
-				.prepare(
-					`SELECT
+	const escaped = canonical.replace(/\\/g, "\\\\").replace(/[%_]/g, "\\$&");
+	const starts = `${escaped}%`;
+	const contains = `%${escaped}%`;
+	const rows = await dbOwnerQuery<{
+		readonly id: string;
+		readonly name: string;
+		readonly canonical_name: string;
+		readonly entity_type: string;
+		readonly description: string | null;
+	} | null>(
+		{
+			sql: `SELECT
 					id,
 					name,
 					COALESCE(canonical_name, LOWER(name)) AS canonical_name,
@@ -639,66 +623,71 @@ export async function resolveNamedEntity(
 				   )
 				 ORDER BY match_rank ASC, mentions DESC, updated_at DESC, name ASC
 				 LIMIT 1`,
-				)
-				.get(
-					canonical,
-					canonical,
-					starts,
-					starts,
-					contains,
-					contains,
-					input.agentId,
-					canonical,
-					canonical,
-					starts,
-					starts,
-					contains,
-					contains,
-				) as
-				| {
-						id: string;
-						name: string;
-						canonical_name: string;
-						entity_type: string;
-						description: string | null;
-				  }
-				| undefined;
-
-			if (!rows) return null;
-			return {
-				id: rows.id,
-				name: rows.name,
-				canonicalName: rows.canonical_name,
-				entityType: rows.entity_type,
-				description: rows.description,
-			};
+			params: [
+				canonical,
+				canonical,
+				starts,
+				starts,
+				contains,
+				contains,
+				input.agentId,
+				canonical,
+				canonical,
+				starts,
+				starts,
+				contains,
+				contains,
+			],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:605" },
+		{ operation: "db:knowledge.resolve-entity.read", deadlineMs: 2_000 },
 	);
+	if (!rows) return null;
+	return {
+		id: rows.id,
+		name: rows.name,
+		canonicalName: rows.canonical_name,
+		entityType: rows.entity_type,
+		description: rows.description,
+	};
 }
 
-function resolveAspectByName(
-	db: ReadDb,
-	params: {
-		readonly entityId: string;
-		readonly agentId: string;
-		readonly aspect: string;
-	},
-): EntityAspect | null {
+async function resolveEntityByNameOnOwner(
+	accessor: DbAccessor,
+	params: { readonly agentId: string; readonly name: string },
+): Promise<Entity | null> {
+	const resolved = await resolveNamedEntity(accessor, params);
+	if (!resolved) return null;
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT * FROM entities WHERE id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'",
+			params: [resolved.id, params.agentId],
+			result: "get",
+		},
+		{ operation: "db:knowledge.entity-by-name.read", deadlineMs: 2_000 },
+	);
+	return row ? rowToEntity(row) : null;
+}
+
+async function resolveAspectByNameOnOwner(params: {
+	readonly entityId: string;
+	readonly agentId: string;
+	readonly aspect: string;
+}): Promise<EntityAspect | null> {
 	const canonical = toCanonicalName(params.aspect);
 	if (canonical.length === 0) return null;
-	const row = db
-		.prepare(
-			`SELECT *
-			 FROM entity_aspects
-			 WHERE entity_id = ?
-			   AND agent_id = ?
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: `SELECT * FROM entity_aspects
+			 WHERE entity_id = ? AND agent_id = ?
 			   AND COALESCE(status, 'active') = 'active'
 			   AND (canonical_name = ? OR LOWER(name) = ?)
-			 ORDER BY weight DESC, updated_at DESC
-			 LIMIT 1`,
-		)
-		.get(params.entityId, params.agentId, canonical, canonical) as Record<string, unknown> | undefined;
+			 ORDER BY weight DESC, updated_at DESC LIMIT 1`,
+			params: [params.entityId, params.agentId, canonical, canonical],
+			result: "get",
+		},
+		{ operation: "db:knowledge.aspect-by-name.read", deadlineMs: 2_000 },
+	);
 	return row ? rowToAspect(row) : null;
 }
 
@@ -780,28 +769,23 @@ export async function listEntityAliases(
 		readonly status?: "active" | "archived" | "all";
 	},
 ): Promise<readonly EntityAlias[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const conditions = ["entity_id = ?", "agent_id = ?"];
-			const args: string[] = [params.entityId, params.agentId];
-			if (params.status && params.status !== "all") {
-				conditions.push("status = ?");
-				args.push(params.status);
-			} else if (!params.status) {
-				conditions.push("status = 'active'");
-			}
-			const rows = db
-				.prepare(
-					`SELECT *
-				 FROM entity_aliases
-				 WHERE ${conditions.join(" AND ")}
-				 ORDER BY status ASC, alias ASC`,
-				)
-				.all(...args) as Array<Record<string, unknown>>;
-			return rows.map(rowToEntityAlias);
+	const conditions = ["entity_id = ?", "agent_id = ?"];
+	const args: Array<string | number> = [params.entityId, params.agentId];
+	if (params.status && params.status !== "all") {
+		conditions.push("status = ?");
+		args.push(params.status);
+	} else if (!params.status) {
+		conditions.push("status = 'active'");
+	}
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT * FROM entity_aliases WHERE ${conditions.join(" AND ")} ORDER BY status ASC, alias ASC`,
+			params: args,
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:783" },
+		{ operation: "db:knowledge.entity-aliases.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToEntityAlias);
 }
 
 export async function getEntityAspectsByName(
@@ -811,20 +795,28 @@ export async function getEntityAspectsByName(
 		readonly entity: string;
 	},
 ): Promise<{ readonly entity: Entity; readonly items: readonly AspectWithCounts[] } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			return {
-				entity,
-				items: readEntityAspectsWithCounts(db, entity.id, params.agentId),
-			};
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT asp.*, COUNT(DISTINCT CASE WHEN attr.kind = 'attribute' AND attr.status = 'active' THEN attr.id END) AS attribute_count,
+				COUNT(DISTINCT CASE WHEN attr.kind = 'constraint' AND attr.status = 'active' THEN attr.id END) AS constraint_count
+			 FROM entity_aspects asp LEFT JOIN entity_attributes attr ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
+			 WHERE asp.entity_id = ? AND asp.agent_id = ? AND COALESCE(asp.status, 'active') = 'active'
+			 GROUP BY asp.id ORDER BY asp.weight DESC, asp.name ASC`,
+			params: [entity.id, params.agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:814" },
+		{ operation: "db:knowledge.entity-aspects-with-counts.read", deadlineMs: 2_000 },
 	);
+	return {
+		entity,
+		items: rows.map((row) => ({
+			aspect: rowToAspect(row),
+			attributeCount: Number(row.attribute_count ?? 0),
+			constraintCount: Number(row.constraint_count ?? 0),
+		})),
+	};
 }
 
 export async function getEntityKnowledgeTree(
@@ -975,7 +967,7 @@ export async function getEntityKnowledgeTree(
 				}),
 			};
 		},
-		{ siteToken: "knowledge-graph.ts:841" },
+		{ siteToken: "db:knowledge.entity-knowledge-tree.read" },
 	);
 }
 
@@ -991,22 +983,17 @@ export async function listEntityGroups(
 	readonly aspect: EntityAspect;
 	readonly items: readonly EntityGroupSummary[];
 } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			const aspect = resolveAspectByName(db, {
-				entityId: entity.id,
-				agentId: params.agentId,
-				aspect: params.aspect,
-			});
-			if (!aspect) return null;
-			const rows = db
-				.prepare(
-					`SELECT
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const aspect = await resolveAspectByNameOnOwner({
+		entityId: entity.id,
+		agentId: params.agentId,
+		aspect: params.aspect,
+	});
+	if (!aspect) return null;
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
 				   COALESCE(ea.group_key, 'general') AS group_key,
 				   COUNT(DISTINCT CASE
 				     WHEN ea.kind = 'attribute' AND ea.status = 'active' THEN ea.id
@@ -1024,22 +1011,22 @@ export async function listEntityGroups(
 				   AND ea.status != 'deleted'
 				 GROUP BY COALESCE(ea.group_key, 'general')
 				 ORDER BY attribute_count DESC, constraint_count DESC, group_key ASC`,
-				)
-				.all(aspect.id, params.agentId) as Array<Record<string, unknown>>;
-			return {
-				entity,
-				aspect,
-				items: rows.map((row) => ({
-					groupKey: row.group_key as string,
-					attributeCount: Number(row.attribute_count ?? 0),
-					constraintCount: Number(row.constraint_count ?? 0),
-					claimCount: Number(row.claim_count ?? 0),
-					latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
-				})),
-			};
+			params: [aspect.id, params.agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:994" },
+		{ operation: "db:knowledge.entity-groups.read", deadlineMs: 2_000 },
 	);
+	return {
+		entity,
+		aspect,
+		items: rows.map((row) => ({
+			groupKey: row.group_key as string,
+			attributeCount: Number(row.attribute_count ?? 0),
+			constraintCount: Number(row.constraint_count ?? 0),
+			claimCount: Number(row.claim_count ?? 0),
+			latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
+		})),
+	};
 }
 
 export async function listEntityClaims(
@@ -1055,23 +1042,18 @@ export async function listEntityClaims(
 	readonly aspect: EntityAspect;
 	readonly items: readonly EntityClaimSummary[];
 } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			const aspect = resolveAspectByName(db, {
-				entityId: entity.id,
-				agentId: params.agentId,
-				aspect: params.aspect,
-			});
-			if (!aspect) return null;
-			const group = toCanonicalName(params.group).replace(/\s+/g, "_");
-			const rows = db
-				.prepare(
-					`SELECT
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const aspect = await resolveAspectByNameOnOwner({
+		entityId: entity.id,
+		agentId: params.agentId,
+		aspect: params.aspect,
+	});
+	if (!aspect) return null;
+	const group = toCanonicalName(params.group).replace(/\s+/g, "_");
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
 				   ea.claim_key,
 				   ea.group_key,
 				   COUNT(DISTINCT CASE WHEN ea.kind = 'attribute' THEN ea.id END) AS attribute_count,
@@ -1098,25 +1080,25 @@ export async function listEntityClaims(
 				   AND ea.status != 'deleted'
 				 GROUP BY ea.claim_key, COALESCE(ea.group_key, 'general')
 				 ORDER BY active_count DESC, latest_updated_at DESC, ea.claim_key ASC`,
-				)
-				.all(aspect.id, params.agentId, group.length > 0 ? group : "general") as Array<Record<string, unknown>>;
-			return {
-				entity,
-				aspect,
-				items: rows.map((row) => ({
-					claimKey: row.claim_key as string,
-					groupKey: typeof row.group_key === "string" ? row.group_key : null,
-					attributeCount: Number(row.attribute_count ?? 0),
-					constraintCount: Number(row.constraint_count ?? 0),
-					activeCount: Number(row.active_count ?? 0),
-					supersededCount: Number(row.superseded_count ?? 0),
-					latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
-					preview: typeof row.preview === "string" ? row.preview : null,
-				})),
-			};
+			params: [aspect.id, params.agentId, group.length > 0 ? group : "general"],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1058" },
+		{ operation: "db:knowledge.entity-claims.read", deadlineMs: 2_000 },
 	);
+	return {
+		entity,
+		aspect,
+		items: rows.map((row) => ({
+			claimKey: row.claim_key as string,
+			groupKey: typeof row.group_key === "string" ? row.group_key : null,
+			attributeCount: Number(row.attribute_count ?? 0),
+			constraintCount: Number(row.constraint_count ?? 0),
+			activeCount: Number(row.active_count ?? 0),
+			supersededCount: Number(row.superseded_count ?? 0),
+			latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
+			preview: typeof row.preview === "string" ? row.preview : null,
+		})),
+	};
 }
 
 export async function listEntityAttributesByPath(
@@ -1137,58 +1119,49 @@ export async function listEntityAttributesByPath(
 	readonly aspect: EntityAspect;
 	readonly items: readonly EntityAttribute[];
 } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			const aspect = resolveAspectByName(db, {
-				entityId: entity.id,
-				agentId: params.agentId,
-				aspect: params.aspect,
-			});
-			if (!aspect) return null;
-			const group = toCanonicalName(params.group).replace(/\s+/g, "_");
-			const claim = toCanonicalName(params.claim).replace(/\s+/g, "_");
-			if (claim.length === 0) return { entity, aspect, items: [] };
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const aspect = await resolveAspectByNameOnOwner({
+		entityId: entity.id,
+		agentId: params.agentId,
+		aspect: params.aspect,
+	});
+	if (!aspect) return null;
+	const group = toCanonicalName(params.group).replace(/\s+/g, "_");
+	const claim = toCanonicalName(params.claim).replace(/\s+/g, "_");
+	if (claim.length === 0) return { entity, aspect, items: [] };
 
-			const conditions = [
-				"ea.aspect_id = ?",
-				"ea.agent_id = ?",
-				"COALESCE(ea.group_key, 'general') = ?",
-				"ea.claim_key = ?",
-			];
-			const args: Array<string | number> = [aspect.id, params.agentId, group.length > 0 ? group : "general", claim];
-			if (params.kind) {
-				conditions.push("ea.kind = ?");
-				args.push(params.kind);
-			}
-			if (params.status && params.status !== "all") {
-				conditions.push("ea.status = ?");
-				args.push(params.status);
-			} else if (!params.status) {
-				conditions.push("ea.status = 'active'");
-			}
+	const conditions = [
+		"ea.aspect_id = ?",
+		"ea.agent_id = ?",
+		"COALESCE(ea.group_key, 'general') = ?",
+		"ea.claim_key = ?",
+	];
+	const args: Array<string | number> = [aspect.id, params.agentId, group.length > 0 ? group : "general", claim];
+	if (params.kind) {
+		conditions.push("ea.kind = ?");
+		args.push(params.kind);
+	}
+	if (params.status && params.status !== "all") {
+		conditions.push("ea.status = ?");
+		args.push(params.status);
+	} else if (!params.status) {
+		conditions.push("ea.status = 'active'");
+	}
 
-			const rows = db
-				.prepare(
-					`SELECT ea.*
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT ea.*
 				 FROM entity_attributes ea
 				 WHERE ${conditions.join(" AND ")}
 				 ORDER BY ea.created_at DESC, ea.importance DESC
 				 LIMIT ? OFFSET ?`,
-				)
-				.all(...args, params.limit, params.offset) as Array<Record<string, unknown>>;
-			return {
-				entity,
-				aspect,
-				items: rows.map(rowToAttribute),
-			};
+			params: [...args, params.limit, params.offset],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1140" },
+		{ operation: "db:knowledge.attributes-by-path.read", deadlineMs: 2_000 },
 	);
+	return { entity, aspect, items: rows.map(rowToAttribute) };
 }
 
 export async function listKnowledgeEntities(
@@ -1201,27 +1174,25 @@ export async function listKnowledgeEntities(
 		readonly offset: number;
 	},
 ): Promise<readonly KnowledgeEntityListItem[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const conditions = ["e.agent_id = ?"];
-			const args: Array<string | number> = [params.agentId];
-			conditions.push("COALESCE(e.status, 'active') = 'active'");
-			if (params.type) {
-				conditions.push("e.entity_type = ?");
-				args.push(params.type);
-			}
-			if (params.query) {
-				conditions.push("e.canonical_name LIKE ?");
-				args.push(`%${params.query.trim().toLowerCase()}%`);
-			}
+	const conditions = ["e.agent_id = ?"];
+	const args: Array<string | number> = [params.agentId];
+	conditions.push("COALESCE(e.status, 'active') = 'active'");
+	if (params.type) {
+		conditions.push("e.entity_type = ?");
+		args.push(params.type);
+	}
+	if (params.query) {
+		conditions.push("e.canonical_name LIKE ?");
+		args.push(`%${params.query.trim().toLowerCase()}%`);
+	}
 
-			// Paginate entity IDs first, then compute counts only for the page.
-			// This avoids materializing GROUP BY + ORDER BY across every entity in
-			// the agent scope before LIMIT can apply, which is prohibitive on graphs
-			// with tens of thousands of entities. See Signet-AI/signetai#515.
-			const rows = db
-				.prepare(
-					`WITH page AS (
+	// Paginate entity IDs first, then compute counts only for the page.
+	// This avoids materializing GROUP BY + ORDER BY across every entity in
+	// the agent scope before LIMIT can apply, which is prohibitive on graphs
+	// with tens of thousands of entities. See Signet-AI/signetai#515.
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `WITH page AS (
 					SELECT e.id
 					FROM entities e
 					WHERE ${conditions.join(" AND ")}
@@ -1268,19 +1239,19 @@ export async function listKnowledgeEntities(
 				 FROM page p
 				 JOIN entities e ON e.id = p.id
 				 ORDER BY e.pinned DESC, e.pinned_at DESC, e.mentions DESC, e.updated_at DESC, e.name ASC`,
-				)
-				.all(...args, params.limit, params.offset) as Array<Record<string, unknown>>;
-
-			return rows.map((row) => ({
-				entity: rowToEntity(row),
-				aspectCount: Number(row.aspect_count ?? 0),
-				attributeCount: Number(row.attribute_count ?? 0),
-				constraintCount: Number(row.constraint_count ?? 0),
-				dependencyCount: Number(row.dependency_count ?? 0),
-			}));
+			params: [...args, params.limit, params.offset],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1204" },
+		{ operation: "db:knowledge.entities-list.read", deadlineMs: 2_000 },
 	);
+
+	return rows.map((row) => ({
+		entity: rowToEntity(row),
+		aspectCount: Number(row.aspect_count ?? 0),
+		attributeCount: Number(row.attribute_count ?? 0),
+		constraintCount: Number(row.constraint_count ?? 0),
+		dependencyCount: Number(row.dependency_count ?? 0),
+	}));
 }
 
 export async function getKnowledgeEntityDetail(
@@ -1288,15 +1259,9 @@ export async function getKnowledgeEntityDetail(
 	entityId: string,
 	agentId: string,
 ): Promise<KnowledgeEntityDetail | null> {
-	const row = await accessor.withReadDbAsync(
-		(db) => {
-			// Scalar subqueries per count avoid GROUP BY materialization across
-			// the (LEFT JOIN aspects x attributes x dependencies) cartesian, which
-			// produces the same pathological shape as listKnowledgeEntities even
-			// when filtered to a single entity id. See Signet-AI/signetai#515.
-			return db
-				.prepare(
-					`SELECT
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: `SELECT
 					e.*,
 					(
 						SELECT COUNT(*) FROM entity_aspects asp
@@ -1339,13 +1304,13 @@ export async function getKnowledgeEntityDetail(
 						  AND COALESCE(src.status, 'active') = 'active'
 						  AND dep.target_entity_id = e.id
 					) AS incoming_dependency_count
-				 FROM entities e
-				 WHERE e.id = ? AND e.agent_id = ?
-				   AND COALESCE(e.status, 'active') = 'active'`,
-				)
-				.get(entityId, agentId) as Record<string, unknown> | undefined;
+			 FROM entities e
+			 WHERE e.id = ? AND e.agent_id = ?
+			   AND COALESCE(e.status, 'active') = 'active'`,
+			params: [entityId, agentId],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:1291" },
+		{ operation: "db:knowledge.entity-detail.read", deadlineMs: 2_000 },
 	);
 
 	if (!row) return null;
@@ -1365,10 +1330,14 @@ export async function getKnowledgeEntityDetail(
 	};
 }
 
-function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: string): readonly AspectWithCounts[] {
-	const rows = db
-		.prepare(
-			`SELECT
+export async function getEntityAspectsWithCounts(
+	_accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): Promise<readonly AspectWithCounts[]> {
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
 				asp.*,
 				COUNT(DISTINCT CASE
 					WHEN attr.kind = 'attribute' AND attr.status = 'active' THEN attr.id
@@ -1383,8 +1352,11 @@ function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: stri
 			   AND COALESCE(asp.status, 'active') = 'active'
 			 GROUP BY asp.id
 			 ORDER BY asp.weight DESC, asp.name ASC`,
-		)
-		.all(entityId, agentId) as Array<Record<string, unknown>>;
+			params: [entityId, agentId],
+			result: "all",
+		},
+		{ operation: "db:knowledge.aspects-with-counts.read", deadlineMs: 2_000 },
+	);
 
 	return rows.map((row) => ({
 		aspect: rowToAspect(row),
@@ -1393,18 +1365,8 @@ function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: stri
 	}));
 }
 
-export async function getEntityAspectsWithCounts(
-	accessor: DbAccessor,
-	entityId: string,
-	agentId: string,
-): Promise<readonly AspectWithCounts[]> {
-	return await accessor.withReadDbAsync(async (db) => readEntityAspectsWithCounts(db, entityId, agentId), {
-		siteToken: "knowledge-graph.ts:1401",
-	});
-}
-
 export async function getAttributesForAspectFiltered(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly entityId: string;
 		readonly aspectId: string;
@@ -1415,99 +1377,95 @@ export async function getAttributesForAspectFiltered(
 		readonly offset: number;
 	},
 ): Promise<readonly EntityAttribute[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const conditions = [
-				"asp.entity_id = ?",
-				"asp.id = ?",
-				"asp.agent_id = ?",
-				"ea.agent_id = ?",
-				"COALESCE(e.status, 'active') = 'active'",
-				"COALESCE(asp.status, 'active') = 'active'",
-			];
-			const args: Array<string | number> = [params.entityId, params.aspectId, params.agentId, params.agentId];
-			if (params.kind) {
-				conditions.push("ea.kind = ?");
-				args.push(params.kind);
-			}
-			if (params.status) {
-				conditions.push("ea.status = ?");
-				args.push(params.status);
-			}
+	const conditions = [
+		"asp.entity_id = ?",
+		"asp.id = ?",
+		"asp.agent_id = ?",
+		"ea.agent_id = ?",
+		"COALESCE(e.status, 'active') = 'active'",
+		"COALESCE(asp.status, 'active') = 'active'",
+	];
+	const args: Array<string | number> = [params.entityId, params.aspectId, params.agentId, params.agentId];
+	if (params.kind) {
+		conditions.push("ea.kind = ?");
+		args.push(params.kind);
+	}
+	if (params.status) {
+		conditions.push("ea.status = ?");
+		args.push(params.status);
+	}
 
-			const rows = db
-				.prepare(
-					`SELECT ea.*
-				 FROM entity_attributes ea
-				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
-				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
-				 WHERE ${conditions.join(" AND ")}
-				 ORDER BY ea.importance DESC, ea.created_at DESC
-				 LIMIT ? OFFSET ?`,
-				)
-				.all(...args, params.limit, params.offset) as Array<Record<string, unknown>>;
-			return rows.map(rowToAttribute);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT ea.*
+			 FROM entity_attributes ea
+			 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+			 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+			 WHERE ${conditions.join(" AND ")}
+			 ORDER BY ea.importance DESC, ea.created_at DESC
+			 LIMIT ? OFFSET ?`,
+			params: [...args, params.limit, params.offset],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1418" },
+		{ operation: "db:knowledge.attributes-filtered.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAttribute);
 }
 
 export async function getEntityDependenciesDetailed(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly entityId: string;
 		readonly agentId: string;
 		readonly direction: "incoming" | "outgoing" | "both";
 	},
 ): Promise<readonly KnowledgeDependencyEdge[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const directionClauses: string[] = [];
-			if (params.direction === "incoming" || params.direction === "both") {
-				directionClauses.push("dep.target_entity_id = ?");
-			}
-			if (params.direction === "outgoing" || params.direction === "both") {
-				directionClauses.push("dep.source_entity_id = ?");
-			}
-			const rows = db
-				.prepare(
-					`SELECT
-					dep.*,
-					src.name AS source_entity_name,
-					dst.name AS target_entity_name
-				 FROM entity_dependencies dep
-				 JOIN entities src ON src.id = dep.source_entity_id
-				 JOIN entities dst ON dst.id = dep.target_entity_id
-				 WHERE dep.agent_id = ?
-				   AND (${directionClauses.join(" OR ")})
-				   AND COALESCE(dep.status, 'active') = 'active'
-				   AND COALESCE(src.status, 'active') = 'active'
-				   AND COALESCE(dst.status, 'active') = 'active'
-				 ORDER BY dep.strength DESC, dep.updated_at DESC`,
-				)
-				.all(
-					params.agentId,
-					...(params.direction === "incoming" || params.direction === "both" ? [params.entityId] : []),
-					...(params.direction === "outgoing" || params.direction === "both" ? [params.entityId] : []),
-				) as Array<Record<string, unknown>>;
-
-			return rows.map((row) => ({
-				id: row.id as string,
-				direction: row.source_entity_id === params.entityId ? "outgoing" : "incoming",
-				dependencyType: row.dependency_type as string,
-				strength: Number(row.strength ?? 0),
-				aspectId: (row.aspect_id as string) ?? null,
-				reason: typeof row.reason === "string" ? row.reason : null,
-				sourceEntityId: row.source_entity_id as string,
-				sourceEntityName: row.source_entity_name as string,
-				targetEntityId: row.target_entity_id as string,
-				targetEntityName: row.target_entity_name as string,
-				createdAt: row.created_at as string,
-				updatedAt: row.updated_at as string,
-			}));
+	const directionClauses: string[] = [];
+	if (params.direction === "incoming" || params.direction === "both") {
+		directionClauses.push("dep.target_entity_id = ?");
+	}
+	if (params.direction === "outgoing" || params.direction === "both") {
+		directionClauses.push("dep.source_entity_id = ?");
+	}
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
+				dep.*,
+				src.name AS source_entity_name,
+				dst.name AS target_entity_name
+			 FROM entity_dependencies dep
+			 JOIN entities src ON src.id = dep.source_entity_id
+			 JOIN entities dst ON dst.id = dep.target_entity_id
+			 WHERE dep.agent_id = ?
+			   AND (${directionClauses.join(" OR ")})
+			   AND COALESCE(dep.status, 'active') = 'active'
+			   AND COALESCE(src.status, 'active') = 'active'
+			   AND COALESCE(dst.status, 'active') = 'active'
+			 ORDER BY dep.strength DESC, dep.updated_at DESC`,
+			params: [
+				params.agentId,
+				...(params.direction === "incoming" || params.direction === "both" ? [params.entityId] : []),
+				...(params.direction === "outgoing" || params.direction === "both" ? [params.entityId] : []),
+			],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1463" },
+		{ operation: "db:knowledge.dependencies-detailed.read", deadlineMs: 2_000 },
 	);
+
+	return rows.map((row) => ({
+		id: row.id as string,
+		direction: row.source_entity_id === params.entityId ? "outgoing" : "incoming",
+		dependencyType: row.dependency_type as string,
+		strength: Number(row.strength ?? 0),
+		aspectId: (row.aspect_id as string) ?? null,
+		reason: typeof row.reason === "string" ? row.reason : null,
+		sourceEntityId: row.source_entity_id as string,
+		sourceEntityName: row.source_entity_name as string,
+		targetEntityId: row.target_entity_id as string,
+		targetEntityName: row.target_entity_name as string,
+		createdAt: row.created_at as string,
+		updatedAt: row.updated_at as string,
+	}));
 }
 
 export async function getKnowledgeStats(_accessor: DbAccessor, agentId: string): Promise<KnowledgeStats> {
@@ -1594,96 +1552,99 @@ export async function getKnowledgeStats(_accessor: DbAccessor, agentId: string):
 }
 
 export async function getEntityHealth(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	agentId: string,
 	since?: string,
 	minComparisons = 3,
 ): Promise<ReadonlyArray<EntityHealth>> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const predictorTable = db
-				.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'predictor_comparisons'")
-				.get() as { name: string } | undefined;
-			if (!predictorTable) return [];
-
-			const args: Array<string | number> = [agentId];
-			const sinceClause = typeof since === "string" && since.length > 0 ? " AND created_at >= ?" : "";
-			if (sinceClause && since !== undefined) {
-				args.push(since);
-			}
-
-			const rows = db
-				.prepare(
-					`SELECT
-					focal_entity_id,
-					COALESCE(focal_entity_name, '') AS focal_entity_name,
-					predictor_won,
-					margin,
-					created_at
-				 FROM predictor_comparisons
-				 WHERE agent_id = ?
-				   AND focal_entity_id IS NOT NULL
-				   ${sinceClause}
-				 ORDER BY focal_entity_id ASC, created_at ASC`,
-				)
-				.all(...args) as Array<Record<string, unknown>>;
-
-			const grouped = new Map<
-				string,
-				Array<{
-					readonly entityName: string;
-					readonly predictorWon: number;
-					readonly margin: number;
-				}>
-			>();
-			for (const row of rows) {
-				if (typeof row.focal_entity_id !== "string") continue;
-				const bucket = grouped.get(row.focal_entity_id) ?? [];
-				bucket.push({
-					entityName:
-						typeof row.focal_entity_name === "string" && row.focal_entity_name.length > 0
-							? row.focal_entity_name
-							: row.focal_entity_id,
-					predictorWon: Number(row.predictor_won ?? 0),
-					margin: Number(row.margin ?? 0),
-				});
-				grouped.set(row.focal_entity_id, bucket);
-			}
-
-			const health: EntityHealth[] = [];
-			for (const [entityId, comparisons] of grouped) {
-				if (comparisons.length < minComparisons) continue;
-
-				const wins = comparisons.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0);
-				const avgMargin = comparisons.reduce((total, row) => total + row.margin, 0) / comparisons.length;
-				const midpoint = Math.max(1, Math.floor(comparisons.length / 2));
-				const firstHalf = comparisons.slice(0, midpoint);
-				const secondHalf = comparisons.slice(midpoint);
-				const firstHalfRate =
-					firstHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / firstHalf.length;
-				const secondHalfRate =
-					secondHalf.length > 0
-						? secondHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / secondHalf.length
-						: firstHalfRate;
-				const rateDelta = secondHalfRate - firstHalfRate;
-				health.push({
-					entityId,
-					entityName: comparisons[0]?.entityName ?? entityId,
-					comparisonCount: comparisons.length,
-					winRate: wins / comparisons.length,
-					avgMargin,
-					trend: rateDelta > 0.1 ? "improving" : rateDelta < -0.1 ? "declining" : "stable",
-				});
-			}
-
-			health.sort((a, b) => {
-				if (b.winRate !== a.winRate) return b.winRate - a.winRate;
-				return b.comparisonCount - a.comparisonCount;
-			});
-			return health;
+	const predictorTable = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'predictor_comparisons'",
+			params: [],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:1602" },
+		{ operation: "db:knowledge.predictor-table.read", deadlineMs: 2_000 },
 	);
+	if (predictorTable === null) return [];
+
+	const args: Array<string | number> = [agentId];
+	const sinceClause = typeof since === "string" && since.length > 0 ? " AND created_at >= ?" : "";
+	if (sinceClause && since !== undefined) {
+		args.push(since);
+	}
+
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
+			focal_entity_id,
+			COALESCE(focal_entity_name, '') AS focal_entity_name,
+			predictor_won,
+			margin,
+			created_at
+		 FROM predictor_comparisons
+		 WHERE agent_id = ?
+		   AND focal_entity_id IS NOT NULL
+		   ${sinceClause}
+		 ORDER BY focal_entity_id ASC, created_at ASC`,
+			params: args,
+			result: "all",
+		},
+		{ operation: "db:knowledge.entity-health.read", deadlineMs: 2_000 },
+	);
+
+	const grouped = new Map<
+		string,
+		Array<{
+			readonly entityName: string;
+			readonly predictorWon: number;
+			readonly margin: number;
+		}>
+	>();
+	for (const row of rows) {
+		if (typeof row.focal_entity_id !== "string") continue;
+		const bucket = grouped.get(row.focal_entity_id) ?? [];
+		bucket.push({
+			entityName:
+				typeof row.focal_entity_name === "string" && row.focal_entity_name.length > 0
+					? row.focal_entity_name
+					: row.focal_entity_id,
+			predictorWon: Number(row.predictor_won ?? 0),
+			margin: Number(row.margin ?? 0),
+		});
+		grouped.set(row.focal_entity_id, bucket);
+	}
+
+	const health: EntityHealth[] = [];
+	for (const [entityId, comparisons] of grouped) {
+		if (comparisons.length < minComparisons) continue;
+
+		const wins = comparisons.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0);
+		const avgMargin = comparisons.reduce((total, row) => total + row.margin, 0) / comparisons.length;
+		const midpoint = Math.max(1, Math.floor(comparisons.length / 2));
+		const firstHalf = comparisons.slice(0, midpoint);
+		const secondHalf = comparisons.slice(midpoint);
+		const firstHalfRate =
+			firstHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / firstHalf.length;
+		const secondHalfRate =
+			secondHalf.length > 0
+				? secondHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / secondHalf.length
+				: firstHalfRate;
+		const rateDelta = secondHalfRate - firstHalfRate;
+		health.push({
+			entityId,
+			entityName: comparisons[0]?.entityName ?? entityId,
+			comparisonCount: comparisons.length,
+			winRate: wins / comparisons.length,
+			avgMargin,
+			trend: rateDelta > 0.1 ? "improving" : rateDelta < -0.1 ? "declining" : "stable",
+		});
+	}
+
+	health.sort((a, b) => {
+		if (b.winRate !== a.winRate) return b.winRate - a.winRate;
+		return b.comparisonCount - a.comparisonCount;
+	});
+	return health;
 }
 
 export async function propagateMemoryStatus(accessor: DbAccessor, agentId: string): Promise<number> {
@@ -2224,7 +2185,7 @@ export async function getKnowledgeGraphForConstellation(
 				},
 			};
 		},
-		{ siteToken: "knowledge-graph.ts:1984" },
+		{ siteToken: "db:knowledge.graph-constellation.read" },
 	);
 }
 

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -25,7 +25,7 @@ import { getDbAccessorPath, type DbAccessor, type ReadDb } from "./db-accessor";
 import { dbOwnerQuery, getDbOwner } from "./db-owner-runtime";
 import { ownerReadOne } from "./db-owner-sql";
 import { runWriteTxAsync } from "./db-accessor";
-import { getDreamingEpisodicTokenBacklogCached } from "./pipeline/dreaming";
+import { getDreamingEpisodicTokenBacklogCached } from "./pipeline/dreaming-token-cache";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/platform/daemon/src/pipeline/dreaming-token-cache.ts
+++ b/platform/daemon/src/pipeline/dreaming-token-cache.ts
@@ -71,6 +71,10 @@ export class DreamingBacklogTokenCache {
 		return this.values.get(agentId) ?? 0;
 	}
 
+	record(agentId: string, count: number): void {
+		this.values.set(agentId, count);
+	}
+
 	hasValue(agentId: string): boolean {
 		return this.values.has(agentId);
 	}
@@ -155,4 +159,21 @@ export class DreamingBacklogTokenCache {
 		this.worker = worker;
 		return worker;
 	}
+}
+
+const dreamingBacklogTokenCache = new DreamingBacklogTokenCache();
+
+export function refreshDreamingBacklogTokenCache(
+	agentId: string,
+	entries: readonly DreamingBacklogTokenEntry[],
+): Promise<number> {
+	return dreamingBacklogTokenCache.refresh(agentId, entries);
+}
+
+export function getDreamingEpisodicTokenBacklogCached(agentId: string): number {
+	return dreamingBacklogTokenCache.get(agentId);
+}
+
+export function recordDreamingEpisodicTokenBacklog(agentId: string, count: number): void {
+	dreamingBacklogTokenCache.record(agentId, count);
 }

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -77,7 +77,11 @@ import {
 	type DreamingSurprisalSelection,
 	selectDreamingSurprisalInDb,
 } from "./dreaming-surprisal";
-import { DreamingBacklogTokenCache, type DreamingBacklogTokenEntry } from "./dreaming-token-cache";
+import {
+	type DreamingBacklogTokenEntry,
+	recordDreamingEpisodicTokenBacklog,
+	refreshDreamingBacklogTokenCache,
+} from "./dreaming-token-cache";
 import {
 	dreamingLiveEvents,
 	publishDreamingAgentEvent,
@@ -2199,8 +2203,6 @@ export function finalizeDreamingPassInDb(db: WriteDb, input: DbOwnerDreamingPass
 export const DREAMING_FAILURE_HALT_THRESHOLD = 5;
 export const DREAMING_HALT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 export const DREAMING_SCHEDULE_BACKLOG_MAX_SOURCES = 50;
-const dreamingBacklogTokenCache = new DreamingBacklogTokenCache();
-
 export function isDreamingScopeHalted(state: DreamingState, nowMs = Date.now()): boolean {
 	if (state.consecutiveFailures < DREAMING_FAILURE_HALT_THRESHOLD) return false;
 	const failedAt = state.lastFailureAt === null ? Number.NaN : Date.parse(state.lastFailureAt);
@@ -2300,9 +2302,9 @@ function readDreamingEpisodicTokenBacklogEntriesInDb(
  */
 export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string, maxSources?: number): Promise<number> {
 	const read = readDreamingEpisodicTokenBacklogEntriesInDb(db, agentId, maxSources);
-	return dreamingBacklogTokenCache
-		.refresh(agentId, read.entries)
-		.then((count) => (read.truncated ? Number.MAX_SAFE_INTEGER : count));
+	return refreshDreamingBacklogTokenCache(agentId, read.entries).then((count) =>
+		read.truncated ? Number.MAX_SAFE_INTEGER : count,
+	);
 }
 
 export async function getDreamingEpisodicTokenBacklog(
@@ -2320,15 +2322,12 @@ export async function getDreamingEpisodicTokenBacklog(
 		estimatedWorkUnits: maxSources === undefined ? DB_OWNER_MAX_WORK_UNITS : maxSources * 10,
 	};
 	if (ownerMaintenance) return await ownerMaintenance.dreamingEpisodicBacklog(input, options);
-	return await runDbOwnerDomainOperation(accessor, {
+	const count = await runDbOwnerDomainOperation(accessor, {
 		runWithOwner: async (owner) => await ownerDreamingEpisodicBacklog(owner, input, options),
 		runInline: ({ read }) => read((db) => getDreamingEpisodicTokenBacklogInDb(db, input.agentId, input.maxSources)),
 	});
-}
-
-/** Read the last worker-computed value for synchronous dashboard metadata. */
-export function getDreamingEpisodicTokenBacklogCached(agentId: string): number {
-	return dreamingBacklogTokenCache.get(agentId);
+	recordDreamingEpisodicTokenBacklog(agentId, count);
+	return count;
 }
 
 export async function shouldTriggerDreaming(

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -9,7 +9,7 @@
  * another cycle starts.
  */
 
-import type { DbAccessor } from "../db-accessor";
+import type { DbAccessor, SyncDbCallSiteToken } from "../db-accessor";
 import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import { ownerQueryAll, ownerQueryOne } from "../db-owner-maintenance";
 import { reclaimIncrementalVacuum } from "../db-vacuum-worker";
@@ -146,7 +146,7 @@ async function getGraphAgentIds(
 				sql,
 			)
 		: await accessor.withReadDbAsync((db) => db.prepare(sql).all() as Array<{ agent_id: string | null }>, {
-				siteToken: "pipeline/maintenance-worker.ts:148",
+				siteToken: "db:maintenance.graph-agent-scopes.read",
 			});
 	const ids = rows.flatMap((row) =>
 		typeof row.agent_id === "string" && row.agent_id.length > 0 ? [row.agent_id] : [],
@@ -338,7 +338,7 @@ export function startMaintenanceWorker(
 	};
 
 	async function doTick(): Promise<MaintenanceCycleResult> {
-		const readDiagnostics = async (siteToken: string): Promise<DiagnosticsReport> =>
+		const readDiagnostics = async (siteToken: SyncDbCallSiteToken): Promise<DiagnosticsReport> =>
 			deps.ownerMaintenance
 				? await deps.ownerMaintenance.diagnostics(tracker.stats)
 				: // Each caller supplies the original static token for this compatibility fallback.
@@ -499,7 +499,7 @@ export function startMaintenanceWorker(
 										DEAD_MEMORY_DEFAULT_ACCESS_DAYS,
 									) as { n: number }
 							).n,
-						{ siteToken: "pipeline/maintenance-worker.ts:485" },
+						{ siteToken: "db:maintenance.dead-memory-count.read" },
 					);
 			const count = typeof countRow === "number" ? countRow : (countRow?.n ?? 0);
 			if (count > 100) {

--- a/platform/daemon/src/sync-db-attribution.test.ts
+++ b/platform/daemon/src/sync-db-attribution.test.ts
@@ -33,6 +33,13 @@ describe("sync DB attribution", () => {
 		void token;
 	});
 
+	test("latches a stable semantic ID without a source line", () => {
+		const token = beginSyncDbCall("withReadDb", 1_000, "db:vacuum.status.read");
+
+		expect(getSyncDbCallSitesForWindow(1_000, 2_000)).toEqual(["withReadDb@db:vacuum.status.read"]);
+		void token;
+	});
+
 	test("keeps an invalid site token explicitly unattributed", () => {
 		const token = beginSyncDbCall("withReadDb", 1_000, "not-a-site");
 		endSyncDbCall(token, 1_051);

--- a/platform/daemon/src/sync-db-attribution.ts
+++ b/platform/daemon/src/sync-db-attribution.ts
@@ -10,6 +10,10 @@
  * retained.
  */
 
+import { classifySyncDbSiteToken, type SyncDbCallSiteToken } from "./sync-db-site-token";
+
+export type { SyncDbCallSiteToken } from "./sync-db-site-token";
+
 export type SyncDbCallKind =
 	| "withReadDb"
 	| "withWriteTx"
@@ -19,8 +23,6 @@ export type SyncDbCallKind =
 	| "checkpointWalAsync"
 	| "incrementalVacuumAsync"
 	| "vacuumConversionAsync";
-export type SyncDbCallSiteToken = string;
-
 export interface SyncDbCallToken {
 	readonly sequence: number;
 	readonly siteId: string;
@@ -136,8 +138,9 @@ function resolveSiteToken(siteToken: SyncDbCallSiteToken | undefined): string {
 	if (siteToken === undefined) return UNATTRIBUTED_SITE;
 	const cached = siteTokenCache.get(siteToken);
 	if (cached !== undefined) return cached;
-	if (!/^[^:]+(?:\/[^:]+)*:\d+$/.test(siteToken)) return UNATTRIBUTED_SITE;
-	const resolved = `${SITE_TOKEN_PREFIX}${siteToken}`;
+	const kind = classifySyncDbSiteToken(siteToken);
+	if (kind === null) return UNATTRIBUTED_SITE;
+	const resolved = kind === "semantic" ? siteToken : `${SITE_TOKEN_PREFIX}${siteToken}`;
 	siteTokenCache.set(siteToken, resolved);
 	return resolved;
 }
@@ -255,7 +258,8 @@ export function captureSyncDbCallSiteToken(): SyncDbCallSiteToken | undefined {
 	const site = captureCallerSite();
 	if (site === UNATTRIBUTED_SITE) return undefined;
 	const prefixIndex = site.lastIndexOf(SITE_TOKEN_PREFIX);
-	return prefixIndex >= 0 ? site.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : site;
+	const token = prefixIndex >= 0 ? site.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : site;
+	return classifySyncDbSiteToken(token) === null ? undefined : (token as SyncDbCallSiteToken);
 }
 
 /** Return site ids whose synchronous interval overlapped the observed stall. */

--- a/platform/daemon/src/sync-db-site-token.ts
+++ b/platform/daemon/src/sync-db-site-token.ts
@@ -1,0 +1,18 @@
+export type SyncDbSourceLocationToken = `${string}:${number}`;
+export type SyncDbSemanticSiteToken = `db:${string}.${string}.${string}`;
+export type SyncDbCallSiteToken = SyncDbSourceLocationToken | SyncDbSemanticSiteToken;
+
+const SOURCE_LOCATION_TOKEN = /^[^:\s]+(?:\/[^:\s]+)*:\d+$/;
+const SEMANTIC_TOKEN = /^db:[a-z0-9]+(?:[.-][a-z0-9]+){2,}$/;
+
+export type SyncDbSiteTokenKind = "source-location" | "semantic";
+
+export function classifySyncDbSiteToken(token: string): SyncDbSiteTokenKind | null {
+	if (SOURCE_LOCATION_TOKEN.test(token)) return "source-location";
+	if (SEMANTIC_TOKEN.test(token)) return "semantic";
+	return null;
+}
+
+export function isSemanticSyncDbSiteToken(token: string | null): token is SyncDbSemanticSiteToken {
+	return token !== null && classifySyncDbSiteToken(token) === "semantic";
+}

--- a/platform/daemon/src/sync-db-site-token.ts
+++ b/platform/daemon/src/sync-db-site-token.ts
@@ -2,7 +2,7 @@ export type SyncDbSourceLocationToken = `${string}:${number}`;
 export type SyncDbSemanticSiteToken = `db:${string}.${string}.${string}`;
 export type SyncDbCallSiteToken = SyncDbSourceLocationToken | SyncDbSemanticSiteToken;
 
-const SOURCE_LOCATION_TOKEN = /^[^:\s]+(?:\/[^:\s]+)*:\d+$/;
+const SOURCE_LOCATION_TOKEN = /^[^:/\s]+(?:\/[^:/\s]+)*:\d+$/;
 const SEMANTIC_TOKEN = /^db:[a-z0-9]+(?:[.-][a-z0-9]+){2,}$/;
 
 export type SyncDbSiteTokenKind = "source-location" | "semantic";

--- a/platform/native/Cargo.lock
+++ b/platform/native/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "signet-native"
-version = "0.214.35"
+version = "0.214.36"
 dependencies = [
  "napi",
  "napi-build",

--- a/platform/native/Cargo.lock
+++ b/platform/native/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "signet-native"
-version = "0.214.36"
+version = "0.214.37"
 dependencies = [
  "napi",
  "napi-build",

--- a/platform/native/Cargo.toml
+++ b/platform/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-native"
-version = "0.214.35"
+version = "0.214.36"
 edition = "2021"
 license = "Apache-2.0"
 description = "Signet native accelerators (napi-rs)"

--- a/platform/native/Cargo.toml
+++ b/platform/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-native"
-version = "0.214.36"
+version = "0.214.37"
 edition = "2021"
 license = "Apache-2.0"
 description = "Signet native accelerators (napi-rs)"

--- a/platform/native/package.json
+++ b/platform/native/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/native",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"private": true,
 	"description": "Signet native accelerators",
 	"main": "index.js",

--- a/platform/native/package.json
+++ b/platform/native/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/native",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"private": true,
 	"description": "Signet native accelerators",
 	"main": "index.js",

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -24,10 +24,10 @@ test("the deterministic ledger retains the exact current source inventory", () =
 	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(166);
 });
 
-test("the event-loop ledger exactly equals the current source inventory", () => {
+test("the event-loop ledger exactly matches the current source identities", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const result = runAudit({ sourceRoot: resolve("platform/daemon/src"), baselineSites: baseline });
-	expect(result.sites).toEqual(baseline);
+	expect(occurrenceKeys(result.sites)).toEqual(occurrenceKeys(baseline));
 });
 
 test("classifies database callbacks by execution home rather than async API spelling", () => {
@@ -152,6 +152,38 @@ test("a tokenless async-named DB call fails the attribution coverage rule", () =
 		expect(violation?.path).toBe("missing-token.ts");
 		expect(violation?.api).toBe("withReadDbAsync");
 		expect(violation?.message).toContain('"missing-token.ts:1"');
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("stable semantic DB tokens survive line movement and remain globally unique", () => {
+	const root = mkdtempSync(join(tmpdir(), "signet-semantic-site-token-"));
+	try {
+		writeFileSync(
+			join(root, "semantic.ts"),
+			['getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });', "", ""].join("\n"),
+		);
+		let result = runAudit({ sourceRoot: root });
+		expect(result.violations.filter((item) => item.kind === "missing-async-db-site-token")).toEqual([]);
+		const baseline = result.sites;
+		const originalKeys = occurrenceKeys(result.sites);
+		writeFileSync(
+			join(root, "semantic.ts"),
+			'\n\ngetDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
+		);
+		result = runAudit({ sourceRoot: root, baselineSites: baseline });
+		expect(occurrenceKeys(result.sites)).toEqual(originalKeys);
+		expect(result.violations.filter((item) => item.kind === "new-parent-execution-site")).toEqual([]);
+
+		writeFileSync(
+			join(root, "duplicate.ts"),
+			'getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
+		);
+		result = runAudit({ sourceRoot: root });
+		const duplicate = result.violations.find((item) => item.kind === "duplicate-db-site-token");
+		expect(duplicate?.message).toContain("semantic.ts:3");
+		expect(duplicate?.message).toContain("duplicate.ts:1");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -364,6 +396,8 @@ test("the generated report describes the type boundary and transitional counts",
 	expect(report).toContain("Database accessor sites classified: 383");
 	expect(report).toContain("ON-PARENT callback execution: 381");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
+	expect(report).toContain("durable identity; file and line remain diagnostic metadata");
+	expect(report).toContain("`db:vacuum.conversion-status.read` (withReadDbAsync)");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).toContain("type boundary");

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(882);
+	expect(baseline).toHaveLength(879);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(147);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(146);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,16 +353,16 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 882 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 200");
+	expect(report).toContain("Exact ledger inventory: 879 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 199 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 197");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 197 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 366");
-	expect(report).toContain("ON-PARENT callback execution: 364");
+	expect(report).toContain("Database accessor sites classified: 363");
+	expect(report).toContain("ON-PARENT callback execution: 361");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(899);
+	expect(baseline).toHaveLength(882);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(166);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(147);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,21 +353,21 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 899 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 219 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 217");
+	expect(report).toContain("Exact ledger inventory: 882 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 200");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 217 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 383");
-	expect(report).toContain("ON-PARENT callback execution: 381");
+	expect(report).toContain("Database accessor sites classified: 366");
+	expect(report).toContain("ON-PARENT callback execution: 364");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).toContain("type boundary");
-	expect(report).not.toContain("Exact ledger inventory: 928 sites");
+	expect(report).not.toContain("Exact ledger inventory: 997 sites");
 });
 
 const countBaseline = (total: number, withReadDb: number, withWriteTx: number): LegacyDbCountBaseline => ({

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -24,10 +24,10 @@ test("the deterministic ledger retains the exact current source inventory", () =
 	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(166);
 });
 
-test("the event-loop ledger exactly matches the current source identities", () => {
+test("the event-loop ledger exactly equals the current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const result = runAudit({ sourceRoot: resolve("platform/daemon/src"), baselineSites: baseline });
-	expect(occurrenceKeys(result.sites)).toEqual(occurrenceKeys(baseline));
+	expect(result.sites).toEqual(baseline);
 });
 
 test("classifies database callbacks by execution home rather than async API spelling", () => {
@@ -152,38 +152,6 @@ test("a tokenless async-named DB call fails the attribution coverage rule", () =
 		expect(violation?.path).toBe("missing-token.ts");
 		expect(violation?.api).toBe("withReadDbAsync");
 		expect(violation?.message).toContain('"missing-token.ts:1"');
-	} finally {
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test("stable semantic DB tokens survive line movement and remain globally unique", () => {
-	const root = mkdtempSync(join(tmpdir(), "signet-semantic-site-token-"));
-	try {
-		writeFileSync(
-			join(root, "semantic.ts"),
-			['getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });', "", ""].join("\n"),
-		);
-		let result = runAudit({ sourceRoot: root });
-		expect(result.violations.filter((item) => item.kind === "missing-async-db-site-token")).toEqual([]);
-		const baseline = result.sites;
-		const originalKeys = occurrenceKeys(result.sites);
-		writeFileSync(
-			join(root, "semantic.ts"),
-			'\n\ngetDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
-		);
-		result = runAudit({ sourceRoot: root, baselineSites: baseline });
-		expect(occurrenceKeys(result.sites)).toEqual(originalKeys);
-		expect(result.violations.filter((item) => item.kind === "new-parent-execution-site")).toEqual([]);
-
-		writeFileSync(
-			join(root, "duplicate.ts"),
-			'getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
-		);
-		result = runAudit({ sourceRoot: root });
-		const duplicate = result.violations.find((item) => item.kind === "duplicate-db-site-token");
-		expect(duplicate?.message).toContain("semantic.ts:3");
-		expect(duplicate?.message).toContain("duplicate.ts:1");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -396,8 +364,6 @@ test("the generated report describes the type boundary and transitional counts",
 	expect(report).toContain("Database accessor sites classified: 383");
 	expect(report).toContain("ON-PARENT callback execution: 381");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
-	expect(report).toContain("durable identity; file and line remain diagnostic metadata");
-	expect(report).toContain("`db:vacuum.conversion-status.read` (withReadDbAsync)");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).toContain("type boundary");

--- a/scripts/audit-event-loop-contract.ts
+++ b/scripts/audit-event-loop-contract.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import ts from "typescript";
+import { isSemanticSyncDbSiteToken } from "../platform/daemon/src/sync-db-site-token";
 
 /** The synchronous APIs recorded in the migration ledger. */
 export const SYNC_APIS = [
@@ -54,6 +55,8 @@ export interface AuditSite {
 	readonly api: SyncApi;
 	readonly source: string;
 	readonly category: SiteCategory;
+	/** Stable identity for migrated DB sites; path and line remain diagnostic metadata. */
+	readonly siteToken?: string;
 }
 
 /** A database site classified by the process that executes its callback. */
@@ -123,6 +126,15 @@ export interface MissingAsyncDbSiteTokenViolation {
 	readonly message: string;
 }
 
+/** A semantic attribution ID reused by more than one database call site. */
+export interface DuplicateDbSiteTokenViolation {
+	readonly kind: "duplicate-db-site-token";
+	readonly path: string;
+	readonly line: number;
+	readonly token: string;
+	readonly message: string;
+}
+
 /** Committed marker-count snapshot; the ratchet fails when the live count grows past it. */
 export interface LegacyDbCountBaseline {
 	readonly version: 1;
@@ -150,6 +162,7 @@ export interface AuditResult {
 		| UnmarkedLegacyDbAccessViolation
 		| MissingLegacyDbSiteTokenViolation
 		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
 	)[];
 	readonly legacyDbAccess: LegacyDbAccessCounts;
 	readonly executionHomeSites: readonly ExecutionHomeSite[];
@@ -404,11 +417,26 @@ function findImportBoundaryViolations(
 function findLegacyDbAccessSites(sourceRoot: string): {
 	readonly sites: AuditSite[];
 	readonly unmarked: UnmarkedCallSite[];
-	readonly missingSiteTokens: (MissingLegacyDbSiteTokenViolation | MissingAsyncDbSiteTokenViolation)[];
+	readonly siteTokenViolations: (
+		| MissingLegacyDbSiteTokenViolation
+		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
+	)[];
 } {
 	const sites: AuditSite[] = [];
 	const unmarked: UnmarkedCallSite[] = [];
-	const missingSiteTokens: (MissingLegacyDbSiteTokenViolation | MissingAsyncDbSiteTokenViolation)[] = [];
+	const siteTokenViolations: (
+		| MissingLegacyDbSiteTokenViolation
+		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
+	)[] = [];
+	const semanticTokenSites = new Map<string, Array<{ readonly path: string; readonly line: number }>>();
+	const recordSemanticToken = (token: string | null, path: string, line: number): void => {
+		if (!isSemanticSyncDbSiteToken(token)) return;
+		const locations = semanticTokenSites.get(token) ?? [];
+		locations.push({ path, line });
+		semanticTokenSites.set(token, locations);
+	};
 	for (const path of walk(sourceRoot)) {
 		const source = readFileSync(path, "utf8");
 		const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
@@ -439,13 +467,7 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 						? expression.name.getStart(sourceFile)
 						: expression.getStart(sourceFile);
 					const line = lineNumber(sourceFile, position);
-					sites.push({
-						path: relativePath,
-						line,
-						api: api as SyncApi,
-						source: lines[line - 1]?.trim() ?? "",
-						category: "hot-path",
-					});
+					let semanticSiteToken: string | undefined;
 					if (isLegacyDbMemberAccess && LEGACY_DB_APIS.includes(api as LegacyDbApi)) {
 						let marked = false;
 						for (let candidate = line - 1; candidate >= Math.max(1, line - MARKER_WINDOW_LINES); candidate--) {
@@ -459,13 +481,15 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 							const tokenArgument = node.arguments[1];
 							const token = tokenArgument === undefined ? null : staticStringValue(tokenArgument, bindings);
 							const expected = `${relativePath}:${line}`;
-							if (token !== expected) {
-								missingSiteTokens.push({
+							recordSemanticToken(token, relativePath, line);
+							if (isSemanticSyncDbSiteToken(token)) semanticSiteToken = token;
+							if (token !== expected && !isSemanticSyncDbSiteToken(token)) {
+								siteTokenViolations.push({
 									kind: "missing-legacy-db-site-token",
 									path: relativePath,
 									line,
 									api: api as LegacyDbApi,
-									message: `${relativePath}:${line} ${api}() must pass its static site token ${JSON.stringify(expected)}; unattributed in-flight DB calls are not allowed`,
+									message: `${relativePath}:${line} ${api}() must pass ${JSON.stringify(expected)} or a unique stable semantic token such as "db:vacuum.status.read"; unattributed in-flight DB calls are not allowed`,
 								});
 							}
 						}
@@ -475,27 +499,49 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 						if (!isLegacy) {
 							const expected = `${relativePath}:${line}`;
 							const token = staticAsyncSiteToken(node, bindings, api as Exclude<AttributedDbApi, LegacyDbApi>);
+							recordSemanticToken(token, relativePath, line);
+							if (isSemanticSyncDbSiteToken(token)) semanticSiteToken = token;
 							const dynamicTokenBoundary = lines
 								.slice(Math.max(0, line - 3), line)
 								.some((candidate) => candidate.includes("DYNAMIC_SITE_TOKEN"));
-							if (!dynamicTokenBoundary && token !== expected) {
-								missingSiteTokens.push({
+							if (!dynamicTokenBoundary && token !== expected && !isSemanticSyncDbSiteToken(token)) {
+								siteTokenViolations.push({
 									kind: "missing-async-db-site-token",
 									path: relativePath,
 									line,
 									api: api as Exclude<AttributedDbApi, LegacyDbApi>,
-									message: `${relativePath}:${line} ${api}() must pass its static site token ${JSON.stringify(expected)}; unattributed in-flight DB calls are not allowed`,
+									message: `${relativePath}:${line} ${api}() must pass ${JSON.stringify(expected)} or a unique stable semantic token such as "db:vacuum.status.read"; unattributed in-flight DB calls are not allowed`,
 								});
 							}
 						}
 					}
+					sites.push({
+						path: relativePath,
+						line,
+						api: api as SyncApi,
+						source: lines[line - 1]?.trim() ?? "",
+						category: "hot-path",
+						...(semanticSiteToken === undefined ? {} : { siteToken: semanticSiteToken }),
+					});
 				}
 			}
 			ts.forEachChild(node, visit);
 		};
 		visit(sourceFile);
 	}
-	return { sites, unmarked, missingSiteTokens };
+	for (const [token, locations] of semanticTokenSites) {
+		if (locations.length < 2) continue;
+		const first = locations[0];
+		if (first === undefined) continue;
+		siteTokenViolations.push({
+			kind: "duplicate-db-site-token",
+			path: first.path,
+			line: first.line,
+			token,
+			message: `stable DB site token ${JSON.stringify(token)} is reused at ${locations.map((site) => `${site.path}:${site.line}`).join(", ")}; semantic tokens must identify exactly one call site`,
+		});
+	}
+	return { sites, unmarked, siteTokenViolations };
 }
 
 /**
@@ -528,7 +574,8 @@ export interface UnmarkedCallSite {
 	readonly api: LegacyDbApi;
 }
 
-function siteKey(site: Pick<AuditSite, "path" | "api" | "source">): string {
+function siteKey(site: Pick<AuditSite, "path" | "api" | "source" | "siteToken">): string {
+	if (site.siteToken !== undefined) return `semantic\u0000${site.api}\u0000${site.siteToken}`;
 	return `${site.path}\u0000${site.api}\u0000${site.source}`;
 }
 
@@ -697,7 +744,7 @@ export function writeCountBaseline(
 }
 
 export function runAudit(options: AuditOptions): AuditResult {
-	const { sites, unmarked, missingSiteTokens } = findLegacyDbAccessSites(options.sourceRoot);
+	const { sites, unmarked, siteTokenViolations } = findLegacyDbAccessSites(options.sourceRoot);
 	const baselineSites = options.baselineSites ?? [];
 	const executionHomeSites = classifyExecutionHomes(sites);
 	return {
@@ -707,7 +754,7 @@ export function runAudit(options: AuditOptions): AuditResult {
 			...findNewLegacyDbAccessViolations(sites, baselineSites),
 			...findNewParentExecutionSiteViolations(executionHomeSites, baselineSites),
 			...findUnmarkedLegacyDbAccess(unmarked),
-			...missingSiteTokens,
+			...siteTokenViolations,
 		],
 		legacyDbAccess: countLegacyDbAccess(options.sourceRoot),
 		executionHomeSites,
@@ -748,11 +795,11 @@ export function renderReport(baselineSites: readonly AuditSite[], legacyDbAccess
 		const sites = executionHomeSites.filter((site) => site.executionHome === home);
 		return sites.length === 0
 			? "- None"
-			: sites.map((site) => `- \`${site.path}:${site.line}\` (${site.api})`).join("\n");
+			: sites.map((site) => `- \`${site.siteToken ?? `${site.path}:${site.line}`}\` (${site.api})`).join("\n");
 	};
 	return `# Event-loop synchronous contract audit
 
-This report is generated from the deterministic migration ledger in \`scripts/event-loop-contract-baseline.json\`. Phase A enforces the type boundary structurally: production code receives an async-only \`DbAccessor\`, while the synchronous compatibility module lives outside the daemon production \`src/\` tree and is rejected by the production TypeScript project's \`rootDir\`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching.
+This report is generated from the deterministic migration ledger in \`scripts/event-loop-contract-baseline.json\`. Phase A enforces the type boundary structurally: production code receives an async-only \`DbAccessor\`, while the synchronous compatibility module lives outside the daemon production \`src/\` tree and is rejected by the production TypeScript project's \`rootDir\`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching. Migrated DB sites use unique \`db:domain.operation.action\` IDs as their durable identity; file and line remain diagnostic metadata.
 
 ## Current inventory
 

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -931,35 +931,40 @@
       "line": 331,
       "api": "withReadDb",
       "source": "return accessor.withReadDb(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-status.sync-read"
     },
     {
       "path": "db-vacuum.ts",
       "line": 339,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-status.read"
     },
     {
       "path": "db-vacuum.ts",
       "line": 347,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-running"
     },
     {
       "path": "db-vacuum.ts",
       "line": 367,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-completed"
     },
     {
       "path": "db-vacuum.ts",
       "line": 386,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-failed"
     },
     {
       "path": "discord-desktop-cache-source.ts",
@@ -3031,7 +3036,8 @@
       "line": 148,
       "api": "withReadDbAsync",
       "source": ": await accessor.withReadDbAsync((db) => db.prepare(sql).all() as Array<{ agent_id: string | null }>, {",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:maintenance.graph-agent-scopes.read"
     },
     {
       "path": "pipeline/maintenance-worker.ts",
@@ -3045,7 +3051,8 @@
       "line": 485,
       "api": "withReadDbAsync",
       "source": ": await accessor.withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:maintenance.dead-memory-count.read"
     },
     {
       "path": "pipeline/prospective-index.ts",

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -931,40 +931,35 @@
       "line": 331,
       "api": "withReadDb",
       "source": "return accessor.withReadDb(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-status.sync-read"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 339,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-status.read"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 347,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-state.mark-running"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 367,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-state.mark-completed"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 386,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-state.mark-failed"
+      "category": "hot-path"
     },
     {
       "path": "discord-desktop-cache-source.ts",

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1453,157 +1453,19 @@
     },
     {
       "path": "knowledge-graph.ts",
-      "line": 193,
+      "line": 833,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:knowledge.entity-knowledge-tree.read"
     },
     {
       "path": "knowledge-graph.ts",
-      "line": 218,
+      "line": 1945,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 243,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 271,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 287,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 312,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 340,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 422,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 605,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 783,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 814,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 841,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 994,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1058,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1140,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1204,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1291,
-      "api": "withReadDbAsync",
-      "source": "const row = await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1401,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(async (db) => readEntityAspectsWithCounts(db, entityId, agentId), {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1418,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1463,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1602,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1984,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:knowledge.graph-constellation.read"
     },
     {
       "path": "lifecycle.ts",

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -2869,14 +2869,14 @@
     },
     {
       "path": "pipeline/dreaming.ts",
-      "line": 885,
+      "line": 889,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return { content: \"\", unreadable: false };",
       "category": "hot-path"
     },
     {
       "path": "pipeline/dreaming.ts",
-      "line": 887,
+      "line": 891,
       "api": "readFileSync",
       "source": "const raw = readFileSync(path, \"utf-8\").trim();",
       "category": "hot-path"

--- a/surfaces/browser-extension/package.json
+++ b/surfaces/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/extension",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"private": true,
 	"description": "Signet browser extension for Chrome and Firefox",
 	"scripts": {

--- a/surfaces/browser-extension/package.json
+++ b/surfaces/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/extension",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"private": true,
 	"description": "Signet browser extension for Chrome and Firefox",
 	"scripts": {

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/cli",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"description": "CLI for Signet - portable AI agent identity",
 	"type": "module",
 	"bin": "./dist/cli.js",

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/cli",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"description": "CLI for Signet - portable AI agent identity",
 	"type": "module",
 	"bin": "./dist/cli.js",

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/desktop",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"private": true,
 	"description": "Electron desktop distribution layer for Signet",
 	"homepage": "https://signetai.sh",

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/desktop",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"private": true,
 	"description": "Electron desktop distribution layer for Signet",
 	"homepage": "https://signetai.sh",

--- a/surfaces/tray/package.json
+++ b/surfaces/tray/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/tray",
-	"version": "0.214.36",
+	"version": "0.214.37",
 	"private": true,
 	"description": "Shared tray and menu bar state utilities for Signet desktop shells",
 	"type": "module",

--- a/surfaces/tray/package.json
+++ b/surfaces/tray/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/tray",
-	"version": "0.214.35",
+	"version": "0.214.36",
 	"private": true,
 	"description": "Shared tray and menu bar state utilities for Signet desktop shells",
 	"type": "module",


### PR DESCRIPTION
## Summary

- move the process-local episodic backlog cache and its synchronous reader into `dreaming-token-cache.ts`, the module that actually owns that state
- stop `knowledge-graph.ts` from importing the 2,300-line Dreaming composition module for one cached number
- mirror exact DB-owner backlog results into the parent cache explicitly, fixing constellation metadata that otherwise reported zero after counting moved off-process
- add a dependency invariant preventing the knowledge graph from regaining the Dreaming composition import

This is stacked on #1757.

## Measured result

- largest daemon runtime strongly connected component: **6 modules -> 0**
- daemon runtime relative-import cycles: **1 -> 0**
- repository runtime relative-import cycles: **3 -> 2**
- repository structural relative-import cycles: **10 -> 9**
- remaining runtime cycles are isolated to MemoryBench server routes/composition and `mcp-probe`/`widget-gen`
- no new type escape, suppression, parent-process DB callback, or production file
- event-loop ledger remains at 899 sites, 164 legacy DB sites, 381 parent callbacks, and 2 off-parent callbacks

## Verification

- daemon TypeScript check
- full daemon and dashboard build
- 23/23 event-loop architecture tests
- 5/5 dependency/lifecycle invariant tests
- 4/4 focused backlog/cache tests
- constellation graph regression including nonzero owner-computed backlog metadata
- Biome, version alignment, and `git diff --check`

## Baseline findings kept separate

- oversized Dreaming evidence still exceeds its 15-second budget on both base and refactor branches: #1715
- the knowledge-detail lease test misses its 500ms race identically on base and refactor branches; deterministic repair is tracked in #1758

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no feature or spec contract changed
- [x] Agent scoping verified on all new/changed data queries — cache keys and exact owner results remain keyed by `agentId`
- [x] Input/config validation and bounds checks added — no new external input; existing bounded backlog inputs are unchanged
- [x] Error handling and fallback paths tested (no silent swallow) — owner result propagation and cache behavior are covered without a fallback reader
- [x] Security checks applied to admin/mutation endpoints — no endpoint or authorization change
- [x] Docs updated for API/spec/status changes — no public API/spec/status change; architecture findings are tracked in #1748 and the Obsidian audit
- [x] Regression tests added for each bug fix — the existing constellation assertion now proves the explicit cross-process cache mirror
- [x] Lint/typecheck/tests pass locally
