### PR TITLE
refactor(daemon): route wave 6 knowledge graph reads through DB owner

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 902 sites
+- Exact ledger inventory: 882 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 222
-- Async-named ON-PARENT DB sites: 220
+- Async-named DB sites: 202
+- Async-named ON-PARENT DB sites: 200
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 902-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 222 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 220 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 882-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 386
-- ON-PARENT callback execution: 384
+- Database accessor sites classified: 366
+- ON-PARENT callback execution: 364
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -98,28 +98,8 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `imported-source-outcome.ts:16` (withWriteTx)
 - `imported-source-outcome.ts:62` (withReadDb)
 - `knowledge-graph-hygiene.ts:428` (withReadDb)
-- `knowledge-graph.ts:193` (withReadDbAsync)
-- `knowledge-graph.ts:218` (withReadDbAsync)
-- `knowledge-graph.ts:243` (withReadDbAsync)
-- `knowledge-graph.ts:271` (withReadDbAsync)
-- `knowledge-graph.ts:287` (withReadDbAsync)
-- `knowledge-graph.ts:312` (withReadDbAsync)
-- `knowledge-graph.ts:340` (withReadDbAsync)
-- `knowledge-graph.ts:422` (withReadDbAsync)
-- `knowledge-graph.ts:605` (withReadDbAsync)
-- `knowledge-graph.ts:783` (withReadDbAsync)
-- `knowledge-graph.ts:814` (withReadDbAsync)
-- `knowledge-graph.ts:841` (withReadDbAsync)
-- `knowledge-graph.ts:994` (withReadDbAsync)
-- `knowledge-graph.ts:1058` (withReadDbAsync)
-- `knowledge-graph.ts:1140` (withReadDbAsync)
-- `knowledge-graph.ts:1204` (withReadDbAsync)
-- `knowledge-graph.ts:1291` (withReadDbAsync)
-- `knowledge-graph.ts:1401` (withReadDbAsync)
-- `knowledge-graph.ts:1418` (withReadDbAsync)
-- `knowledge-graph.ts:1463` (withReadDbAsync)
-- `knowledge-graph.ts:1602` (withReadDbAsync)
-- `knowledge-graph.ts:1984` (withReadDbAsync)
+- `db:knowledge.entity-knowledge-tree.read` (withReadDbAsync)
+- `db:knowledge.graph-constellation.read` (withReadDbAsync)
 - `memory-candidates.ts:470` (withReadDb)
 - `memory-candidates.ts:511` (withReadDb)
 - `memory-head-curation.ts:31` (withReadDbAsync)

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -1,26 +1,26 @@
 # Event-loop synchronous contract audit
 
-This report is generated from the deterministic migration ledger in `scripts/event-loop-contract-baseline.json`. Phase A enforces the type boundary structurally: production code receives an async-only `DbAccessor`, while the synchronous compatibility module lives outside the daemon production `src/` tree and is rejected by the production TypeScript project's `rootDir`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching.
+This report is generated from the deterministic migration ledger in `scripts/event-loop-contract-baseline.json`. Phase A enforces the type boundary structurally: production code receives an async-only `DbAccessor`, while the synchronous compatibility module lives outside the daemon production `src/` tree and is rejected by the production TypeScript project's `rootDir`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching. Migrated DB sites use unique `db:domain.operation.action` IDs as their durable identity; file and line remain diagnostic metadata.
 
 ## Current inventory
 
-- Exact ledger inventory: 899 sites
+- Exact ledger inventory: 902 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 219
-- Async-named ON-PARENT DB sites: 217
+- Async-named DB sites: 222
+- Async-named ON-PARENT DB sites: 220
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 899-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 219 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 217 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 902-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 222 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 220 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 383
-- ON-PARENT callback execution: 381
+- Database accessor sites classified: 386
+- ON-PARENT callback execution: 384
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -60,11 +60,13 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `database-integrity.ts:712` (withReadDbAsync)
 - `database-integrity.ts:830` (withReadDbAsync)
 - `db-accessor.ts:3031` (withWriteTxAsync)
-- `db-vacuum.ts:331` (withReadDb)
-- `db-vacuum.ts:339` (withReadDbAsync)
-- `db-vacuum.ts:347` (withWriteTxAsync)
-- `db-vacuum.ts:367` (withWriteTxAsync)
-- `db-vacuum.ts:386` (withWriteTxAsync)
+- `db-vacuum.ts:340` (withReadDb)
+- `db-vacuum.ts:348` (withReadDbAsync)
+- `db-vacuum.ts:460` (incrementalVacuumAsync)
+- `db-vacuum.ts:498` (withWriteTxAsync)
+- `db-vacuum.ts:528` (vacuumConversionAsync)
+- `db-vacuum.ts:530` (withWriteTxAsync)
+- `db-vacuum.ts:548` (withWriteTxAsync)
 - `discord-desktop-cache-source.ts:484` (withReadDbAsync)
 - `discord-desktop-cache-source.ts:497` (withWriteTxAsync)
 - `discord-source-provider.ts:573` (withReadDbAsync)
@@ -217,9 +219,10 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `pipeline/dreaming-worker.ts:227` (withReadDbAsync)
 - `pipeline/dreaming-worker.ts:247` (withReadDbAsync)
 - `pipeline/graph-traversal.ts:92` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:148` (withReadDbAsync)
+- `db:maintenance.graph-agent-scopes.read` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:485` (withReadDbAsync)
+- `db:maintenance.dead-memory-count.read` (withReadDbAsync)
+- `pipeline/maintenance-worker.ts:535` (withReadDbAsync)
 - `pipeline/prospective-index.ts:284` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:300` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:336` (withWriteTxAsync)

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 882 sites
+- Exact ledger inventory: 879 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 202
-- Async-named ON-PARENT DB sites: 200
+- Async-named DB sites: 199
+- Async-named ON-PARENT DB sites: 197
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 882-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 879-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 199 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 197 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 366
-- ON-PARENT callback execution: 364
+- Database accessor sites classified: 363
+- ON-PARENT callback execution: 361
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -60,13 +60,11 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `database-integrity.ts:712` (withReadDbAsync)
 - `database-integrity.ts:830` (withReadDbAsync)
 - `db-accessor.ts:3031` (withWriteTxAsync)
-- `db-vacuum.ts:340` (withReadDb)
-- `db-vacuum.ts:348` (withReadDbAsync)
-- `db-vacuum.ts:460` (incrementalVacuumAsync)
-- `db-vacuum.ts:498` (withWriteTxAsync)
-- `db-vacuum.ts:528` (vacuumConversionAsync)
-- `db-vacuum.ts:530` (withWriteTxAsync)
-- `db-vacuum.ts:548` (withWriteTxAsync)
+- `db-vacuum.ts:331` (withReadDb)
+- `db-vacuum.ts:339` (withReadDbAsync)
+- `db-vacuum.ts:347` (withWriteTxAsync)
+- `db-vacuum.ts:367` (withWriteTxAsync)
+- `db-vacuum.ts:386` (withWriteTxAsync)
 - `discord-desktop-cache-source.ts:484` (withReadDbAsync)
 - `discord-desktop-cache-source.ts:497` (withWriteTxAsync)
 - `discord-source-provider.ts:573` (withReadDbAsync)
@@ -202,7 +200,6 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `db:maintenance.graph-agent-scopes.read` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
 - `db:maintenance.dead-memory-count.read` (withReadDbAsync)
