### PR TITLE
fix(attribution): accept absolute-path stack tokens in bundled runtime (#1764 regression)

### DIFF
--- a/platform/daemon/src/sync-db-attribution.test.ts
+++ b/platform/daemon/src/sync-db-attribution.test.ts
@@ -75,6 +75,7 @@ describe("sync DB attribution", () => {
 		expect(classifySyncDbSiteToken("/dist/daemon.js:54")).toBe("source-location");
 		expect(classifySyncDbSiteToken("dir/file.ts:12")).toBe("source-location");
 		expect(classifySyncDbSiteToken("//dist/daemon.js:54")).toBeNull();
+		expect(classifySyncDbSiteToken("/dist//daemon.js:54")).toBeNull();
 		expect(classifySyncDbSiteToken("dir//file.ts:12")).toBeNull();
 	});
 });

--- a/platform/daemon/src/sync-db-attribution.test.ts
+++ b/platform/daemon/src/sync-db-attribution.test.ts
@@ -7,7 +7,7 @@ import {
 	getSyncDbCallSitesForWindow,
 	resetSyncDbAttribution,
 } from "./sync-db-attribution";
-import { classifySyncDbSiteToken } from "./sync-db-site-token";
+import { classifySyncDbSiteToken, normalizeSyncDbSiteToken } from "./sync-db-site-token";
 
 afterEach(() => {
 	resetSyncDbAttribution();
@@ -77,5 +77,25 @@ describe("sync DB attribution", () => {
 		expect(classifySyncDbSiteToken("//dist/daemon.js:54")).toBeNull();
 		expect(classifySyncDbSiteToken("/dist//daemon.js:54")).toBeNull();
 		expect(classifySyncDbSiteToken("dir//file.ts:12")).toBeNull();
+	});
+
+	test("normalizes Windows absolute source locations without accepting duplicate separators", () => {
+		const driveBackslash = String.raw`C:\work\daemon.js:54`;
+		const uncBackslash = String.raw`\\server\share\daemon.js:54`;
+		const duplicateDriveSeparator = String.raw`C:\\work\daemon.js:54`;
+		const duplicateUncSeparator = String.raw`\\server\\share\daemon.js:54`;
+
+		expect(classifySyncDbSiteToken("C:/work/daemon.js:54")).toBe("source-location");
+		expect(classifySyncDbSiteToken(driveBackslash)).toBe("source-location");
+		expect(classifySyncDbSiteToken("/C:/work/daemon.js:54")).toBe("source-location");
+		expect(classifySyncDbSiteToken(uncBackslash)).toBe("source-location");
+		expect(normalizeSyncDbSiteToken(driveBackslash)).toBe("/C:/work/daemon.js:54");
+		expect(normalizeSyncDbSiteToken("/C:/work/daemon.js:54")).toBe("/C:/work/daemon.js:54");
+		expect(normalizeSyncDbSiteToken(uncBackslash)).toBe("/UNC/server/share/daemon.js:54");
+		expect(classifySyncDbSiteToken(duplicateDriveSeparator)).toBeNull();
+		expect(classifySyncDbSiteToken(duplicateUncSeparator)).toBeNull();
+
+		const token = beginSyncDbCall("withWriteTxAsync", 1_000, "C:/work/daemon.js:54");
+		expect(token.siteId).toBe("withWriteTxAsync@/C:/work/daemon.js:54");
 	});
 });

--- a/platform/daemon/src/sync-db-attribution.test.ts
+++ b/platform/daemon/src/sync-db-attribution.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
 	beginSyncDbCall,
+	captureSyncDbCallSiteToken,
 	endSyncDbCall,
 	getSyncDbAttributionMetrics,
 	getSyncDbCallSitesForWindow,
 	resetSyncDbAttribution,
 } from "./sync-db-attribution";