-- `pipeline/maintenance-worker.ts:535` (withReadDbAsync)
 - `pipeline/prospective-index.ts:284` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:300` (withWriteDbAsync)
 - `pipeline/prospective-index.ts:336` (withWriteTxAsync)

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -186,7 +186,7 @@ function rowToTaskMeta(r: Record<string, unknown>): TaskMeta {
 // ---------------------------------------------------------------------------
 
 export async function getAspectsForEntity(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAspect[]> {
@@ -209,7 +209,7 @@ export async function getAspectsForEntity(
 // ---------------------------------------------------------------------------
 
 export async function getAttributesForAspect(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	aspectId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
@@ -232,7 +232,7 @@ export async function getAttributesForAspect(
  * This is the query that enforces the "constraints always surface" invariant.
  */
 export async function getConstraintsForEntity(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
@@ -259,7 +259,7 @@ export async function getConstraintsForEntity(
 // ---------------------------------------------------------------------------
 
 export async function getEntityDependencyById(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: { readonly id: string; readonly agentId: string },
 ): Promise<EntityDependency | null> {
 	const row = await dbOwnerQuery<Record<string, unknown> | null>(
@@ -274,7 +274,7 @@ export async function getEntityDependencyById(
 }
 
 export async function getDependenciesFrom(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
@@ -297,7 +297,7 @@ export async function getDependenciesFrom(
 }
 
 export async function getDependenciesTo(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
@@ -324,7 +324,7 @@ export async function getDependenciesTo(
 // ---------------------------------------------------------------------------
 
 export async function getPinnedEntities(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	agentId: string,
 ): Promise<ReadonlyArray<PinnedEntitySummary>> {
 	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
@@ -398,7 +398,7 @@ export async function upsertTaskMeta(accessor: DbAccessor, params: UpsertTaskMet
 	});
 }
 
-export async function getTaskMeta(accessor: DbAccessor, entityId: string, agentId: string): Promise<TaskMeta | null> {
+export async function getTaskMeta(_accessor: DbAccessor, entityId: string, agentId: string): Promise<TaskMeta | null> {
 	const row = await dbOwnerQuery<Record<string, unknown> | null>(
 		{
 			sql: "SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?",
@@ -573,7 +573,7 @@ export interface EntityKnowledgeTree {
 }
 
 export async function resolveNamedEntity(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	input: {
 		readonly agentId: string;
 		readonly name: string;
@@ -762,7 +762,7 @@ export async function getKnowledgeEntityByName(
 }
 
 export async function listEntityAliases(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly entityId: string;
@@ -1165,7 +1165,7 @@ export async function listEntityAttributesByPath(
 }
 
 export async function listKnowledgeEntities(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly type?: string;

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -22,7 +22,7 @@ import type {
 } from "@signet/core";
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import { getDbAccessorPath, type DbAccessor, type ReadDb } from "./db-accessor";
-import { getDbOwner } from "./db-owner-runtime";
+import { dbOwnerQuery, getDbOwner } from "./db-owner-runtime";
 import { ownerReadOne } from "./db-owner-sql";
 import { runWriteTxAsync } from "./db-accessor";
 import { getDreamingEpisodicTokenBacklogCached } from "./pipeline/dreaming";
@@ -190,20 +190,18 @@ export async function getAspectsForEntity(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAspect[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT * FROM entity_aspects
-				 WHERE entity_id = ? AND agent_id = ?
-				   AND COALESCE(status, 'active') = 'active'
-				 ORDER BY weight DESC`,
-				)
-				.all(entityId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToAspect);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT * FROM entity_aspects
+			 WHERE entity_id = ? AND agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
+			 ORDER BY weight DESC`,
+			params: [entityId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:193" },
+		{ operation: "db:knowledge.aspects-for-entity.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAspect);
 }
 
 // ---------------------------------------------------------------------------
@@ -215,19 +213,17 @@ export async function getAttributesForAspect(
 	aspectId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT * FROM entity_attributes
-				 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
-				 ORDER BY importance DESC`,
-				)
-				.all(aspectId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToAttribute);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT * FROM entity_attributes
+			 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
+			 ORDER BY importance DESC`,
+			params: [aspectId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:218" },
+		{ operation: "db:knowledge.attributes-for-aspect.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAttribute);
 }
 
 /**
@@ -240,24 +236,22 @@ export async function getConstraintsForEntity(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityAttribute[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT ea.* FROM entity_attributes ea
-				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
-				 WHERE asp.entity_id = ? AND asp.agent_id = ?
-				   AND ea.agent_id = ?
-				   AND COALESCE(asp.status, 'active') = 'active'
-				   AND ea.kind = 'constraint'
-				   AND ea.status = 'active'
-				 ORDER BY ea.importance DESC`,
-				)
-				.all(entityId, agentId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToAttribute);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT ea.* FROM entity_attributes ea
+			 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+			 WHERE asp.entity_id = ? AND asp.agent_id = ?
+			   AND ea.agent_id = ?
+			   AND COALESCE(asp.status, 'active') = 'active'
+			   AND ea.kind = 'constraint'
+			   AND ea.status = 'active'
+			 ORDER BY ea.importance DESC`,
+			params: [entityId, agentId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:243" },
+		{ operation: "db:knowledge.constraints-for-entity.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAttribute);
 }
 
 // ---------------------------------------------------------------------------
@@ -268,15 +262,15 @@ export async function getEntityDependencyById(
 	accessor: DbAccessor,
 	params: { readonly id: string; readonly agentId: string },
 ): Promise<EntityDependency | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const row = db
-				.prepare("SELECT * FROM entity_dependencies WHERE id = ? AND agent_id = ?")
-				.get(params.id, params.agentId) as Record<string, unknown> | undefined;
-			return row === undefined ? null : rowToDependency(row);
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT * FROM entity_dependencies WHERE id = ? AND agent_id = ?",
+			params: [params.id, params.agentId],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:271" },
+		{ operation: "db:knowledge.dependency-by-id.read", deadlineMs: 2_000 },
 	);
+	return row === null ? null : rowToDependency(row);
 }
 
 export async function getDependenciesFrom(
@@ -284,24 +278,22 @@ export async function getDependenciesFrom(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT dep.*
-				 FROM entity_dependencies dep
-				 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
-				 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
-				 WHERE dep.source_entity_id = ? AND dep.agent_id = ?
-				   AND COALESCE(dep.status, 'active') = 'active'
-				   AND COALESCE(src.status, 'active') = 'active'
-				   AND COALESCE(dst.status, 'active') = 'active'`,
-				)
-				.all(entityId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToDependency);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT dep.*
+			 FROM entity_dependencies dep
+			 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+			 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+			 WHERE dep.source_entity_id = ? AND dep.agent_id = ?
+			   AND COALESCE(dep.status, 'active') = 'active'
+			   AND COALESCE(src.status, 'active') = 'active'
+			   AND COALESCE(dst.status, 'active') = 'active'`,
+			params: [entityId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:287" },
+		{ operation: "db:knowledge.dependencies-from.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToDependency);
 }
 
 export async function getDependenciesTo(
@@ -309,24 +301,22 @@ export async function getDependenciesTo(
 	entityId: string,
 	agentId: string,
 ): Promise<readonly EntityDependency[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT dep.*
-				 FROM entity_dependencies dep
-				 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
-				 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
-				 WHERE dep.target_entity_id = ? AND dep.agent_id = ?
-				   AND COALESCE(dep.status, 'active') = 'active'
-				   AND COALESCE(src.status, 'active') = 'active'
-				   AND COALESCE(dst.status, 'active') = 'active'`,
-				)
-				.all(entityId, agentId) as Array<Record<string, unknown>>;
-			return rows.map(rowToDependency);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT dep.*
+			 FROM entity_dependencies dep
+			 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+			 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+			 WHERE dep.target_entity_id = ? AND dep.agent_id = ?
+			   AND COALESCE(dep.status, 'active') = 'active'
+			   AND COALESCE(src.status, 'active') = 'active'
+			   AND COALESCE(dst.status, 'active') = 'active'`,
+			params: [entityId, agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:312" },
+		{ operation: "db:knowledge.dependencies-to.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToDependency);
 }
 
 // ---------------------------------------------------------------------------
@@ -337,33 +327,23 @@ export async function getPinnedEntities(
 	accessor: DbAccessor,
 	agentId: string,
 ): Promise<ReadonlyArray<PinnedEntitySummary>> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const rows = db
-				.prepare(
-					`SELECT id, name, pinned_at
-				 FROM entities
-				 WHERE agent_id = ?
-				   AND pinned = 1
-				   AND COALESCE(status, 'active') = 'active'
-				 ORDER BY pinned_at DESC, updated_at DESC, name ASC`,
-				)
-				.all(agentId) as Array<Record<string, unknown>>;
-			return rows.flatMap((row) => {
-				if (typeof row.id !== "string" || typeof row.name !== "string") {
-					return [];
-				}
-				return [
-					{
-						id: row.id,
-						name: row.name,
-						pinnedAt: typeof row.pinned_at === "string" ? row.pinned_at : "",
-					},
-				];
-			});
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT id, name, pinned_at
+			 FROM entities
+			 WHERE agent_id = ?
+			   AND pinned = 1
+			   AND COALESCE(status, 'active') = 'active'
+			 ORDER BY pinned_at DESC, updated_at DESC, name ASC`,
+			params: [agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:340" },
+		{ operation: "db:knowledge.pinned-entities.read", deadlineMs: 2_000 },
 	);