+import { classifySyncDbSiteToken } from "./sync-db-site-token";
 
 afterEach(() => {
 	resetSyncDbAttribution();
@@ -57,5 +59,22 @@ describe("sync DB attribution", () => {
 		expect(metrics.unattributedCalls).toBe(0);
 		expect(metrics.sites).toHaveLength(1);
 		expect(metrics.sites[0]?.siteId).toContain("sync-db-attribution.test.ts:");
+	});
+
+	test("captures source-tree caller tokens before queueing", () => {
+		expect(captureSyncDbCallSiteToken()).toMatch(/^sync-db-attribution\.test\.ts:\d+$/);
+	});
+
+	test("keeps absolute bundled source locations intact in attribution IDs", () => {
+		const token = beginSyncDbCall("withWriteTxAsync", 1_000, "/dist/daemon.js:54");
+
+		expect(token.siteId).toBe("withWriteTxAsync@/dist/daemon.js:54");
+	});
+
+	test("accepts absolute bundled source locations while rejecting malformed paths", () => {
+		expect(classifySyncDbSiteToken("/dist/daemon.js:54")).toBe("source-location");
+		expect(classifySyncDbSiteToken("dir/file.ts:12")).toBe("source-location");
+		expect(classifySyncDbSiteToken("//dist/daemon.js:54")).toBeNull();
+		expect(classifySyncDbSiteToken("dir//file.ts:12")).toBeNull();
 	});
 });

--- a/platform/daemon/src/sync-db-attribution.ts
+++ b/platform/daemon/src/sync-db-attribution.ts
@@ -10,7 +10,7 @@
  * retained.
  */
 
-import { classifySyncDbSiteToken, type SyncDbCallSiteToken } from "./sync-db-site-token";
+import { classifySyncDbSiteToken, normalizeSyncDbSiteToken, type SyncDbCallSiteToken } from "./sync-db-site-token";
 
 export type { SyncDbCallSiteToken } from "./sync-db-site-token";
 