+	return rows.flatMap((row) => {
+		if (typeof row.id !== "string" || typeof row.name !== "string") return [];
+		return [{ id: row.id, name: row.name, pinnedAt: typeof row.pinned_at === "string" ? row.pinned_at : "" }];
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -419,15 +399,15 @@ export async function upsertTaskMeta(accessor: DbAccessor, params: UpsertTaskMet
 }
 
 export async function getTaskMeta(accessor: DbAccessor, entityId: string, agentId: string): Promise<TaskMeta | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const row = db.prepare("SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?").get(entityId, agentId) as
-				| Record<string, unknown>
-				| undefined;
-			return row ? rowToTaskMeta(row) : null;
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?",
+			params: [entityId, agentId],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:422" },
+		{ operation: "db:knowledge.task-meta.read", deadlineMs: 2_000 },
 	);
+	return row ? rowToTaskMeta(row) : null;
 }
 
 export async function updateTaskStatus(
@@ -602,14 +582,18 @@ export async function resolveNamedEntity(
 	const canonical = toCanonicalName(input.name);
 	if (canonical.length === 0) return null;
 
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const escaped = canonical.replace(/\\/g, "\\\\").replace(/[%_]/g, "\\$&");
-			const starts = `${escaped}%`;
-			const contains = `%${escaped}%`;
-			const rows = db
-				.prepare(
-					`SELECT
+	const escaped = canonical.replace(/\\/g, "\\\\").replace(/[%_]/g, "\\$&");
+	const starts = `${escaped}%`;
+	const contains = `%${escaped}%`;
+	const rows = await dbOwnerQuery<{
+		readonly id: string;
+		readonly name: string;
+		readonly canonical_name: string;
+		readonly entity_type: string;
+		readonly description: string | null;
+	} | null>(
+		{
+			sql: `SELECT
 					id,
 					name,
 					COALESCE(canonical_name, LOWER(name)) AS canonical_name,
@@ -639,66 +623,71 @@ export async function resolveNamedEntity(
 				   )
 				 ORDER BY match_rank ASC, mentions DESC, updated_at DESC, name ASC
 				 LIMIT 1`,
-				)
-				.get(
-					canonical,
-					canonical,
-					starts,
-					starts,
-					contains,
-					contains,
-					input.agentId,
-					canonical,
-					canonical,
-					starts,
-					starts,
-					contains,
-					contains,
-				) as
-				| {
-						id: string;
-						name: string;
-						canonical_name: string;
-						entity_type: string;
-						description: string | null;
-				  }
-				| undefined;
-
-			if (!rows) return null;
-			return {
-				id: rows.id,
-				name: rows.name,
-				canonicalName: rows.canonical_name,
-				entityType: rows.entity_type,
-				description: rows.description,
-			};
+			params: [
+				canonical,
+				canonical,
+				starts,
+				starts,
+				contains,
+				contains,
+				input.agentId,
+				canonical,
+				canonical,
+				starts,
+				starts,
+				contains,
+				contains,
+			],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:605" },
+		{ operation: "db:knowledge.resolve-entity.read", deadlineMs: 2_000 },
 	);
+	if (!rows) return null;
+	return {
+		id: rows.id,
+		name: rows.name,
+		canonicalName: rows.canonical_name,
+		entityType: rows.entity_type,
+		description: rows.description,
+	};
 }
 
-function resolveAspectByName(
-	db: ReadDb,
-	params: {
-		readonly entityId: string;
-		readonly agentId: string;
-		readonly aspect: string;
-	},
-): EntityAspect | null {
+async function resolveEntityByNameOnOwner(
+	accessor: DbAccessor,
+	params: { readonly agentId: string; readonly name: string },
+): Promise<Entity | null> {
+	const resolved = await resolveNamedEntity(accessor, params);
+	if (!resolved) return null;
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT * FROM entities WHERE id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'",
+			params: [resolved.id, params.agentId],
+			result: "get",
+		},
+		{ operation: "db:knowledge.entity-by-name.read", deadlineMs: 2_000 },
+	);
+	return row ? rowToEntity(row) : null;
+}
+
+async function resolveAspectByNameOnOwner(params: {
+	readonly entityId: string;
+	readonly agentId: string;
+	readonly aspect: string;
+}): Promise<EntityAspect | null> {
 	const canonical = toCanonicalName(params.aspect);
 	if (canonical.length === 0) return null;
-	const row = db
-		.prepare(
-			`SELECT *
-			 FROM entity_aspects
-			 WHERE entity_id = ?
-			   AND agent_id = ?
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: `SELECT * FROM entity_aspects
+			 WHERE entity_id = ? AND agent_id = ?
 			   AND COALESCE(status, 'active') = 'active'
 			   AND (canonical_name = ? OR LOWER(name) = ?)
-			 ORDER BY weight DESC, updated_at DESC
-			 LIMIT 1`,
-		)
-		.get(params.entityId, params.agentId, canonical, canonical) as Record<string, unknown> | undefined;
+			 ORDER BY weight DESC, updated_at DESC LIMIT 1`,
+			params: [params.entityId, params.agentId, canonical, canonical],
+			result: "get",
+		},
+		{ operation: "db:knowledge.aspect-by-name.read", deadlineMs: 2_000 },
+	);
 	return row ? rowToAspect(row) : null;
 }
 
@@ -780,28 +769,23 @@ export async function listEntityAliases(
 		readonly status?: "active" | "archived" | "all";
 	},
 ): Promise<readonly EntityAlias[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const conditions = ["entity_id = ?", "agent_id = ?"];
-			const args: string[] = [params.entityId, params.agentId];
-			if (params.status && params.status !== "all") {
-				conditions.push("status = ?");
-				args.push(params.status);
-			} else if (!params.status) {
-				conditions.push("status = 'active'");
-			}
-			const rows = db
-				.prepare(
-					`SELECT *
-				 FROM entity_aliases
-				 WHERE ${conditions.join(" AND ")}
-				 ORDER BY status ASC, alias ASC`,
-				)
-				.all(...args) as Array<Record<string, unknown>>;
-			return rows.map(rowToEntityAlias);
+	const conditions = ["entity_id = ?", "agent_id = ?"];
+	const args: Array<string | number> = [params.entityId, params.agentId];
+	if (params.status && params.status !== "all") {
+		conditions.push("status = ?");
+		args.push(params.status);
+	} else if (!params.status) {
+		conditions.push("status = 'active'");
+	}
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT * FROM entity_aliases WHERE ${conditions.join(" AND ")} ORDER BY status ASC, alias ASC`,
+			params: args,
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:783" },
+		{ operation: "db:knowledge.entity-aliases.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToEntityAlias);
 }
 
 export async function getEntityAspectsByName(
@@ -811,20 +795,28 @@ export async function getEntityAspectsByName(
 		readonly entity: string;
 	},
 ): Promise<{ readonly entity: Entity; readonly items: readonly AspectWithCounts[] } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			return {
-				entity,
-				items: readEntityAspectsWithCounts(db, entity.id, params.agentId),
-			};
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT asp.*, COUNT(DISTINCT CASE WHEN attr.kind = 'attribute' AND attr.status = 'active' THEN attr.id END) AS attribute_count,
+				COUNT(DISTINCT CASE WHEN attr.kind = 'constraint' AND attr.status = 'active' THEN attr.id END) AS constraint_count
+			 FROM entity_aspects asp LEFT JOIN entity_attributes attr ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
+			 WHERE asp.entity_id = ? AND asp.agent_id = ? AND COALESCE(asp.status, 'active') = 'active'
+			 GROUP BY asp.id ORDER BY asp.weight DESC, asp.name ASC`,
+			params: [entity.id, params.agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:814" },
+		{ operation: "db:knowledge.entity-aspects-with-counts.read", deadlineMs: 2_000 },
 	);
+	return {
+		entity,
+		items: rows.map((row) => ({
+			aspect: rowToAspect(row),
+			attributeCount: Number(row.attribute_count ?? 0),
+			constraintCount: Number(row.constraint_count ?? 0),
+		})),
+	};
 }
 
 export async function getEntityKnowledgeTree(
@@ -975,7 +967,7 @@ export async function getEntityKnowledgeTree(
 				}),
 			};
 		},
-		{ siteToken: "knowledge-graph.ts:841" },
+		{ siteToken: "db:knowledge.entity-knowledge-tree.read" },
 	);
 }
 
@@ -991,22 +983,17 @@ export async function listEntityGroups(
 	readonly aspect: EntityAspect;
 	readonly items: readonly EntityGroupSummary[];
 } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			const aspect = resolveAspectByName(db, {
-				entityId: entity.id,
-				agentId: params.agentId,
-				aspect: params.aspect,
-			});
-			if (!aspect) return null;
-			const rows = db
-				.prepare(
-					`SELECT
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const aspect = await resolveAspectByNameOnOwner({
+		entityId: entity.id,
+		agentId: params.agentId,
+		aspect: params.aspect,
+	});
+	if (!aspect) return null;
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
 				   COALESCE(ea.group_key, 'general') AS group_key,
 				   COUNT(DISTINCT CASE
 				     WHEN ea.kind = 'attribute' AND ea.status = 'active' THEN ea.id
@@ -1024,22 +1011,22 @@ export async function listEntityGroups(
 				   AND ea.status != 'deleted'
 				 GROUP BY COALESCE(ea.group_key, 'general')
 				 ORDER BY attribute_count DESC, constraint_count DESC, group_key ASC`,
-				)
-				.all(aspect.id, params.agentId) as Array<Record<string, unknown>>;
-			return {
-				entity,
-				aspect,
-				items: rows.map((row) => ({
-					groupKey: row.group_key as string,
-					attributeCount: Number(row.attribute_count ?? 0),
-					constraintCount: Number(row.constraint_count ?? 0),
-					claimCount: Number(row.claim_count ?? 0),
-					latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
-				})),
-			};
+			params: [aspect.id, params.agentId],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:994" },
+		{ operation: "db:knowledge.entity-groups.read", deadlineMs: 2_000 },
 	);
+	return {
+		entity,
+		aspect,
+		items: rows.map((row) => ({
+			groupKey: row.group_key as string,
+			attributeCount: Number(row.attribute_count ?? 0),
+			constraintCount: Number(row.constraint_count ?? 0),
+			claimCount: Number(row.claim_count ?? 0),
+			latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
+		})),
+	};
 }
 
 export async function listEntityClaims(
@@ -1055,23 +1042,18 @@ export async function listEntityClaims(
 	readonly aspect: EntityAspect;
 	readonly items: readonly EntityClaimSummary[];
 } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			const aspect = resolveAspectByName(db, {
-				entityId: entity.id,
-				agentId: params.agentId,
-				aspect: params.aspect,
-			});
-			if (!aspect) return null;
-			const group = toCanonicalName(params.group).replace(/\s+/g, "_");
-			const rows = db
-				.prepare(
-					`SELECT
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const aspect = await resolveAspectByNameOnOwner({
+		entityId: entity.id,
+		agentId: params.agentId,
+		aspect: params.aspect,
+	});
+	if (!aspect) return null;
+	const group = toCanonicalName(params.group).replace(/\s+/g, "_");
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
 				   ea.claim_key,
 				   ea.group_key,
 				   COUNT(DISTINCT CASE WHEN ea.kind = 'attribute' THEN ea.id END) AS attribute_count,
@@ -1098,25 +1080,25 @@ export async function listEntityClaims(
 				   AND ea.status != 'deleted'
 				 GROUP BY ea.claim_key, COALESCE(ea.group_key, 'general')
 				 ORDER BY active_count DESC, latest_updated_at DESC, ea.claim_key ASC`,
-				)
-				.all(aspect.id, params.agentId, group.length > 0 ? group : "general") as Array<Record<string, unknown>>;
-			return {
-				entity,
-				aspect,
-				items: rows.map((row) => ({
-					claimKey: row.claim_key as string,
-					groupKey: typeof row.group_key === "string" ? row.group_key : null,
-					attributeCount: Number(row.attribute_count ?? 0),
-					constraintCount: Number(row.constraint_count ?? 0),
-					activeCount: Number(row.active_count ?? 0),
-					supersededCount: Number(row.superseded_count ?? 0),
-					latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
-					preview: typeof row.preview === "string" ? row.preview : null,
-				})),
-			};
+			params: [aspect.id, params.agentId, group.length > 0 ? group : "general"],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1058" },
+		{ operation: "db:knowledge.entity-claims.read", deadlineMs: 2_000 },
 	);
+	return {
+		entity,
+		aspect,
+		items: rows.map((row) => ({
+			claimKey: row.claim_key as string,
+			groupKey: typeof row.group_key === "string" ? row.group_key : null,
+			attributeCount: Number(row.attribute_count ?? 0),
+			constraintCount: Number(row.constraint_count ?? 0),
+			activeCount: Number(row.active_count ?? 0),
+			supersededCount: Number(row.superseded_count ?? 0),
+			latestUpdatedAt: typeof row.latest_updated_at === "string" ? row.latest_updated_at : null,
+			preview: typeof row.preview === "string" ? row.preview : null,
+		})),
+	};
 }
 
 export async function listEntityAttributesByPath(
@@ -1137,58 +1119,49 @@ export async function listEntityAttributesByPath(
 	readonly aspect: EntityAspect;
 	readonly items: readonly EntityAttribute[];
 } | null> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const entity = resolveEntityRecordByName(db, {
-				agentId: params.agentId,
-				name: params.entity,
-			});
-			if (!entity) return null;
-			const aspect = resolveAspectByName(db, {
-				entityId: entity.id,
-				agentId: params.agentId,
-				aspect: params.aspect,
-			});
-			if (!aspect) return null;
-			const group = toCanonicalName(params.group).replace(/\s+/g, "_");
-			const claim = toCanonicalName(params.claim).replace(/\s+/g, "_");
-			if (claim.length === 0) return { entity, aspect, items: [] };
+	const entity = await resolveEntityByNameOnOwner(accessor, { agentId: params.agentId, name: params.entity });
+	if (!entity) return null;
+	const aspect = await resolveAspectByNameOnOwner({
+		entityId: entity.id,
+		agentId: params.agentId,
+		aspect: params.aspect,
+	});
+	if (!aspect) return null;
+	const group = toCanonicalName(params.group).replace(/\s+/g, "_");
+	const claim = toCanonicalName(params.claim).replace(/\s+/g, "_");
+	if (claim.length === 0) return { entity, aspect, items: [] };
 
-			const conditions = [
-				"ea.aspect_id = ?",
-				"ea.agent_id = ?",
-				"COALESCE(ea.group_key, 'general') = ?",
-				"ea.claim_key = ?",
-			];
-			const args: Array<string | number> = [aspect.id, params.agentId, group.length > 0 ? group : "general", claim];
-			if (params.kind) {
-				conditions.push("ea.kind = ?");
-				args.push(params.kind);
-			}
-			if (params.status && params.status !== "all") {
-				conditions.push("ea.status = ?");
-				args.push(params.status);
-			} else if (!params.status) {
-				conditions.push("ea.status = 'active'");
-			}
+	const conditions = [
+		"ea.aspect_id = ?",
+		"ea.agent_id = ?",
+		"COALESCE(ea.group_key, 'general') = ?",
+		"ea.claim_key = ?",
+	];
+	const args: Array<string | number> = [aspect.id, params.agentId, group.length > 0 ? group : "general", claim];
+	if (params.kind) {
+		conditions.push("ea.kind = ?");
+		args.push(params.kind);
+	}
+	if (params.status && params.status !== "all") {
+		conditions.push("ea.status = ?");
+		args.push(params.status);
+	} else if (!params.status) {
+		conditions.push("ea.status = 'active'");
+	}
 
-			const rows = db
-				.prepare(
-					`SELECT ea.*
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT ea.*
 				 FROM entity_attributes ea
 				 WHERE ${conditions.join(" AND ")}
 				 ORDER BY ea.created_at DESC, ea.importance DESC
 				 LIMIT ? OFFSET ?`,
-				)
-				.all(...args, params.limit, params.offset) as Array<Record<string, unknown>>;
-			return {
-				entity,
-				aspect,
-				items: rows.map(rowToAttribute),
-			};
+			params: [...args, params.limit, params.offset],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1140" },
+		{ operation: "db:knowledge.attributes-by-path.read", deadlineMs: 2_000 },
 	);
+	return { entity, aspect, items: rows.map(rowToAttribute) };
 }
 
 export async function listKnowledgeEntities(
@@ -1201,27 +1174,25 @@ export async function listKnowledgeEntities(
 		readonly offset: number;
 	},
 ): Promise<readonly KnowledgeEntityListItem[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const conditions = ["e.agent_id = ?"];
-			const args: Array<string | number> = [params.agentId];
-			conditions.push("COALESCE(e.status, 'active') = 'active'");
-			if (params.type) {
-				conditions.push("e.entity_type = ?");
-				args.push(params.type);
-			}
-			if (params.query) {
-				conditions.push("e.canonical_name LIKE ?");
-				args.push(`%${params.query.trim().toLowerCase()}%`);
-			}
+	const conditions = ["e.agent_id = ?"];
+	const args: Array<string | number> = [params.agentId];
+	conditions.push("COALESCE(e.status, 'active') = 'active'");
+	if (params.type) {
+		conditions.push("e.entity_type = ?");
+		args.push(params.type);
+	}
+	if (params.query) {
+		conditions.push("e.canonical_name LIKE ?");
+		args.push(`%${params.query.trim().toLowerCase()}%`);
+	}
 
-			// Paginate entity IDs first, then compute counts only for the page.
-			// This avoids materializing GROUP BY + ORDER BY across every entity in
-			// the agent scope before LIMIT can apply, which is prohibitive on graphs
-			// with tens of thousands of entities. See Signet-AI/signetai#515.
-			const rows = db
-				.prepare(
-					`WITH page AS (
+	// Paginate entity IDs first, then compute counts only for the page.
+	// This avoids materializing GROUP BY + ORDER BY across every entity in
+	// the agent scope before LIMIT can apply, which is prohibitive on graphs
+	// with tens of thousands of entities. See Signet-AI/signetai#515.
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `WITH page AS (
 					SELECT e.id
 					FROM entities e
 					WHERE ${conditions.join(" AND ")}
@@ -1268,19 +1239,19 @@ export async function listKnowledgeEntities(
 				 FROM page p
 				 JOIN entities e ON e.id = p.id
 				 ORDER BY e.pinned DESC, e.pinned_at DESC, e.mentions DESC, e.updated_at DESC, e.name ASC`,
-				)
-				.all(...args, params.limit, params.offset) as Array<Record<string, unknown>>;
-
-			return rows.map((row) => ({
-				entity: rowToEntity(row),
-				aspectCount: Number(row.aspect_count ?? 0),
-				attributeCount: Number(row.attribute_count ?? 0),
-				constraintCount: Number(row.constraint_count ?? 0),
-				dependencyCount: Number(row.dependency_count ?? 0),
-			}));
+			params: [...args, params.limit, params.offset],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1204" },
+		{ operation: "db:knowledge.entities-list.read", deadlineMs: 2_000 },
 	);
+
+	return rows.map((row) => ({
+		entity: rowToEntity(row),
+		aspectCount: Number(row.aspect_count ?? 0),
+		attributeCount: Number(row.attribute_count ?? 0),
+		constraintCount: Number(row.constraint_count ?? 0),
+		dependencyCount: Number(row.dependency_count ?? 0),
+	}));
 }
 
 export async function getKnowledgeEntityDetail(
@@ -1288,15 +1259,9 @@ export async function getKnowledgeEntityDetail(
 	entityId: string,
 	agentId: string,
 ): Promise<KnowledgeEntityDetail | null> {
-	const row = await accessor.withReadDbAsync(
-		(db) => {
-			// Scalar subqueries per count avoid GROUP BY materialization across
-			// the (LEFT JOIN aspects x attributes x dependencies) cartesian, which
-			// produces the same pathological shape as listKnowledgeEntities even
-			// when filtered to a single entity id. See Signet-AI/signetai#515.
-			return db
-				.prepare(
-					`SELECT
+	const row = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: `SELECT
 					e.*,
 					(
 						SELECT COUNT(*) FROM entity_aspects asp
@@ -1339,13 +1304,13 @@ export async function getKnowledgeEntityDetail(
 						  AND COALESCE(src.status, 'active') = 'active'
 						  AND dep.target_entity_id = e.id
 					) AS incoming_dependency_count
-				 FROM entities e
-				 WHERE e.id = ? AND e.agent_id = ?
-				   AND COALESCE(e.status, 'active') = 'active'`,
-				)
-				.get(entityId, agentId) as Record<string, unknown> | undefined;
+			 FROM entities e
+			 WHERE e.id = ? AND e.agent_id = ?
+			   AND COALESCE(e.status, 'active') = 'active'`,
+			params: [entityId, agentId],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:1291" },
+		{ operation: "db:knowledge.entity-detail.read", deadlineMs: 2_000 },
 	);
 
 	if (!row) return null;
@@ -1365,10 +1330,14 @@ export async function getKnowledgeEntityDetail(
 	};
 }
 
-function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: string): readonly AspectWithCounts[] {
-	const rows = db
-		.prepare(
-			`SELECT
+export async function getEntityAspectsWithCounts(
+	_accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): Promise<readonly AspectWithCounts[]> {
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
 				asp.*,
 				COUNT(DISTINCT CASE
 					WHEN attr.kind = 'attribute' AND attr.status = 'active' THEN attr.id
@@ -1383,8 +1352,11 @@ function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: stri
 			   AND COALESCE(asp.status, 'active') = 'active'
 			 GROUP BY asp.id
 			 ORDER BY asp.weight DESC, asp.name ASC`,
-		)
-		.all(entityId, agentId) as Array<Record<string, unknown>>;
+			params: [entityId, agentId],
+			result: "all",
+		},
+		{ operation: "db:knowledge.aspects-with-counts.read", deadlineMs: 2_000 },
+	);
 
 	return rows.map((row) => ({
 		aspect: rowToAspect(row),
@@ -1393,18 +1365,8 @@ function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: stri
 	}));
 }
 
-export async function getEntityAspectsWithCounts(
-	accessor: DbAccessor,
-	entityId: string,
-	agentId: string,
-): Promise<readonly AspectWithCounts[]> {
-	return await accessor.withReadDbAsync(async (db) => readEntityAspectsWithCounts(db, entityId, agentId), {
-		siteToken: "knowledge-graph.ts:1401",
-	});
-}
-
 export async function getAttributesForAspectFiltered(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly entityId: string;
 		readonly aspectId: string;
@@ -1415,99 +1377,95 @@ export async function getAttributesForAspectFiltered(
 		readonly offset: number;
 	},
 ): Promise<readonly EntityAttribute[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const conditions = [
-				"asp.entity_id = ?",
-				"asp.id = ?",
-				"asp.agent_id = ?",
-				"ea.agent_id = ?",
-				"COALESCE(e.status, 'active') = 'active'",
-				"COALESCE(asp.status, 'active') = 'active'",
-			];
-			const args: Array<string | number> = [params.entityId, params.aspectId, params.agentId, params.agentId];
-			if (params.kind) {
-				conditions.push("ea.kind = ?");
-				args.push(params.kind);
-			}
-			if (params.status) {
-				conditions.push("ea.status = ?");
-				args.push(params.status);
-			}
+	const conditions = [
+		"asp.entity_id = ?",
+		"asp.id = ?",
+		"asp.agent_id = ?",
+		"ea.agent_id = ?",
+		"COALESCE(e.status, 'active') = 'active'",
+		"COALESCE(asp.status, 'active') = 'active'",
+	];
+	const args: Array<string | number> = [params.entityId, params.aspectId, params.agentId, params.agentId];
+	if (params.kind) {
+		conditions.push("ea.kind = ?");
+		args.push(params.kind);
+	}
+	if (params.status) {
+		conditions.push("ea.status = ?");
+		args.push(params.status);
+	}
 
-			const rows = db
-				.prepare(
-					`SELECT ea.*
-				 FROM entity_attributes ea
-				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
-				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
-				 WHERE ${conditions.join(" AND ")}
-				 ORDER BY ea.importance DESC, ea.created_at DESC
-				 LIMIT ? OFFSET ?`,
-				)
-				.all(...args, params.limit, params.offset) as Array<Record<string, unknown>>;
-			return rows.map(rowToAttribute);
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT ea.*
+			 FROM entity_attributes ea
+			 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+			 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+			 WHERE ${conditions.join(" AND ")}
+			 ORDER BY ea.importance DESC, ea.created_at DESC
+			 LIMIT ? OFFSET ?`,
+			params: [...args, params.limit, params.offset],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1418" },
+		{ operation: "db:knowledge.attributes-filtered.read", deadlineMs: 2_000 },
 	);
+	return rows.map(rowToAttribute);
 }
 
 export async function getEntityDependenciesDetailed(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	params: {
 		readonly entityId: string;
 		readonly agentId: string;
 		readonly direction: "incoming" | "outgoing" | "both";
 	},
 ): Promise<readonly KnowledgeDependencyEdge[]> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const directionClauses: string[] = [];
-			if (params.direction === "incoming" || params.direction === "both") {
-				directionClauses.push("dep.target_entity_id = ?");
-			}
-			if (params.direction === "outgoing" || params.direction === "both") {
-				directionClauses.push("dep.source_entity_id = ?");
-			}
-			const rows = db
-				.prepare(
-					`SELECT
-					dep.*,
-					src.name AS source_entity_name,
-					dst.name AS target_entity_name
-				 FROM entity_dependencies dep
-				 JOIN entities src ON src.id = dep.source_entity_id
-				 JOIN entities dst ON dst.id = dep.target_entity_id
-				 WHERE dep.agent_id = ?
-				   AND (${directionClauses.join(" OR ")})
-				   AND COALESCE(dep.status, 'active') = 'active'
-				   AND COALESCE(src.status, 'active') = 'active'
-				   AND COALESCE(dst.status, 'active') = 'active'
-				 ORDER BY dep.strength DESC, dep.updated_at DESC`,
-				)
-				.all(
-					params.agentId,
-					...(params.direction === "incoming" || params.direction === "both" ? [params.entityId] : []),
-					...(params.direction === "outgoing" || params.direction === "both" ? [params.entityId] : []),
-				) as Array<Record<string, unknown>>;
-
-			return rows.map((row) => ({
-				id: row.id as string,
-				direction: row.source_entity_id === params.entityId ? "outgoing" : "incoming",
-				dependencyType: row.dependency_type as string,
-				strength: Number(row.strength ?? 0),
-				aspectId: (row.aspect_id as string) ?? null,
-				reason: typeof row.reason === "string" ? row.reason : null,
-				sourceEntityId: row.source_entity_id as string,
-				sourceEntityName: row.source_entity_name as string,
-				targetEntityId: row.target_entity_id as string,
-				targetEntityName: row.target_entity_name as string,
-				createdAt: row.created_at as string,
-				updatedAt: row.updated_at as string,
-			}));
+	const directionClauses: string[] = [];
+	if (params.direction === "incoming" || params.direction === "both") {
+		directionClauses.push("dep.target_entity_id = ?");
+	}
+	if (params.direction === "outgoing" || params.direction === "both") {
+		directionClauses.push("dep.source_entity_id = ?");
+	}
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
+				dep.*,
+				src.name AS source_entity_name,
+				dst.name AS target_entity_name
+			 FROM entity_dependencies dep
+			 JOIN entities src ON src.id = dep.source_entity_id
+			 JOIN entities dst ON dst.id = dep.target_entity_id
+			 WHERE dep.agent_id = ?
+			   AND (${directionClauses.join(" OR ")})
+			   AND COALESCE(dep.status, 'active') = 'active'
+			   AND COALESCE(src.status, 'active') = 'active'
+			   AND COALESCE(dst.status, 'active') = 'active'
+			 ORDER BY dep.strength DESC, dep.updated_at DESC`,
+			params: [
+				params.agentId,
+				...(params.direction === "incoming" || params.direction === "both" ? [params.entityId] : []),
+				...(params.direction === "outgoing" || params.direction === "both" ? [params.entityId] : []),
+			],
+			result: "all",
 		},
-		{ siteToken: "knowledge-graph.ts:1463" },
+		{ operation: "db:knowledge.dependencies-detailed.read", deadlineMs: 2_000 },
 	);
+
+	return rows.map((row) => ({
+		id: row.id as string,
+		direction: row.source_entity_id === params.entityId ? "outgoing" : "incoming",
+		dependencyType: row.dependency_type as string,
+		strength: Number(row.strength ?? 0),
+		aspectId: (row.aspect_id as string) ?? null,
+		reason: typeof row.reason === "string" ? row.reason : null,
+		sourceEntityId: row.source_entity_id as string,
+		sourceEntityName: row.source_entity_name as string,
+		targetEntityId: row.target_entity_id as string,
+		targetEntityName: row.target_entity_name as string,
+		createdAt: row.created_at as string,
+		updatedAt: row.updated_at as string,
+	}));
 }
 
 export async function getKnowledgeStats(_accessor: DbAccessor, agentId: string): Promise<KnowledgeStats> {
@@ -1594,96 +1552,99 @@ export async function getKnowledgeStats(_accessor: DbAccessor, agentId: string):
 }
 
 export async function getEntityHealth(
-	accessor: DbAccessor,
+	_accessor: DbAccessor,
 	agentId: string,
 	since?: string,
 	minComparisons = 3,
 ): Promise<ReadonlyArray<EntityHealth>> {
-	return await accessor.withReadDbAsync(
-		async (db) => {
-			const predictorTable = db
-				.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'predictor_comparisons'")
-				.get() as { name: string } | undefined;
-			if (!predictorTable) return [];
-
-			const args: Array<string | number> = [agentId];
-			const sinceClause = typeof since === "string" && since.length > 0 ? " AND created_at >= ?" : "";
-			if (sinceClause && since !== undefined) {
-				args.push(since);
-			}
-
-			const rows = db
-				.prepare(
-					`SELECT
-					focal_entity_id,
-					COALESCE(focal_entity_name, '') AS focal_entity_name,
-					predictor_won,
-					margin,
-					created_at
-				 FROM predictor_comparisons
-				 WHERE agent_id = ?
-				   AND focal_entity_id IS NOT NULL
-				   ${sinceClause}
-				 ORDER BY focal_entity_id ASC, created_at ASC`,
-				)
-				.all(...args) as Array<Record<string, unknown>>;
-
-			const grouped = new Map<
-				string,
-				Array<{
-					readonly entityName: string;
-					readonly predictorWon: number;
-					readonly margin: number;
-				}>
-			>();
-			for (const row of rows) {
-				if (typeof row.focal_entity_id !== "string") continue;
-				const bucket = grouped.get(row.focal_entity_id) ?? [];
-				bucket.push({
-					entityName:
-						typeof row.focal_entity_name === "string" && row.focal_entity_name.length > 0
-							? row.focal_entity_name
-							: row.focal_entity_id,
-					predictorWon: Number(row.predictor_won ?? 0),
-					margin: Number(row.margin ?? 0),
-				});
-				grouped.set(row.focal_entity_id, bucket);
-			}
-
-			const health: EntityHealth[] = [];
-			for (const [entityId, comparisons] of grouped) {
-				if (comparisons.length < minComparisons) continue;
-
-				const wins = comparisons.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0);
-				const avgMargin = comparisons.reduce((total, row) => total + row.margin, 0) / comparisons.length;
-				const midpoint = Math.max(1, Math.floor(comparisons.length / 2));
-				const firstHalf = comparisons.slice(0, midpoint);
-				const secondHalf = comparisons.slice(midpoint);
-				const firstHalfRate =
-					firstHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / firstHalf.length;
-				const secondHalfRate =
-					secondHalf.length > 0
-						? secondHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / secondHalf.length
-						: firstHalfRate;
-				const rateDelta = secondHalfRate - firstHalfRate;
-				health.push({
-					entityId,
-					entityName: comparisons[0]?.entityName ?? entityId,
-					comparisonCount: comparisons.length,
-					winRate: wins / comparisons.length,
-					avgMargin,
-					trend: rateDelta > 0.1 ? "improving" : rateDelta < -0.1 ? "declining" : "stable",
-				});
-			}
-
-			health.sort((a, b) => {
-				if (b.winRate !== a.winRate) return b.winRate - a.winRate;
-				return b.comparisonCount - a.comparisonCount;
-			});
-			return health;
+	const predictorTable = await dbOwnerQuery<Record<string, unknown> | null>(
+		{
+			sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'predictor_comparisons'",
+			params: [],
+			result: "get",
 		},
-		{ siteToken: "knowledge-graph.ts:1602" },
+		{ operation: "db:knowledge.predictor-table.read", deadlineMs: 2_000 },
 	);
+	if (predictorTable === null) return [];
+
+	const args: Array<string | number> = [agentId];
+	const sinceClause = typeof since === "string" && since.length > 0 ? " AND created_at >= ?" : "";
+	if (sinceClause && since !== undefined) {
+		args.push(since);
+	}
+
+	const rows = await dbOwnerQuery<Array<Record<string, unknown>>>(
+		{
+			sql: `SELECT
+			focal_entity_id,
+			COALESCE(focal_entity_name, '') AS focal_entity_name,
+			predictor_won,
+			margin,
+			created_at
+		 FROM predictor_comparisons
+		 WHERE agent_id = ?
+		   AND focal_entity_id IS NOT NULL
+		   ${sinceClause}
+		 ORDER BY focal_entity_id ASC, created_at ASC`,
+			params: args,
+			result: "all",
+		},
+		{ operation: "db:knowledge.entity-health.read", deadlineMs: 2_000 },
+	);
+
+	const grouped = new Map<
+		string,
+		Array<{
+			readonly entityName: string;
+			readonly predictorWon: number;
+			readonly margin: number;
+		}>
+	>();
+	for (const row of rows) {
+		if (typeof row.focal_entity_id !== "string") continue;
+		const bucket = grouped.get(row.focal_entity_id) ?? [];
+		bucket.push({
+			entityName:
+				typeof row.focal_entity_name === "string" && row.focal_entity_name.length > 0
+					? row.focal_entity_name
+					: row.focal_entity_id,
+			predictorWon: Number(row.predictor_won ?? 0),
+			margin: Number(row.margin ?? 0),
+		});
+		grouped.set(row.focal_entity_id, bucket);
+	}
+
+	const health: EntityHealth[] = [];
+	for (const [entityId, comparisons] of grouped) {
+		if (comparisons.length < minComparisons) continue;
+
+		const wins = comparisons.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0);
+		const avgMargin = comparisons.reduce((total, row) => total + row.margin, 0) / comparisons.length;
+		const midpoint = Math.max(1, Math.floor(comparisons.length / 2));
+		const firstHalf = comparisons.slice(0, midpoint);
+		const secondHalf = comparisons.slice(midpoint);
+		const firstHalfRate =
+			firstHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / firstHalf.length;
+		const secondHalfRate =
+			secondHalf.length > 0
+				? secondHalf.reduce((total, row) => total + (row.predictorWon > 0 ? 1 : 0), 0) / secondHalf.length
+				: firstHalfRate;
+		const rateDelta = secondHalfRate - firstHalfRate;
+		health.push({
+			entityId,
+			entityName: comparisons[0]?.entityName ?? entityId,
+			comparisonCount: comparisons.length,
+			winRate: wins / comparisons.length,
+			avgMargin,
+			trend: rateDelta > 0.1 ? "improving" : rateDelta < -0.1 ? "declining" : "stable",
+		});
+	}
+
+	health.sort((a, b) => {
+		if (b.winRate !== a.winRate) return b.winRate - a.winRate;
+		return b.comparisonCount - a.comparisonCount;
+	});
+	return health;
 }
 
 export async function propagateMemoryStatus(accessor: DbAccessor, agentId: string): Promise<number> {
@@ -2224,7 +2185,7 @@ export async function getKnowledgeGraphForConstellation(
 				},
 			};
 		},
-		{ siteToken: "knowledge-graph.ts:1984" },
+		{ siteToken: "db:knowledge.graph-constellation.read" },
 	);
 }
 

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -9,7 +9,7 @@
  * another cycle starts.
  */
 
-import type { DbAccessor } from "../db-accessor";
+import type { DbAccessor, SyncDbCallSiteToken } from "../db-accessor";
 import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import { ownerQueryAll, ownerQueryOne } from "../db-owner-maintenance";
 import { reclaimIncrementalVacuum } from "../db-vacuum-worker";
@@ -146,7 +146,7 @@ async function getGraphAgentIds(
 				sql,
 			)
 		: await accessor.withReadDbAsync((db) => db.prepare(sql).all() as Array<{ agent_id: string | null }>, {
-				siteToken: "pipeline/maintenance-worker.ts:148",
+				siteToken: "db:maintenance.graph-agent-scopes.read",
 			});
 	const ids = rows.flatMap((row) =>
 		typeof row.agent_id === "string" && row.agent_id.length > 0 ? [row.agent_id] : [],
@@ -338,7 +338,7 @@ export function startMaintenanceWorker(
 	};
 
 	async function doTick(): Promise<MaintenanceCycleResult> {
-		const readDiagnostics = async (siteToken: string): Promise<DiagnosticsReport> =>
+		const readDiagnostics = async (siteToken: SyncDbCallSiteToken): Promise<DiagnosticsReport> =>
 			deps.ownerMaintenance
 				? await deps.ownerMaintenance.diagnostics(tracker.stats)
 				: // Each caller supplies the original static token for this compatibility fallback.
@@ -499,7 +499,7 @@ export function startMaintenanceWorker(
 										DEAD_MEMORY_DEFAULT_ACCESS_DAYS,
 									) as { n: number }
 							).n,
-						{ siteToken: "pipeline/maintenance-worker.ts:485" },
+						{ siteToken: "db:maintenance.dead-memory-count.read" },
 					);
 			const count = typeof countRow === "number" ? countRow : (countRow?.n ?? 0);
 			if (count > 100) {

--- a/platform/daemon/src/sync-db-attribution.test.ts
+++ b/platform/daemon/src/sync-db-attribution.test.ts
@@ -33,6 +33,13 @@ describe("sync DB attribution", () => {
 		void token;
 	});
 
+	test("latches a stable semantic ID without a source line", () => {
+		const token = beginSyncDbCall("withReadDb", 1_000, "db:vacuum.status.read");
+
+		expect(getSyncDbCallSitesForWindow(1_000, 2_000)).toEqual(["withReadDb@db:vacuum.status.read"]);
+		void token;
+	});
+
 	test("keeps an invalid site token explicitly unattributed", () => {
 		const token = beginSyncDbCall("withReadDb", 1_000, "not-a-site");
 		endSyncDbCall(token, 1_051);

--- a/platform/daemon/src/sync-db-attribution.ts
+++ b/platform/daemon/src/sync-db-attribution.ts
@@ -10,6 +10,10 @@
  * retained.
  */
 
+import { classifySyncDbSiteToken, type SyncDbCallSiteToken } from "./sync-db-site-token";
+
+export type { SyncDbCallSiteToken } from "./sync-db-site-token";
+
 export type SyncDbCallKind =
 	| "withReadDb"
 	| "withWriteTx"
@@ -19,8 +23,6 @@ export type SyncDbCallKind =
 	| "checkpointWalAsync"
 	| "incrementalVacuumAsync"
 	| "vacuumConversionAsync";
-export type SyncDbCallSiteToken = string;
-
 export interface SyncDbCallToken {
 	readonly sequence: number;
 	readonly siteId: string;
@@ -136,8 +138,9 @@ function resolveSiteToken(siteToken: SyncDbCallSiteToken | undefined): string {
 	if (siteToken === undefined) return UNATTRIBUTED_SITE;
 	const cached = siteTokenCache.get(siteToken);
 	if (cached !== undefined) return cached;
-	if (!/^[^:]+(?:\/[^:]+)*:\d+$/.test(siteToken)) return UNATTRIBUTED_SITE;
-	const resolved = `${SITE_TOKEN_PREFIX}${siteToken}`;
+	const kind = classifySyncDbSiteToken(siteToken);
+	if (kind === null) return UNATTRIBUTED_SITE;
+	const resolved = kind === "semantic" ? siteToken : `${SITE_TOKEN_PREFIX}${siteToken}`;
 	siteTokenCache.set(siteToken, resolved);
 	return resolved;
 }
@@ -255,7 +258,8 @@ export function captureSyncDbCallSiteToken(): SyncDbCallSiteToken | undefined {
 	const site = captureCallerSite();
 	if (site === UNATTRIBUTED_SITE) return undefined;
 	const prefixIndex = site.lastIndexOf(SITE_TOKEN_PREFIX);
-	return prefixIndex >= 0 ? site.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : site;
+	const token = prefixIndex >= 0 ? site.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : site;
+	return classifySyncDbSiteToken(token) === null ? undefined : (token as SyncDbCallSiteToken);
 }
 
 /** Return site ids whose synchronous interval overlapped the observed stall. */

--- a/platform/daemon/src/sync-db-site-token.ts
+++ b/platform/daemon/src/sync-db-site-token.ts
@@ -1,0 +1,18 @@
+export type SyncDbSourceLocationToken = `${string}:${number}`;
+export type SyncDbSemanticSiteToken = `db:${string}.${string}.${string}`;
+export type SyncDbCallSiteToken = SyncDbSourceLocationToken | SyncDbSemanticSiteToken;
+
+const SOURCE_LOCATION_TOKEN = /^[^:\s]+(?:\/[^:\s]+)*:\d+$/;
+const SEMANTIC_TOKEN = /^db:[a-z0-9]+(?:[.-][a-z0-9]+){2,}$/;
+
+export type SyncDbSiteTokenKind = "source-location" | "semantic";
+
+export function classifySyncDbSiteToken(token: string): SyncDbSiteTokenKind | null {
+	if (SOURCE_LOCATION_TOKEN.test(token)) return "source-location";
+	if (SEMANTIC_TOKEN.test(token)) return "semantic";
+	return null;
+}
+
+export function isSemanticSyncDbSiteToken(token: string | null): token is SyncDbSemanticSiteToken {
+	return token !== null && classifySyncDbSiteToken(token) === "semantic";
+}

--- a/platform/daemon/src/sync-db-site-token.ts
+++ b/platform/daemon/src/sync-db-site-token.ts
@@ -2,7 +2,7 @@ export type SyncDbSourceLocationToken = `${string}:${number}`;
 export type SyncDbSemanticSiteToken = `db:${string}.${string}.${string}`;
 export type SyncDbCallSiteToken = SyncDbSourceLocationToken | SyncDbSemanticSiteToken;
 
-const SOURCE_LOCATION_TOKEN = /^[^:\s]+(?:\/[^:\s]+)*:\d+$/;
+const SOURCE_LOCATION_TOKEN = /^[^:/\s]+(?:\/[^:/\s]+)*:\d+$/;
 const SEMANTIC_TOKEN = /^db:[a-z0-9]+(?:[.-][a-z0-9]+){2,}$/;
 
 export type SyncDbSiteTokenKind = "source-location" | "semantic";

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -24,10 +24,10 @@ test("the deterministic ledger retains the exact current source inventory", () =
 	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(166);
 });
 
-test("the event-loop ledger exactly equals the current source inventory", () => {
+test("the event-loop ledger exactly matches the current source identities", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const result = runAudit({ sourceRoot: resolve("platform/daemon/src"), baselineSites: baseline });
-	expect(result.sites).toEqual(baseline);
+	expect(occurrenceKeys(result.sites)).toEqual(occurrenceKeys(baseline));
 });
 
 test("classifies database callbacks by execution home rather than async API spelling", () => {
@@ -152,6 +152,38 @@ test("a tokenless async-named DB call fails the attribution coverage rule", () =
 		expect(violation?.path).toBe("missing-token.ts");
 		expect(violation?.api).toBe("withReadDbAsync");
 		expect(violation?.message).toContain('"missing-token.ts:1"');
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("stable semantic DB tokens survive line movement and remain globally unique", () => {
+	const root = mkdtempSync(join(tmpdir(), "signet-semantic-site-token-"));
+	try {
+		writeFileSync(
+			join(root, "semantic.ts"),
+			['getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });', "", ""].join("\n"),
+		);
+		let result = runAudit({ sourceRoot: root });
+		expect(result.violations.filter((item) => item.kind === "missing-async-db-site-token")).toEqual([]);
+		const baseline = result.sites;
+		const originalKeys = occurrenceKeys(result.sites);
+		writeFileSync(
+			join(root, "semantic.ts"),
+			'\n\ngetDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
+		);
+		result = runAudit({ sourceRoot: root, baselineSites: baseline });
+		expect(occurrenceKeys(result.sites)).toEqual(originalKeys);
+		expect(result.violations.filter((item) => item.kind === "new-parent-execution-site")).toEqual([]);
+
+		writeFileSync(
+			join(root, "duplicate.ts"),
+			'getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
+		);
+		result = runAudit({ sourceRoot: root });
+		const duplicate = result.violations.find((item) => item.kind === "duplicate-db-site-token");
+		expect(duplicate?.message).toContain("semantic.ts:3");
+		expect(duplicate?.message).toContain("duplicate.ts:1");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -364,6 +396,8 @@ test("the generated report describes the type boundary and transitional counts",
 	expect(report).toContain("Database accessor sites classified: 383");
 	expect(report).toContain("ON-PARENT callback execution: 381");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
+	expect(report).toContain("durable identity; file and line remain diagnostic metadata");
+	expect(report).toContain("`db:vacuum.conversion-status.read` (withReadDbAsync)");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).toContain("type boundary");

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(882);
+	expect(baseline).toHaveLength(879);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(147);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(146);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,16 +353,16 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 882 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 200");
+	expect(report).toContain("Exact ledger inventory: 879 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 199 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 197");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 197 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 366");
-	expect(report).toContain("ON-PARENT callback execution: 364");
+	expect(report).toContain("Database accessor sites classified: 363");
+	expect(report).toContain("ON-PARENT callback execution: 361");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(899);
+	expect(baseline).toHaveLength(882);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(166);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(147);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,21 +353,21 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 899 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 219 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 217");
+	expect(report).toContain("Exact ledger inventory: 882 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 202 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 200");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 217 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 200 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 383");
-	expect(report).toContain("ON-PARENT callback execution: 381");
+	expect(report).toContain("Database accessor sites classified: 366");
+	expect(report).toContain("ON-PARENT callback execution: 364");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).toContain("type boundary");
-	expect(report).not.toContain("Exact ledger inventory: 928 sites");
+	expect(report).not.toContain("Exact ledger inventory: 997 sites");
 });
 
 const countBaseline = (total: number, withReadDb: number, withWriteTx: number): LegacyDbCountBaseline => ({

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -24,10 +24,10 @@ test("the deterministic ledger retains the exact current source inventory", () =
 	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(166);
 });
 
-test("the event-loop ledger exactly matches the current source identities", () => {
+test("the event-loop ledger exactly equals the current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const result = runAudit({ sourceRoot: resolve("platform/daemon/src"), baselineSites: baseline });
-	expect(occurrenceKeys(result.sites)).toEqual(occurrenceKeys(baseline));
+	expect(result.sites).toEqual(baseline);
 });
 
 test("classifies database callbacks by execution home rather than async API spelling", () => {
@@ -152,38 +152,6 @@ test("a tokenless async-named DB call fails the attribution coverage rule", () =
 		expect(violation?.path).toBe("missing-token.ts");
 		expect(violation?.api).toBe("withReadDbAsync");
 		expect(violation?.message).toContain('"missing-token.ts:1"');
-	} finally {
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test("stable semantic DB tokens survive line movement and remain globally unique", () => {
-	const root = mkdtempSync(join(tmpdir(), "signet-semantic-site-token-"));
-	try {
-		writeFileSync(
-			join(root, "semantic.ts"),
-			['getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });', "", ""].join("\n"),
-		);
-		let result = runAudit({ sourceRoot: root });
-		expect(result.violations.filter((item) => item.kind === "missing-async-db-site-token")).toEqual([]);
-		const baseline = result.sites;
-		const originalKeys = occurrenceKeys(result.sites);
-		writeFileSync(
-			join(root, "semantic.ts"),
-			'\n\ngetDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
-		);
-		result = runAudit({ sourceRoot: root, baselineSites: baseline });
-		expect(occurrenceKeys(result.sites)).toEqual(originalKeys);
-		expect(result.violations.filter((item) => item.kind === "new-parent-execution-site")).toEqual([]);
-
-		writeFileSync(
-			join(root, "duplicate.ts"),
-			'getDbAccessor().withReadDbAsync((db) => db, { siteToken: "db:vacuum.status.read" });\n',
-		);
-		result = runAudit({ sourceRoot: root });
-		const duplicate = result.violations.find((item) => item.kind === "duplicate-db-site-token");
-		expect(duplicate?.message).toContain("semantic.ts:3");
-		expect(duplicate?.message).toContain("duplicate.ts:1");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -396,8 +364,6 @@ test("the generated report describes the type boundary and transitional counts",
 	expect(report).toContain("Database accessor sites classified: 383");
 	expect(report).toContain("ON-PARENT callback execution: 381");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
-	expect(report).toContain("durable identity; file and line remain diagnostic metadata");
-	expect(report).toContain("`db:vacuum.conversion-status.read` (withReadDbAsync)");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).toContain("type boundary");

--- a/scripts/audit-event-loop-contract.ts
+++ b/scripts/audit-event-loop-contract.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import ts from "typescript";
+import { isSemanticSyncDbSiteToken } from "../platform/daemon/src/sync-db-site-token";
 
 /** The synchronous APIs recorded in the migration ledger. */
 export const SYNC_APIS = [
@@ -54,6 +55,8 @@ export interface AuditSite {
 	readonly api: SyncApi;
 	readonly source: string;
 	readonly category: SiteCategory;
+	/** Stable identity for migrated DB sites; path and line remain diagnostic metadata. */
+	readonly siteToken?: string;
 }
 
 /** A database site classified by the process that executes its callback. */
@@ -123,6 +126,15 @@ export interface MissingAsyncDbSiteTokenViolation {
 	readonly message: string;
 }
 
+/** A semantic attribution ID reused by more than one database call site. */
+export interface DuplicateDbSiteTokenViolation {
+	readonly kind: "duplicate-db-site-token";
+	readonly path: string;
+	readonly line: number;
+	readonly token: string;
+	readonly message: string;
+}
+
 /** Committed marker-count snapshot; the ratchet fails when the live count grows past it. */
 export interface LegacyDbCountBaseline {
 	readonly version: 1;
@@ -150,6 +162,7 @@ export interface AuditResult {
 		| UnmarkedLegacyDbAccessViolation
 		| MissingLegacyDbSiteTokenViolation
 		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
 	)[];
 	readonly legacyDbAccess: LegacyDbAccessCounts;
 	readonly executionHomeSites: readonly ExecutionHomeSite[];
@@ -404,11 +417,26 @@ function findImportBoundaryViolations(
 function findLegacyDbAccessSites(sourceRoot: string): {
 	readonly sites: AuditSite[];
 	readonly unmarked: UnmarkedCallSite[];
-	readonly missingSiteTokens: (MissingLegacyDbSiteTokenViolation | MissingAsyncDbSiteTokenViolation)[];
+	readonly siteTokenViolations: (
+		| MissingLegacyDbSiteTokenViolation
+		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
+	)[];
 } {
 	const sites: AuditSite[] = [];
 	const unmarked: UnmarkedCallSite[] = [];
-	const missingSiteTokens: (MissingLegacyDbSiteTokenViolation | MissingAsyncDbSiteTokenViolation)[] = [];
+	const siteTokenViolations: (
+		| MissingLegacyDbSiteTokenViolation
+		| MissingAsyncDbSiteTokenViolation
+		| DuplicateDbSiteTokenViolation
+	)[] = [];
+	const semanticTokenSites = new Map<string, Array<{ readonly path: string; readonly line: number }>>();
+	const recordSemanticToken = (token: string | null, path: string, line: number): void => {
+		if (!isSemanticSyncDbSiteToken(token)) return;
+		const locations = semanticTokenSites.get(token) ?? [];
+		locations.push({ path, line });
+		semanticTokenSites.set(token, locations);
+	};
 	for (const path of walk(sourceRoot)) {
 		const source = readFileSync(path, "utf8");
 		const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
@@ -439,13 +467,7 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 						? expression.name.getStart(sourceFile)
 						: expression.getStart(sourceFile);
 					const line = lineNumber(sourceFile, position);
-					sites.push({
-						path: relativePath,
-						line,
-						api: api as SyncApi,
-						source: lines[line - 1]?.trim() ?? "",
-						category: "hot-path",
-					});
+					let semanticSiteToken: string | undefined;
 					if (isLegacyDbMemberAccess && LEGACY_DB_APIS.includes(api as LegacyDbApi)) {
 						let marked = false;
 						for (let candidate = line - 1; candidate >= Math.max(1, line - MARKER_WINDOW_LINES); candidate--) {
@@ -459,13 +481,15 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 							const tokenArgument = node.arguments[1];
 							const token = tokenArgument === undefined ? null : staticStringValue(tokenArgument, bindings);
 							const expected = `${relativePath}:${line}`;
-							if (token !== expected) {
-								missingSiteTokens.push({
+							recordSemanticToken(token, relativePath, line);
+							if (isSemanticSyncDbSiteToken(token)) semanticSiteToken = token;
+							if (token !== expected && !isSemanticSyncDbSiteToken(token)) {
+								siteTokenViolations.push({
 									kind: "missing-legacy-db-site-token",
 									path: relativePath,
 									line,
 									api: api as LegacyDbApi,
-									message: `${relativePath}:${line} ${api}() must pass its static site token ${JSON.stringify(expected)}; unattributed in-flight DB calls are not allowed`,
+									message: `${relativePath}:${line} ${api}() must pass ${JSON.stringify(expected)} or a unique stable semantic token such as "db:vacuum.status.read"; unattributed in-flight DB calls are not allowed`,
 								});
 							}
 						}
@@ -475,27 +499,49 @@ function findLegacyDbAccessSites(sourceRoot: string): {
 						if (!isLegacy) {
 							const expected = `${relativePath}:${line}`;
 							const token = staticAsyncSiteToken(node, bindings, api as Exclude<AttributedDbApi, LegacyDbApi>);
+							recordSemanticToken(token, relativePath, line);
+							if (isSemanticSyncDbSiteToken(token)) semanticSiteToken = token;
 							const dynamicTokenBoundary = lines
 								.slice(Math.max(0, line - 3), line)
 								.some((candidate) => candidate.includes("DYNAMIC_SITE_TOKEN"));
-							if (!dynamicTokenBoundary && token !== expected) {
-								missingSiteTokens.push({
+							if (!dynamicTokenBoundary && token !== expected && !isSemanticSyncDbSiteToken(token)) {
+								siteTokenViolations.push({
 									kind: "missing-async-db-site-token",
 									path: relativePath,
 									line,
 									api: api as Exclude<AttributedDbApi, LegacyDbApi>,
-									message: `${relativePath}:${line} ${api}() must pass its static site token ${JSON.stringify(expected)}; unattributed in-flight DB calls are not allowed`,
+									message: `${relativePath}:${line} ${api}() must pass ${JSON.stringify(expected)} or a unique stable semantic token such as "db:vacuum.status.read"; unattributed in-flight DB calls are not allowed`,
 								});
 							}
 						}
 					}
+					sites.push({
+						path: relativePath,
+						line,
+						api: api as SyncApi,
+						source: lines[line - 1]?.trim() ?? "",
+						category: "hot-path",
+						...(semanticSiteToken === undefined ? {} : { siteToken: semanticSiteToken }),
+					});
 				}
 			}
 			ts.forEachChild(node, visit);
 		};
 		visit(sourceFile);
 	}
-	return { sites, unmarked, missingSiteTokens };
+	for (const [token, locations] of semanticTokenSites) {
+		if (locations.length < 2) continue;
+		const first = locations[0];
+		if (first === undefined) continue;
+		siteTokenViolations.push({
+			kind: "duplicate-db-site-token",
+			path: first.path,
+			line: first.line,
+			token,
+			message: `stable DB site token ${JSON.stringify(token)} is reused at ${locations.map((site) => `${site.path}:${site.line}`).join(", ")}; semantic tokens must identify exactly one call site`,
+		});
+	}
+	return { sites, unmarked, siteTokenViolations };
 }
 
 /**
@@ -528,7 +574,8 @@ export interface UnmarkedCallSite {
 	readonly api: LegacyDbApi;
 }
 
-function siteKey(site: Pick<AuditSite, "path" | "api" | "source">): string {
+function siteKey(site: Pick<AuditSite, "path" | "api" | "source" | "siteToken">): string {
+	if (site.siteToken !== undefined) return `semantic\u0000${site.api}\u0000${site.siteToken}`;
 	return `${site.path}\u0000${site.api}\u0000${site.source}`;
 }
 
@@ -697,7 +744,7 @@ export function writeCountBaseline(
 }
 
 export function runAudit(options: AuditOptions): AuditResult {
-	const { sites, unmarked, missingSiteTokens } = findLegacyDbAccessSites(options.sourceRoot);
+	const { sites, unmarked, siteTokenViolations } = findLegacyDbAccessSites(options.sourceRoot);
 	const baselineSites = options.baselineSites ?? [];
 	const executionHomeSites = classifyExecutionHomes(sites);
 	return {
@@ -707,7 +754,7 @@ export function runAudit(options: AuditOptions): AuditResult {
 			...findNewLegacyDbAccessViolations(sites, baselineSites),
 			...findNewParentExecutionSiteViolations(executionHomeSites, baselineSites),
 			...findUnmarkedLegacyDbAccess(unmarked),
-			...missingSiteTokens,
+			...siteTokenViolations,
 		],
 		legacyDbAccess: countLegacyDbAccess(options.sourceRoot),
 		executionHomeSites,
@@ -748,11 +795,11 @@ export function renderReport(baselineSites: readonly AuditSite[], legacyDbAccess
 		const sites = executionHomeSites.filter((site) => site.executionHome === home);
 		return sites.length === 0
 			? "- None"
-			: sites.map((site) => `- \`${site.path}:${site.line}\` (${site.api})`).join("\n");
+			: sites.map((site) => `- \`${site.siteToken ?? `${site.path}:${site.line}`}\` (${site.api})`).join("\n");
 	};
 	return `# Event-loop synchronous contract audit
 
-This report is generated from the deterministic migration ledger in \`scripts/event-loop-contract-baseline.json\`. Phase A enforces the type boundary structurally: production code receives an async-only \`DbAccessor\`, while the synchronous compatibility module lives outside the daemon production \`src/\` tree and is rejected by the production TypeScript project's \`rootDir\`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching.
+This report is generated from the deterministic migration ledger in \`scripts/event-loop-contract-baseline.json\`. Phase A enforces the type boundary structurally: production code receives an async-only \`DbAccessor\`, while the synchronous compatibility module lives outside the daemon production \`src/\` tree and is rejected by the production TypeScript project's \`rootDir\`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching. Migrated DB sites use unique \`db:domain.operation.action\` IDs as their durable identity; file and line remain diagnostic metadata.
 
 ## Current inventory
 

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -931,35 +931,40 @@
       "line": 331,
       "api": "withReadDb",
       "source": "return accessor.withReadDb(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-status.sync-read"
     },
     {
       "path": "db-vacuum.ts",
       "line": 339,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-status.read"
     },
     {
       "path": "db-vacuum.ts",
       "line": 347,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-running"
     },
     {
       "path": "db-vacuum.ts",
       "line": 367,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-completed"
     },
     {
       "path": "db-vacuum.ts",
       "line": 386,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:vacuum.conversion-state.mark-failed"
     },
     {
       "path": "discord-desktop-cache-source.ts",
@@ -3031,7 +3036,8 @@
       "line": 148,
       "api": "withReadDbAsync",
       "source": ": await accessor.withReadDbAsync((db) => db.prepare(sql).all() as Array<{ agent_id: string | null }>, {",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:maintenance.graph-agent-scopes.read"
     },
     {
       "path": "pipeline/maintenance-worker.ts",
@@ -3045,7 +3051,8 @@
       "line": 485,
       "api": "withReadDbAsync",
       "source": ": await accessor.withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:maintenance.dead-memory-count.read"
     },
     {
       "path": "pipeline/prospective-index.ts",

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -931,40 +931,35 @@
       "line": 331,
       "api": "withReadDb",
       "source": "return accessor.withReadDb(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-status.sync-read"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 339,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-status.read"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 347,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-state.mark-running"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 367,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-state.mark-completed"
+      "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 386,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path",
-      "siteToken": "db:vacuum.conversion-state.mark-failed"
+      "category": "hot-path"
     },
     {
       "path": "discord-desktop-cache-source.ts",

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1453,157 +1453,19 @@
     },
     {
       "path": "knowledge-graph.ts",
-      "line": 193,
+      "line": 833,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:knowledge.entity-knowledge-tree.read"
     },
     {
       "path": "knowledge-graph.ts",
-      "line": 218,
+      "line": 1945,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 243,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 271,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 287,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 312,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 340,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 422,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 605,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 783,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 814,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 841,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 994,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1058,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1140,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1204,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1291,
-      "api": "withReadDbAsync",
-      "source": "const row = await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1401,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(async (db) => readEntityAspectsWithCounts(db, entityId, agentId), {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1418,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1463,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1602,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1984,
-      "api": "withReadDbAsync",
-      "source": "return await accessor.withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:knowledge.graph-constellation.read"
     },
     {
       "path": "lifecycle.ts",


### PR DESCRIPTION
## Summary

Route the wave 6 knowledge-graph read sites through the daemon DB owner with bounded admission, while preserving the two intentionally multi-query reads as owner-attributed callbacks. Add stable semantic attribution IDs so the event-loop audit ledger survives line movement and rejects duplicate identities.

## Changes

- Migrated 20 knowledge-graph async read sites to `dbOwnerQuery` with explicit operations and deadlines.
- Added semantic `db:domain.operation.action` site tokens and duplicate-token audit validation.
- Updated DB attribution tests and maintenance-worker tokens.
- Regenerated the deterministic event-loop audit baseline/report after rebasing onto current `main`.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [x] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: 

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints (no admin/mutation endpoint changes)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (focused checks pass; baseline failures documented below)

## Migration Notes (if applicable)

N/A: no schema or data migration.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Verification performed:

- `bun scripts/audit-event-loop-contract.ts` passes: 879 sites, 164 legacy DB sites, 361 ON-PARENT and 2 OFF-PARENT async-named sites.
- `bun test scripts/audit-event-loop-contract.test.ts platform/daemon/src/sync-db-attribution.test.ts` passes: 28 tests.
- `bun run --filter '@signet/daemon' typecheck` passes.
- `bun run --filter '@signet/daemon' build` passes.
- Biome check passes for all touched source, test, script, baseline, and report files.
- The five focused knowledge-graph test files produce 30 passing tests and two failures that reproduce on the original branch/current main: the existing constellation episodic-token expectation receives 0 instead of 4, and the knowledge-expand API second test can race database migration with `no such table: entities`. These are recorded as pre-existing baseline failures, not introduced by this branch.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Rebased onto current `origin/main` (`057a56925`). The original `w6-knowledge-ontology` remote branch remains unchanged; this PR is published from `w6-knowledge-ontology-gate` because the environment disallowed a force-push rewrite.