@@ -115,6 +115,8 @@ function captureCallerSite(): string {
 			parsed.functionName.endsWith("captureCallerSite") ||
 			parsed.functionName.endsWith("beginSyncDbCall") ||
 			parsed.functionName.endsWith("endSyncDbCall") ||
+			parsed.functionName.endsWith("captureSyncDbCallSiteToken") ||
+			parsed.functionName.endsWith("runWriteTxAsync") ||
 			parsed.functionName.endsWith("withReadDb") ||
 			parsed.functionName.endsWith("withWriteTx") ||
 			parsed.functionName.endsWith("withReadDbAsync") ||
@@ -138,9 +140,11 @@ function resolveSiteToken(siteToken: SyncDbCallSiteToken | undefined): string {
 	if (siteToken === undefined) return UNATTRIBUTED_SITE;
 	const cached = siteTokenCache.get(siteToken);
 	if (cached !== undefined) return cached;
-	const kind = classifySyncDbSiteToken(siteToken);
+	const normalized = normalizeSyncDbSiteToken(siteToken);
+	if (normalized === null) return UNATTRIBUTED_SITE;
+	const kind = classifySyncDbSiteToken(normalized);
 	if (kind === null) return UNATTRIBUTED_SITE;
-	const resolved = kind === "semantic" || siteToken.startsWith("/") ? siteToken : `${SITE_TOKEN_PREFIX}${siteToken}`;
+	const resolved = kind === "semantic" || normalized.startsWith("/") ? normalized : `${SITE_TOKEN_PREFIX}${normalized}`;
 	siteTokenCache.set(siteToken, resolved);
 	return resolved;
 }
@@ -257,9 +261,11 @@ export function endSyncDbCall(token: SyncDbCallToken, endedAtMs = Date.now()): v
 export function captureSyncDbCallSiteToken(): SyncDbCallSiteToken | undefined {
 	const site = captureCallerSite();
 	if (site === UNATTRIBUTED_SITE) return undefined;
-	const prefixIndex = site.lastIndexOf(SITE_TOKEN_PREFIX);
-	const token = prefixIndex >= 0 ? site.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : site;
-	return classifySyncDbSiteToken(token) === null ? undefined : (token as SyncDbCallSiteToken);
+	const normalizedSite = normalizeSyncDbSiteToken(site);
+	if (normalizedSite === null) return undefined;
+	const prefixIndex = normalizedSite.lastIndexOf(SITE_TOKEN_PREFIX);
+	const token = prefixIndex >= 0 ? normalizedSite.slice(prefixIndex + SITE_TOKEN_PREFIX.length) : normalizedSite;
+	return normalizeSyncDbSiteToken(token) ?? undefined;
 }
 
 /** Return site ids whose synchronous interval overlapped the observed stall. */

--- a/platform/daemon/src/sync-db-attribution.ts
+++ b/platform/daemon/src/sync-db-attribution.ts
@@ -140,7 +140,7 @@ function resolveSiteToken(siteToken: SyncDbCallSiteToken | undefined): string {
 	if (cached !== undefined) return cached;
 	const kind = classifySyncDbSiteToken(siteToken);
 	if (kind === null) return UNATTRIBUTED_SITE;
-	const resolved = kind === "semantic" ? siteToken : `${SITE_TOKEN_PREFIX}${siteToken}`;
+	const resolved = kind === "semantic" || siteToken.startsWith("/") ? siteToken : `${SITE_TOKEN_PREFIX}${siteToken}`;
 	siteTokenCache.set(siteToken, resolved);
 	return resolved;
 }

--- a/platform/daemon/src/sync-db-site-token.ts
+++ b/platform/daemon/src/sync-db-site-token.ts
@@ -2,7 +2,7 @@ export type SyncDbSourceLocationToken = `${string}:${number}`;
 export type SyncDbSemanticSiteToken = `db:${string}.${string}.${string}`;
 export type SyncDbCallSiteToken = SyncDbSourceLocationToken | SyncDbSemanticSiteToken;
 
-const SOURCE_LOCATION_TOKEN = /^[^:\s]+(?:\/[^:\s]+)*:\d+$/;
+const SOURCE_LOCATION_TOKEN = /^\/?[^:/\s]+(?:\/[^:/\s]+)*:\d+$/;
 const SEMANTIC_TOKEN = /^db:[a-z0-9]+(?:[.-][a-z0-9]+){2,}$/;
 
 export type SyncDbSiteTokenKind = "source-location" | "semantic";

--- a/platform/daemon/src/sync-db-site-token.ts
+++ b/platform/daemon/src/sync-db-site-token.ts
@@ -1,16 +1,57 @@
 export type SyncDbSourceLocationToken = `${string}:${number}`;
+export type SyncDbWindowsSourceLocationToken = `${string}:${string}:${number}`;
 export type SyncDbSemanticSiteToken = `db:${string}.${string}.${string}`;
-export type SyncDbCallSiteToken = SyncDbSourceLocationToken | SyncDbSemanticSiteToken;
+export type SyncDbCallSiteToken =
+	| SyncDbSourceLocationToken
+	| SyncDbWindowsSourceLocationToken
+	| SyncDbSemanticSiteToken;
 
 const SOURCE_LOCATION_TOKEN = /^\/?[^:/\s]+(?:\/[^:/\s]+)*:\d+$/;
+const WINDOWS_DRIVE_SOURCE_LOCATION_TOKEN = /^\/[A-Za-z]:\/[^:/\s]+(?:\/[^:/\s]+)*:\d+$/;
 const SEMANTIC_TOKEN = /^db:[a-z0-9]+(?:[.-][a-z0-9]+){2,}$/;
 
 export type SyncDbSiteTokenKind = "source-location" | "semantic";
 
+function isSourceLocationToken(token: string): boolean {
+	return SOURCE_LOCATION_TOKEN.test(token) || WINDOWS_DRIVE_SOURCE_LOCATION_TOKEN.test(token);
+}
+
+function isWindowsPathRemainder(value: string): boolean {
+	if (value.length === 0 || value.startsWith("/") || value.endsWith("/") || value.includes("//")) return false;
+	return value.split("/").every((segment) => segment.length > 0 && !segment.includes(":") && !/\s/.test(segment));
+}
+
+function normalizeSourcePath(path: string): string | null {
+	const drive = /^(?:\/)?([A-Za-z]):[\\/]/.exec(path);
+	if (drive) {
+		const remainder = path.slice(drive[0].length).replaceAll("\\", "/");
+		if (!isWindowsPathRemainder(remainder)) return null;
+		return `/${drive[1]}:/${remainder}`;
+	}
+	if (path.startsWith("\\\\")) {
+		const remainder = path.slice(2).replaceAll("\\", "/");
+		if (!isWindowsPathRemainder(remainder) || remainder.split("/").length < 2) return null;
+		return `/UNC/${remainder}`;
+	}
+	if (path.includes("\\")) return null;
+	return path;
+}
+
+export function normalizeSyncDbSiteToken(token: string): SyncDbCallSiteToken | null {
+	if (SEMANTIC_TOKEN.test(token)) return token as SyncDbSemanticSiteToken;
+	const source = /^(.*):(\d+)$/.exec(token);
+	if (!source) return null;
+	const path = normalizeSourcePath(source[1] ?? "");
+	if (path === null) return null;
+	const normalized = `${path}:${source[2] ?? ""}`;
+	if (!isSourceLocationToken(normalized)) return null;
+	return normalized as SyncDbSourceLocationToken;
+}
+
 export function classifySyncDbSiteToken(token: string): SyncDbSiteTokenKind | null {
-	if (SOURCE_LOCATION_TOKEN.test(token)) return "source-location";
-	if (SEMANTIC_TOKEN.test(token)) return "semantic";
-	return null;
+	const normalized = normalizeSyncDbSiteToken(token);
+	if (normalized === null) return null;
+	return SEMANTIC_TOKEN.test(normalized) ? "semantic" : "source-location";
 }
 
 export function isSemanticSyncDbSiteToken(token: string | null): token is SyncDbSemanticSiteToken {

--- a/scripts/sync-db-attribution-runtime.test.ts
+++ b/scripts/sync-db-attribution-runtime.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const tempDirs: string[] = [];
+
+interface ProbeResult {
+	readonly one?: unknown;
+	readonly two?: unknown;
+}
+
+afterEach(() => {
+	for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function outputOf(result: ReturnType<typeof spawnSync>): string {
+	return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+}
+
+function parseProbeOutput(output: string): ProbeResult {
+	const lines = output.trim().split("\n");
+	const lastLine = lines.at(-1);
+	if (lastLine === undefined) throw new Error(`probe did not return JSON:\n${output}`);
+	const parsed: unknown = JSON.parse(lastLine);
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new Error(`probe returned non-object JSON:\n${output}`);
+	}
+	return parsed as ProbeResult;
+}
+
+function runProbe(command: string, args: readonly string[] = []): ProbeResult {
+	const result = spawnSync(command, args, { encoding: "utf8", timeout: 30_000 });
+	const output = outputOf(result);
+	expect(result.error, output).toBeUndefined();
+	expect(result.status, output).toBe(0);
+	return parseProbeOutput(output);
+}
+
+describe("sync DB attribution runtime boundaries", () => {
+	test("keeps distinct caller locations in Bun bundles and compiled binaries", () => {
+		const directory = mkdtempSync(join(tmpdir(), "signet-sync-db-attribution-runtime-"));
+		tempDirs.push(directory);
+		const fixture = join(directory, "attribution-probe.ts");
+		const bundle = join(directory, "attribution-probe.bundle.js");
+		const binary = join(directory, process.platform === "win32" ? "attribution-probe.exe" : "attribution-probe");
+		const attribution = join(root, "platform", "daemon", "src", "db-accessor.ts");
+
+		writeFileSync(
+			fixture,
+			`import { runWriteTxAsync } from ${JSON.stringify(attribution)};
+
+const accessor = {
+  withWriteTxAsync: async (_fn: unknown, options?: { siteToken?: string }): Promise<string | undefined> =>
+    options?.siteToken,
+};
+
+async function callerOne(): Promise<string | undefined> {
+  return runWriteTxAsync(accessor as never, () => 0);
+}
+
+async function callerTwo(): Promise<string | undefined> {
+  return runWriteTxAsync(accessor as never, () => 0);
+}
+
+const one = await callerOne();
+const two = await callerTwo();
+if (one === undefined || two === undefined || one === two) {
+  throw new Error(\`distinct caller attribution failed: \${String(one)} / \${String(two)}\`);
+}
+console.log(JSON.stringify({ one, two }));
+process.exit(0);
+`,
+		);
+
+		const bundleBuild = spawnSync(
+			process.execPath,
+			["build", "--target=bun", "--external", "better-sqlite3", "--outfile", bundle, fixture],
+			{
+				cwd: root,
+				encoding: "utf8",
+				timeout: 120_000,
+			},
+		);
+		const bundleBuildOutput = outputOf(bundleBuild);
+		expect(bundleBuild.error, bundleBuildOutput).toBeUndefined();
+		expect(bundleBuild.status, bundleBuildOutput).toBe(0);
+		const bundled = runProbe(process.execPath, [bundle]);
+		expect(bundled.one).toEqual(expect.any(String));
+		expect(bundled.two).toEqual(expect.any(String));
+		expect(bundled.one).toMatch(/:\d+$/);
+		expect(bundled.two).toMatch(/:\d+$/);
+		expect(bundled.one).not.toBe(bundled.two);
+
+		const compileBuild = spawnSync(
+			process.execPath,
+			["build", "--compile", "--target=bun", "--external", "better-sqlite3", "--outfile", binary, fixture],
+			{ cwd: root, encoding: "utf8", timeout: 120_000 },
+		);
+		const compileBuildOutput = outputOf(compileBuild);
+		expect(compileBuild.error, compileBuildOutput).toBeUndefined();
+		expect(compileBuild.status, compileBuildOutput).toBe(0);
+		if (process.platform !== "win32") chmodSync(binary, 0o755);
+		const compiled = runProbe(binary);
+		expect(compiled.one).toEqual(expect.any(String));
+		expect(compiled.two).toEqual(expect.any(String));
+		expect(compiled.one).toMatch(/:\d+$/);
+		expect(compiled.two).toMatch(/:\d+$/);
+		expect(compiled.one).not.toBe(compiled.two);
+	});
+});


### PR DESCRIPTION
## Summary

Restore pre-queue database call-site attribution when the daemon runs from a Bun bundle or compiled native binary, including Windows source-location tokens.

## Changes

- Skip the attribution helper and `runWriteTxAsync` frames when resolving the actual caller, so distinct bundled and compiled callers retain distinct site tokens.
- Add a runtime regression fixture that invokes the real `runWriteTxAsync` through both a Bun bundle and a compiled native binary.
- Normalize Windows drive paths (`C:/...`, `C:\\...`, `/C:/...`) and raw backslash UNC paths to canonical absolute tokens before classification.
- Reject duplicate separators and malformed Windows path segments while preserving valid absolute source locations during attribution ID normalization.
- Add regression coverage for drive, slash-drive, UNC, malformed, bundled, and compiled-native shapes.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable. This change does not touch a UI surface.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

The readiness items that do not apply were reviewed as not applicable to this internal attribution-only change; no data queries, endpoints, or public API/docs changed. The classifier regression rejects malformed path separators, and focused lint, typecheck, tests, bundled/compiled probes, native smoke, event-loop audit, and daemon build pass.

## Migration Notes (if applicable)

Not applicable. No schema or migration files changed.

## Testing

- [ ] `bun test` passes (full repository suite not run)
- [x] `bun run typecheck` passes (daemon package)
- [x] `bun run lint` passes (scoped Biome check on changed files)
- [ ] Tested against running daemon
- [x] N/A — bundled and compiled-native behavior was exercised with real bundle/binary probes; focused daemon tests and builds pass.

Focused commands and results:

- `bun test platform/daemon/src/sync-db-attribution.test.ts scripts/sync-db-attribution-runtime.test.ts` — 10 passed, 0 failed, 45 expect() calls
- `bun test platform/daemon/src/db-accessor.test.ts` — 70 passed, 0 failed, 155 expect() calls
- `bun run --filter '@signet/core' build` — passed (daemon build prerequisite)
- `bun run --filter '@signet/daemon' typecheck` — passed
- `bun run --filter '@signet/daemon' build` — passed
- `bun run build:native-bun` — passed; compiled native binary produced
- `SIGNET_NATIVE_EMBEDDING_SMOKE=0 SIGNET_DB_OWNER_SMOKE=1 SIGNET_DREAMING_TOKEN_SMOKE=1 SIGNET_DREAMING_MCP_SMOKE=1 SIGNET_NATIVE_SMOKE_BINARY=./dist/native/signet bun test scripts/native-embedding-runtime-smoke.test.ts scripts/native-dreaming-mcp-smoke.test.ts` — 8 passed, 4 skipped, 0 failed, 22 expect() calls
- `bun test scripts/audit-event-loop-contract.test.ts` — 23 passed, 0 failed
- `bun scripts/audit-event-loop-contract.ts` — ledger inventory 850; legacy DB sites 164 (65 writes, 99 reads); execution home 335 ON-PARENT, 2 OFF-PARENT; ratchet holds at 164
- `bunx biome check` on the four changed files — passed
- `git diff --check` — passed
- Mutation verification — removing the helper-frame skips failed the bundled/compiled caller regression with identical tokens; restoring strict Windows normalization failed the Windows classifier regression; both source files were restored and the focused suite returned 10 passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This is a follow-up repair for the merged PR #1764 regression. PR #1774 is intentionally left open for an independent escape review pinned to the published head; it must not be merged without review.