### PR TITLE
fix(daemon): route memory recall traversal through DB owner

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 853 sites
+- Exact ledger inventory: 864 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 173
-- Async-named ON-PARENT DB sites: 171
+- Async-named DB sites: 184
+- Async-named ON-PARENT DB sites: 182
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 515
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 853-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 164 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 864-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 184 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 182 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 361
-- ON-PARENT callback execution: 359
+- Database accessor sites classified: 348
+- ON-PARENT callback execution: 346
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -121,21 +121,21 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `memory-search-telemetry.ts:321` (withReadDbAsync)
 - `memory-search.ts:1924` (withReadDbAsync)
 - `memory-search.ts:1947` (withReadDbAsync)
-- `memory-search.ts:2069` (withReadDbAsync)
-- `memory-search.ts:2158` (withReadDbAsync)
-- `memory-search.ts:2221` (withReadDbAsync)
-- `memory-search.ts:2304` (withReadDbAsync)
-- `memory-search.ts:2350` (withReadDbAsync)
-- `memory-search.ts:2386` (withReadDbAsync)
-- `memory-search.ts:2433` (withReadDbAsync)
-- `memory-search.ts:2512` (withReadDbAsync)
-- `memory-search.ts:2533` (withReadDbAsync)
-- `memory-search.ts:2562` (withReadDbAsync)
-- `memory-search.ts:2799` (withReadDbAsync)
-- `memory-search.ts:2826` (withReadDbAsync)
-- `memory-search.ts:3024` (withReadDbAsync)
-- `memory-search.ts:3126` (withReadDbAsync)
-- `memory-search.ts:3235` (withReadDbAsync)
+- `memory-search.ts:2071` (withReadDbAsync)
+- `memory-search.ts:2165` (withReadDbAsync)
+- `memory-search.ts:2230` (withReadDbAsync)
+- `memory-search.ts:2318` (withReadDbAsync)
+- `memory-search.ts:2364` (withReadDbAsync)
+- `memory-search.ts:2400` (withReadDbAsync)
+- `memory-search.ts:2447` (withReadDbAsync)
+- `memory-search.ts:2526` (withReadDbAsync)
+- `memory-search.ts:2547` (withReadDbAsync)
+- `memory-search.ts:2576` (withReadDbAsync)
+- `memory-search.ts:2813` (withReadDbAsync)
+- `memory-search.ts:2840` (withReadDbAsync)
+- `memory-search.ts:3038` (withReadDbAsync)
+- `memory-search.ts:3140` (withReadDbAsync)
+- `memory-search.ts:3249` (withReadDbAsync)
 - `obsidian-source-embeddings.ts:629` (withReadDb)
 - `obsidian-source-embeddings.ts:665` (withWriteTx)
 - `obsidian-source-embeddings.ts:681` (withReadDb)
@@ -194,19 +194,10 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `pipeline/dreaming-worker.ts:148` (withReadDbAsync)
 - `pipeline/dreaming-worker.ts:227` (withReadDbAsync)
 - `pipeline/dreaming-worker.ts:247` (withReadDbAsync)
-- `pipeline/graph-traversal.ts:99` (withReadDbAsync)
+- `pipeline/graph-traversal.ts:101` (withReadDbAsync)
 - `db:maintenance.graph-agent-scopes.read` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
 - `db:maintenance.dead-memory-count.read` (withReadDbAsync)
-- `pipeline/prospective-index.ts:284` (withWriteDbAsync)
-- `pipeline/prospective-index.ts:300` (withWriteDbAsync)
-- `pipeline/prospective-index.ts:336` (withWriteTxAsync)
-- `pipeline/prospective-index.ts:394` (withWriteTxAsync)
-- `pipeline/prospective-index.ts:412` (withWriteTxAsync)
-- `pipeline/prospective-index.ts:436` (withWriteTxAsync)
-- `pipeline/prospective-index.ts:459` (withWriteTxAsync)
-- `pipeline/prospective-index.ts:485` (withWriteTxAsync)
-- `pipeline/prospective-index.ts:590` (withWriteTxAsync)
 - `pipeline/reflection-worker.ts:368` (withReadDb)
 - `pipeline/reflection-worker.ts:401` (withReadDb)
 - `pipeline/reflection-worker.ts:463` (withWriteTx)
@@ -316,10 +307,6 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `routes/telemetry-routes.ts:265` (withReadDb)
 - `routes/utils.ts:437` (withReadDb)
 - `routes/utils.ts:525` (withReadDb)
-- `scheduler/worker.ts:107` (withWriteTxAsync)
-- `scheduler/worker.ts:131` (withReadDbAsync)
-- `scheduler/worker.ts:202` (withWriteTxAsync)
-- `scheduler/worker.ts:291` (withWriteTxAsync)
 - `session-checkpoints.ts:112` (withWriteTxAsync)
 - `session-checkpoints.ts:180` (withWriteTx)
 - `session-checkpoints.ts:297` (withReadDb)
@@ -390,8 +377,8 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 
 ### OFF-PARENT sites
 
-- `db-owner-worker.ts:876` (withReadDbAsync)
-- `db-owner-worker.ts:909` (withReadDbAsync)
+- `db-owner-worker.ts:885` (withReadDbAsync)
+- `db-owner-worker.ts:918` (withReadDbAsync)
 
 ## A3 Slice 2 migration notes
 

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 864 sites
+- Exact ledger inventory: 853 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 184
-- Async-named ON-PARENT DB sites: 182
+- Async-named DB sites: 173
+- Async-named ON-PARENT DB sites: 171
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 515
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 864-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 184 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 182 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 853-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 348
-- ON-PARENT callback execution: 346
+- Database accessor sites classified: 337
+- ON-PARENT callback execution: 335
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -119,23 +119,12 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `memory-lineage.ts:2355` (withReadDbAsync)
 - `memory-search-telemetry.ts:245` (withWriteTxAsync)
 - `memory-search-telemetry.ts:321` (withReadDbAsync)
-- `memory-search.ts:1924` (withReadDbAsync)
-- `memory-search.ts:1947` (withReadDbAsync)
-- `memory-search.ts:2071` (withReadDbAsync)
-- `memory-search.ts:2165` (withReadDbAsync)
-- `memory-search.ts:2230` (withReadDbAsync)
-- `memory-search.ts:2318` (withReadDbAsync)
-- `memory-search.ts:2364` (withReadDbAsync)
-- `memory-search.ts:2400` (withReadDbAsync)
-- `memory-search.ts:2447` (withReadDbAsync)
-- `memory-search.ts:2526` (withReadDbAsync)
-- `memory-search.ts:2547` (withReadDbAsync)
-- `memory-search.ts:2576` (withReadDbAsync)
-- `memory-search.ts:2813` (withReadDbAsync)
-- `memory-search.ts:2840` (withReadDbAsync)
-- `memory-search.ts:3038` (withReadDbAsync)
-- `memory-search.ts:3140` (withReadDbAsync)
-- `memory-search.ts:3249` (withReadDbAsync)
+- `memory-search.ts:2308` (withReadDbAsync)
+- `memory-search.ts:2386` (withReadDbAsync)
+- `memory-search.ts:2433` (withReadDbAsync)
+- `memory-search.ts:2512` (withReadDbAsync)
+- `memory-search.ts:2793` (withReadDbAsync)
+- `memory-search.ts:2820` (withReadDbAsync)
 - `obsidian-source-embeddings.ts:629` (withReadDb)
 - `obsidian-source-embeddings.ts:665` (withWriteTx)
 - `obsidian-source-embeddings.ts:681` (withReadDb)

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 865 sites
+- Exact ledger inventory: 853 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 186
-- Async-named ON-PARENT DB sites: 184
+- Async-named DB sites: 173
+- Async-named ON-PARENT DB sites: 171
 - Async-named OFF-PARENT DB sites: 2
 - Synchronous filesystem/process sites: 515
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 865-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 186 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 184 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 853-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 164 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 350
-- ON-PARENT callback execution: 348
+- Database accessor sites classified: 361
+- ON-PARENT callback execution: 359
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -119,25 +119,23 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `memory-lineage.ts:2355` (withReadDbAsync)
 - `memory-search-telemetry.ts:245` (withWriteTxAsync)
 - `memory-search-telemetry.ts:321` (withReadDbAsync)
-- `memory-search.ts:1861` (withReadDbAsync)
-- `memory-search.ts:1884` (withReadDbAsync)
-- `memory-search.ts:1985` (withReadDbAsync)
-- `memory-search.ts:2012` (withReadDbAsync)
-- `memory-search.ts:2100` (withReadDbAsync)
-- `memory-search.ts:2136` (withReadDbAsync)
-- `memory-search.ts:2169` (withReadDbAsync)
-- `memory-search.ts:2251` (withReadDbAsync)
-- `memory-search.ts:2297` (withReadDbAsync)
-- `memory-search.ts:2333` (withReadDbAsync)
-- `memory-search.ts:2380` (withReadDbAsync)
-- `memory-search.ts:2459` (withReadDbAsync)
-- `memory-search.ts:2480` (withReadDbAsync)
-- `memory-search.ts:2509` (withReadDbAsync)
-- `memory-search.ts:2746` (withReadDbAsync)
-- `memory-search.ts:2773` (withReadDbAsync)
-- `memory-search.ts:2971` (withReadDbAsync)
-- `memory-search.ts:3071` (withReadDbAsync)
-- `memory-search.ts:3180` (withReadDbAsync)
+- `memory-search.ts:1924` (withReadDbAsync)
+- `memory-search.ts:1947` (withReadDbAsync)
+- `memory-search.ts:2069` (withReadDbAsync)
+- `memory-search.ts:2158` (withReadDbAsync)
+- `memory-search.ts:2221` (withReadDbAsync)
+- `memory-search.ts:2304` (withReadDbAsync)
+- `memory-search.ts:2350` (withReadDbAsync)
+- `memory-search.ts:2386` (withReadDbAsync)
+- `memory-search.ts:2433` (withReadDbAsync)
+- `memory-search.ts:2512` (withReadDbAsync)
+- `memory-search.ts:2533` (withReadDbAsync)
+- `memory-search.ts:2562` (withReadDbAsync)
+- `memory-search.ts:2799` (withReadDbAsync)
+- `memory-search.ts:2826` (withReadDbAsync)
+- `memory-search.ts:3024` (withReadDbAsync)
+- `memory-search.ts:3126` (withReadDbAsync)
+- `memory-search.ts:3235` (withReadDbAsync)
 - `obsidian-source-embeddings.ts:629` (withReadDb)
 - `obsidian-source-embeddings.ts:665` (withWriteTx)
 - `obsidian-source-embeddings.ts:681` (withReadDb)
@@ -196,10 +194,19 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `pipeline/dreaming-worker.ts:148` (withReadDbAsync)
 - `pipeline/dreaming-worker.ts:227` (withReadDbAsync)
 - `pipeline/dreaming-worker.ts:247` (withReadDbAsync)
-- `pipeline/graph-traversal.ts:92` (withReadDbAsync)
+- `pipeline/graph-traversal.ts:99` (withReadDbAsync)
 - `db:maintenance.graph-agent-scopes.read` (withReadDbAsync)
 - `pipeline/maintenance-worker.ts:346` (withReadDbAsync)
 - `db:maintenance.dead-memory-count.read` (withReadDbAsync)
+- `pipeline/prospective-index.ts:284` (withWriteDbAsync)
+- `pipeline/prospective-index.ts:300` (withWriteDbAsync)
+- `pipeline/prospective-index.ts:336` (withWriteTxAsync)
+- `pipeline/prospective-index.ts:394` (withWriteTxAsync)
+- `pipeline/prospective-index.ts:412` (withWriteTxAsync)
+- `pipeline/prospective-index.ts:436` (withWriteTxAsync)
+- `pipeline/prospective-index.ts:459` (withWriteTxAsync)
+- `pipeline/prospective-index.ts:485` (withWriteTxAsync)
+- `pipeline/prospective-index.ts:590` (withWriteTxAsync)
 - `pipeline/reflection-worker.ts:368` (withReadDb)
 - `pipeline/reflection-worker.ts:401` (withReadDb)
 - `pipeline/reflection-worker.ts:463` (withWriteTx)
@@ -309,6 +316,10 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `routes/telemetry-routes.ts:265` (withReadDb)
 - `routes/utils.ts:437` (withReadDb)
 - `routes/utils.ts:525` (withReadDb)
+- `scheduler/worker.ts:107` (withWriteTxAsync)
+- `scheduler/worker.ts:131` (withReadDbAsync)
+- `scheduler/worker.ts:202` (withWriteTxAsync)
+- `scheduler/worker.ts:291` (withWriteTxAsync)
 - `session-checkpoints.ts:112` (withWriteTxAsync)
 - `session-checkpoints.ts:180` (withWriteTx)
 - `session-checkpoints.ts:297` (withReadDb)
@@ -379,8 +390,8 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 
 ### OFF-PARENT sites
 
-- `db-owner-worker.ts:885` (withReadDbAsync)
-- `db-owner-worker.ts:918` (withReadDbAsync)
+- `db-owner-worker.ts:876` (withReadDbAsync)
+- `db-owner-worker.ts:909` (withReadDbAsync)
 
 ## A3 Slice 2 migration notes
 

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,7 +4,7 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 853 sites
+- Exact ledger inventory: 852 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
 - Async-named DB sites: 173
@@ -15,7 +15,7 @@ This report is generated from the deterministic migration ledger in `scripts/eve
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 853-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 852-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -160,6 +160,21 @@ describe("hybridRecall", () => {
 		expect(source.match(/traverseKnowledgeGraphViaOwner\(/g) ?? []).toHaveLength(2);
 	});
 
+	it("does not classify post-traversal parent reads as graph failures", () => {
+		const source = readFileSync(join(import.meta.dir, "memory-search.ts"), "utf-8");
+		const embeddingStart = source.indexOf("let embRows:");
+		const embeddingEnd = source.indexOf("const qv = queryVecF32", embeddingStart);
+		const embeddingBlock = source.slice(embeddingStart, embeddingEnd);
+		expect(embeddingBlock).toContain("Traversal embedding re-scoring failed");
+		expect(embeddingBlock).not.toContain("recordGraphResult");
+
+		const hydrationStart = source.indexOf("let baseRows:");
+		const hydrationEnd = source.indexOf("for (const row of baseRows)", hydrationStart);
+		const hydrationBlock = source.slice(hydrationStart, hydrationEnd);
+		expect(hydrationBlock).toContain("KA traversal candidate hydration failed");
+		expect(hydrationBlock).not.toContain("recordGraphResult");
+	});
+
 	function seedUnbackedOntologyClaim(opts: {
 		readonly id: string;
 		readonly agentId?: string;

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -175,6 +175,66 @@ describe("hybridRecall", () => {
 		expect(hydrationBlock).not.toContain("recordGraphResult");
 	});
 
+	it("keeps graph-associated recall reads off parent SQLite", async () => {
+		const now = new Date().toISOString();
+		await getDbAccessor().withWriteTxAsync(async (db) => {
+			db.prepare(
+				`INSERT INTO memories (id, content, type, agent_id, created_at, updated_at, updated_by)
+				 VALUES ('graph-owner-memory', 'Signet owner-bound graph memory', 'fact', 'default', ?, ?, 'test')`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('graph-owner-entity', 'Signet', 'signet', 'project', 'default', 10, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('graph-owner-aspect', 'graph-owner-entity', 'default', 'context', 'context', 0.9, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes (
+					id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+					confidence, importance, status, created_at, updated_at
+				) VALUES ('graph-owner-attribute', 'graph-owner-aspect', 'default', 'graph-owner-memory',
+					'attribute', 'Signet owner-bound graph memory', 'signet owner-bound graph memory', 1, 0.9, 'active', ?, ?)`,
+			).run(now, now);
+		});
+
+		const accessor = getDbAccessor();
+		const originalWithReadDbAsync = accessor.withReadDbAsync;
+		const parentGraphReads: string[] = [];
+		accessor.withReadDbAsync = async (fn, options) => {
+			const source = String(fn);
+			if (
+				/(memory_entity_mentions|entity_attributes|entity_aspects|entity_dependencies|FROM entities|FROM relations)/.test(
+					source,
+				)
+			) {
+				parentGraphReads.push(source);
+			}
+			return await originalWithReadDbAsync(fn, options);
+		};
+
+		try {
+			const result = await hybridRecall(
+				{
+					query: "Signet",
+					keywordQuery: "Signet",
+					limit: 5,
+					agentId: "default",
+					readPolicy: "isolated",
+					trackRecallAccess: false,
+				},
+				testCfg({ graph: true, traversal: true }),
+				async () => null,
+			);
+			expect(result.results.map((row) => row.id)).toContain("graph-owner-memory");
+		} finally {
+			accessor.withReadDbAsync = originalWithReadDbAsync;
+		}
+
+		expect(parentGraphReads).toEqual([]);
+	});
+
 	function seedUnbackedOntologyClaim(opts: {
 		readonly id: string;
 		readonly agentId?: string;

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -235,6 +235,60 @@ describe("hybridRecall", () => {
 		expect(parentGraphReads).toEqual([]);
 	});
 
+	it("does not report a post-traversal parent read failure as graph degradation", async () => {
+		const now = new Date().toISOString();
+		await getDbAccessor().withWriteTxAsync(async (db) => {
+			db.prepare(
+				`INSERT INTO memories (id, content, type, agent_id, created_at, updated_at, updated_by)
+				 VALUES ('graph-parent-failure-memory', 'Signet graph parent failure memory', 'fact', 'default', ?, ?, 'test')`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('graph-parent-failure-entity', 'Signet', 'signet', 'project', 'default', 10, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('graph-parent-failure-aspect', 'graph-parent-failure-entity', 'default', 'context', 'context', 0.9, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes (
+					id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+					confidence, importance, status, created_at, updated_at
+				) VALUES ('graph-parent-failure-attribute', 'graph-parent-failure-aspect', 'default',
+					'graph-parent-failure-memory', 'attribute', 'Signet graph parent failure memory',
+					'signet graph parent failure memory', 1, 0.9, 'active', ?, ?)`,
+			).run(now, now);
+		});
+
+		const accessor = getDbAccessor();
+		const originalWithReadDbAsync = accessor.withReadDbAsync;
+		accessor.withReadDbAsync = async (fn, options) => {
+			if (options?.siteToken === "memory-search.ts:2512")
+				throw new Error("injected post-traversal parent read failure");
+			return await originalWithReadDbAsync(fn, options);
+		};
+
+		try {
+			const result = await hybridRecall(
+				{
+					query: "Signet",
+					keywordQuery: "Signet",
+					limit: 5,
+					agentId: "default",
+					readPolicy: "isolated",
+					trackRecallAccess: false,
+				},
+				testCfg({ graph: true, traversal: true }),
+				async () => null,
+			);
+			expect(result.results.map((row) => row.id)).toContain("graph-parent-failure-memory");
+			expect(result.meta.graphPartial).toBeUndefined();
+			expect(result.meta.graphError).toBeUndefined();
+		} finally {
+			accessor.withReadDbAsync = originalWithReadDbAsync;
+		}
+	});
+
 	function seedUnbackedOntologyClaim(opts: {
 		readonly id: string;
 		readonly agentId?: string;

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -154,6 +154,12 @@ describe("hybridRecall", () => {
 		expect(classifyRecallTelemetry(telemetryResponse("ka_traversal"))).toBe("graph");
 	});
 
+	it("keeps both recall traversal branches on the owner boundary", () => {
+		const source = readFileSync(join(import.meta.dir, "memory-search.ts"), "utf-8");
+		expect(source).not.toContain("traverseKnowledgeGraph(");
+		expect(source.match(/traverseKnowledgeGraphViaOwner\(/g) ?? []).toHaveLength(2);
+	});
+
 	function seedUnbackedOntologyClaim(opts: {
 		readonly id: string;
 		readonly agentId?: string;

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { normalizeAndHashContent } from "./content-normalization";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import type { DbOwnerJobHandle, DbOwnerRequest, DbOwnerSubmitOptions } from "./db-owner-client";
+import { getDbOwner } from "./db-owner-runtime";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
 import { isFtsIndexIncomplete, setFtsIndexIncomplete } from "./fts-index-state";
 import { upsertMemoryContentSafetyInTx } from "./memory-content-safety";
@@ -235,37 +237,39 @@ describe("hybridRecall", () => {
 		expect(parentGraphReads).toEqual([]);
 	});
 
-	it("does not report a post-traversal parent read failure as graph degradation", async () => {
+	it("does not report an owner post-traversal read failure as graph degradation", async () => {
 		const now = new Date().toISOString();
 		await getDbAccessor().withWriteTxAsync(async (db) => {
 			db.prepare(
 				`INSERT INTO memories (id, content, type, agent_id, created_at, updated_at, updated_by)
-				 VALUES ('graph-parent-failure-memory', 'Signet graph parent failure memory', 'fact', 'default', ?, ?, 'test')`,
+				 VALUES ('graph-owner-failure-memory', 'Signet graph owner failure memory', 'fact', 'default', ?, ?, 'test')`,
 			).run(now, now);
 			db.prepare(
 				`INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
-				 VALUES ('graph-parent-failure-entity', 'Signet', 'signet', 'project', 'default', 10, ?, ?)`,
+				 VALUES ('graph-owner-failure-entity', 'Signet', 'signet', 'project', 'default', 10, ?, ?)`,
 			).run(now, now);
 			db.prepare(
 				`INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
-				 VALUES ('graph-parent-failure-aspect', 'graph-parent-failure-entity', 'default', 'context', 'context', 0.9, ?, ?)`,
+				 VALUES ('graph-owner-failure-aspect', 'graph-owner-failure-entity', 'default', 'context', 'context', 0.9, ?, ?)`,
 			).run(now, now);
 			db.prepare(
 				`INSERT INTO entity_attributes (
 					id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
 					confidence, importance, status, created_at, updated_at
-				) VALUES ('graph-parent-failure-attribute', 'graph-parent-failure-aspect', 'default',
-					'graph-parent-failure-memory', 'attribute', 'Signet graph parent failure memory',
-					'signet graph parent failure memory', 1, 0.9, 'active', ?, ?)`,
+				) VALUES ('graph-owner-failure-attribute', 'graph-owner-failure-aspect', 'default',
+					'graph-owner-failure-memory', 'attribute', 'Signet graph owner failure memory',
+					'signet graph owner failure memory', 1, 0.9, 'active', ?, ?)`,
 			).run(now, now);
 		});
 
-		const accessor = getDbAccessor();
-		const originalWithReadDbAsync = accessor.withReadDbAsync;
-		accessor.withReadDbAsync = async (fn, options) => {
-			if (options?.siteToken === "memory-search.ts:2512")
-				throw new Error("injected post-traversal parent read failure");
-			return await originalWithReadDbAsync(fn, options);
+		const owner = await getDbOwner();
+		const originalSubmit = owner.submit.bind(owner);
+		let injected = false;
+		owner.submit = <Result>(request: DbOwnerRequest, options: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> => {
+			const handle = originalSubmit<Result>(request, options);
+			if (options.operation !== "memory-search.traversal.embedding-rescore") return handle;
+			injected = true;
+			return { ...handle, result: Promise.reject(new Error("injected owner embedding read failure")) };
 		};
 
 		try {
@@ -279,14 +283,62 @@ describe("hybridRecall", () => {
 					trackRecallAccess: false,
 				},
 				testCfg({ graph: true, traversal: true }),
-				async () => null,
+				async () => unitVector(),
 			);
-			expect(result.results.map((row) => row.id)).toContain("graph-parent-failure-memory");
+			expect(result.results.map((row) => row.id)).toContain("graph-owner-failure-memory");
+			expect(injected).toBe(true);
 			expect(result.meta.graphPartial).toBeUndefined();
 			expect(result.meta.graphError).toBeUndefined();
 		} finally {
-			accessor.withReadDbAsync = originalWithReadDbAsync;
+			owner.submit = originalSubmit;
 		}
+	});
+
+	it("excludes clean-looking graph entity context when persisted memory safety blocks it", async () => {
+		const now = new Date().toISOString();
+		await getDbAccessor().withWriteTxAsync(async (db) => {
+			db.prepare(
+				`INSERT INTO memories (id, content, type, agent_id, created_at, updated_at, updated_by)
+				 VALUES ('graph-unsafe-memory', 'Signet clean-looking memory', 'fact', 'default', ?, ?, 'test')`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('graph-unsafe-entity', 'Signet', 'signet', 'project', 'default', 10, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('graph-unsafe-aspect', 'graph-unsafe-entity', 'default', 'context', 'context', 0.9, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes (
+					id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+					confidence, importance, status, created_at, updated_at
+				) VALUES ('graph-unsafe-attribute', 'graph-unsafe-aspect', 'default',
+					'graph-unsafe-memory', 'attribute', 'Signet clean-looking memory',
+					'signet clean-looking memory', 1, 0.9, 'active', ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO memory_content_safety (
+					agent_id, source_kind, source_id, status, context_eligible,
+					reasons_json, policy_version, scanned_at
+				) VALUES ('default', 'memory', 'graph-unsafe-memory', 'tainted', 0, '[]', 'test', ?)`,
+			).run(now);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "Signet",
+				keywordQuery: "Signet",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+				trackRecallAccess: false,
+			},
+			testCfg({ graph: true, traversal: true }),
+			async () => null,
+		);
+
+		expect(result.entities).toBeUndefined();
 	});
 
 	function seedUnbackedOntologyClaim(opts: {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -27,6 +27,7 @@ import {
 } from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
 import { getDbAccessor, getDbAccessorPath, runWriteTxAsync } from "./db-accessor";
+import type { DbOwnerClient } from "./db-owner-client";
 import { vectorSearchThroughDbOwner } from "./db-owner-recall";
 import { ownerBytesFromHex, ownerReadAll, ownerReadOne } from "./db-owner-sql";
 import { getDbOwner, getDbRecallOwner } from "./db-owner-runtime";
@@ -46,7 +47,7 @@ import {
 	type resolveFocalEntities,
 	resolveFocalEntitiesViaOwner,
 	setTraversalStatus,
-	traverseKnowledgeGraph,
+	traverseKnowledgeGraphViaOwner,
 } from "./pipeline/graph-traversal";
 import { type RerankCandidate, noopReranker, rerank } from "./pipeline/reranker";
 import { createEmbeddingReranker } from "./pipeline/reranker-embedding";
@@ -153,6 +154,16 @@ export interface RecallResponse {
 		vectorCompleteness?: VectorSearchCompleteness;
 		/** Maximum canonical rows inspected by a bounded fallback scan. */
 		searchedWindow?: number;
+		/** True when graph traversal timed out or failed after bounded fallback. */
+		graphPartial?: boolean;
+		/** Operational graph failure, when one was observed. */
+		graphError?: {
+			channel: "graph_traversal";
+			code: string | number | null;
+			message: string;
+		};
+		/** Most specific known degradation reason for partial recall. */
+		degradation?: "fts_incomplete" | "graph_traversal_timeout" | "graph_traversal_failed";
 		/**
 		 * True when lexical coverage is known incomplete because FTS rows are
 		 * missing. The response remains successful and may contain bounded bridge
@@ -1449,6 +1460,20 @@ function cosineSimilarity(query: Float32Array, memory: Float32Array): number {
 	return Math.max(0, Math.min(1, dot / denom));
 }
 
+function describeRecallGraphError(error: unknown): {
+	readonly code: string | number | null;
+	readonly message: string;
+} {
+	const code =
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(typeof error.code === "string" || typeof error.code === "number")
+			? error.code
+			: null;
+	return { code, message: error instanceof Error ? error.message : String(error) };
+}
+
 // ---------------------------------------------------------------------------
 // Main search orchestration
 // ---------------------------------------------------------------------------
@@ -1502,9 +1527,35 @@ export async function hybridRecall(
 	const needsPostFilter = params.scope !== undefined || !!params.project || !!params.agentId;
 	const timings = createRecallTimingCollector();
 	let lexicalSearchPartial = false;
+	let graphPartial = false;
+	let graphError: RecallResponse["meta"]["graphError"];
+	let graphDegradation: RecallResponse["meta"]["degradation"];
 	const selectionSuppressedIds = new Set<string>();
 	const lifecycleSourceResults = new Map<string, { readonly source?: string; readonly source_id?: string }>();
 	const selectionDedupeEnabled = !!params.sessionKey?.trim() && params.includeRecalled !== true;
+	let graphOwner: DbOwnerClient | null = null;
+	const getGraphOwner = async (): Promise<DbOwnerClient> => {
+		graphOwner ??= await getDbOwner(getDbAccessorPath());
+		return graphOwner;
+	};
+	const recordGraphResult = (result: {
+		readonly timedOut: boolean;
+		readonly error?: { readonly code: string | number | null; readonly message: string };
+	}): void => {
+		if (result.timedOut) {
+			graphPartial = true;
+			graphDegradation ??= "graph_traversal_timeout";
+		}
+		if (result.error) {
+			graphPartial = true;
+			graphDegradation = "graph_traversal_failed";
+			graphError = {
+				channel: "graph_traversal",
+				code: result.error.code,
+				message: result.error.message,
+			};
+		}
+	};
 	const suppressPreviouslyRecalledForSelection = <T extends RecallResult>(items: T[]): T[] => {
 		if (!selectionDedupeEnabled || items.length === 0) return items;
 		const deduped = applyRecallDedupe({
@@ -1546,7 +1597,14 @@ export async function hybridRecall(
 			totalReturned: response.results.length,
 			hasSupplementary: response.results.some((row) => row.supplementary === true),
 			noHits: response.results.length === 0,
-			...(lexicalSearchPartial ? { partial: true } : {}),
+			...(lexicalSearchPartial || graphPartial ? { partial: true } : {}),
+			...(graphPartial ? { graphPartial: true } : {}),
+			...(graphError ? { graphError } : {}),
+			...(graphDegradation
+				? { degradation: graphDegradation }
+				: lexicalSearchPartial
+					? { degradation: "fts_incomplete" as const }
+					: {}),
 			...(dedupeMeta.enabled ? { dedupe: dedupeMeta } : {}),
 		};
 		try {
@@ -1579,8 +1637,10 @@ export async function hybridRecall(
 			results: response.results.length,
 			latencyMs: recallTimings.totalMs,
 			truncated: response.results.length >= limit,
-			partial: lexicalSearchPartial,
-			...(lexicalSearchPartial ? { degradation: "fts_incomplete" } : {}),
+			partial: lexicalSearchPartial || graphPartial,
+			...(lexicalSearchPartial || graphPartial
+				? { degradation: graphDegradation ?? (lexicalSearchPartial ? "fts_incomplete" : "graph_traversal_failed") }
+				: {}),
 		});
 		const selectedLifecycleSources = response.results.flatMap((row) => {
 			const source = lifecycleSourceResults.get(row.id);
@@ -1656,9 +1716,12 @@ export async function hybridRecall(
 		graphQueryTokens ??= tokenizeGraphQuery(query);
 		return graphQueryTokens;
 	};
-	const getFocalEntities = async (agentId: string): Promise<ReturnType<typeof resolveFocalEntities>> => {
+	const getFocalEntities = async (
+		owner: DbOwnerClient,
+		agentId: string,
+	): Promise<ReturnType<typeof resolveFocalEntities>> => {
 		if (focalCache?.agentId === agentId) return focalCache.value;
-		const value = await resolveFocalEntitiesViaOwner(await getDbOwner(getDbAccessorPath()), agentId, {
+		const value = await resolveFocalEntitiesViaOwner(owner, agentId, {
 			queryTokens: getGraphQueryTokens(),
 			includePinned: false,
 		});
@@ -1976,29 +2039,23 @@ export async function hybridRecall(
 					const queryTokens = getGraphQueryTokens();
 					if (queryTokens.length > 0) {
 						const agentId = params.agentId ?? "default";
-						const focal = await getFocalEntities(agentId);
+						const owner = await getGraphOwner();
+						const focal = await getFocalEntities(owner, agentId);
+						if (focal.error) recordGraphResult({ timedOut: false, error: focal.error });
 
 						if (focal.entityIds.length > 0) {
-							const traversal = await traverseKnowledgeGraph(
-								focal.entityIds,
-								(readFn) =>
-									getDbAccessor().withReadDbAsync(readFn, {
-										siteToken: "memory-search.ts:1985",
-										operation: "memory.graph-traversal",
-									}),
-								agentId,
-								{
-									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
-									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
-									maxDependencyHops: traversalCfg.maxDependencyHops,
-									minDependencyStrength: traversalCfg.minDependencyStrength,
-									maxBranching: traversalCfg.maxBranching,
-									maxTraversalPaths: traversalCfg.maxTraversalPaths,
-									minConfidence: traversalCfg.minConfidence,
-									timeoutMs: traversalCfg.timeoutMs,
-									scope: params.scope,
-								},
-							);
+							const traversal = await traverseKnowledgeGraphViaOwner(focal.entityIds, owner, agentId, {
+								maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
+								maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
+								maxDependencyHops: traversalCfg.maxDependencyHops,
+								minDependencyStrength: traversalCfg.minDependencyStrength,
+								maxBranching: traversalCfg.maxBranching,
+								maxTraversalPaths: traversalCfg.maxTraversalPaths,
+								minConfidence: traversalCfg.minConfidence,
+								timeoutMs: traversalCfg.timeoutMs,
+								scope: params.scope,
+							});
+							recordGraphResult(traversal);
 
 							// Cosine re-scoring: when query embedding is available,
 							// blend structural importance with semantic similarity so
@@ -2059,6 +2116,7 @@ export async function hybridRecall(
 						}
 					}
 				} catch (e) {
+					recordGraphResult({ timedOut: false, error: describeRecallGraphError(e) });
 					logger.warn("memory", "Traversal channel failed (non-fatal)", {
 						error: e instanceof Error ? e.message : String(e),
 					});
@@ -2127,28 +2185,22 @@ export async function hybridRecall(
 					const queryTokens = getGraphQueryTokens();
 					if (traversalCfg && queryTokens.length > 0) {
 						const agentId = params.agentId ?? "default";
-						const focal = await getFocalEntities(agentId);
+						const owner = await getGraphOwner();
+						const focal = await getFocalEntities(owner, agentId);
+						if (focal.error) recordGraphResult({ timedOut: false, error: focal.error });
 
 						if (focal.entityIds.length > 0) {
-							const traversal = await traverseKnowledgeGraph(
-								focal.entityIds,
-								(readFn) =>
-									getDbAccessor().withReadDbAsync(readFn, {
-										siteToken: "memory-search.ts:2136",
-										operation: "memory.graph-traversal",
-									}),
-								agentId,
-								{
-									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
-									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
-									maxDependencyHops: traversalCfg.maxDependencyHops,
-									minDependencyStrength: traversalCfg.minDependencyStrength,
-									maxBranching: traversalCfg.maxBranching,
-									maxTraversalPaths: traversalCfg.maxTraversalPaths,
-									minConfidence: traversalCfg.minConfidence,
-									timeoutMs: traversalCfg.timeoutMs,
-								},
-							);
+							const traversal = await traverseKnowledgeGraphViaOwner(focal.entityIds, owner, agentId, {
+								maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
+								maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
+								maxDependencyHops: traversalCfg.maxDependencyHops,
+								minDependencyStrength: traversalCfg.minDependencyStrength,
+								maxBranching: traversalCfg.maxBranching,
+								maxTraversalPaths: traversalCfg.maxTraversalPaths,
+								minConfidence: traversalCfg.minConfidence,
+								timeoutMs: traversalCfg.timeoutMs,
+							});
+							recordGraphResult(traversal);
 
 							const tw = traversalCfg.boostWeight;
 							const scoredById = new Map(scored.map((row) => [row.id, row]));
@@ -2219,6 +2271,7 @@ export async function hybridRecall(
 					}
 				});
 			} catch (e) {
+				recordGraphResult({ timedOut: false, error: describeRecallGraphError(e) });
 				logger.warn("memory", "KA traversal boost failed (non-fatal)", {
 					error: e instanceof Error ? e.message : String(e),
 				});
@@ -3067,7 +3120,9 @@ export async function hybridRecall(
 			const queryTokens = getGraphQueryTokens();
 			if (queryTokens.length > 0) {
 				const agentId = params.agentId ?? "default";
-				const focal = await getFocalEntities(agentId);
+				const owner = await getGraphOwner();
+				const focal = await getFocalEntities(owner, agentId);
+				if (focal.error) recordGraphResult({ timedOut: false, error: focal.error });
 				const ctx = await getDbAccessor().withReadDbAsync(
 					async (db) => {
 						if (focal.entityIds.length === 0) return null;

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -40,9 +40,9 @@ import { buildAgentScopeClause } from "./memory-access-scope";
 import type { EmbeddingConfig, MemorySearchConfig, ResolvedMemoryConfig } from "./memory-config";
 import { isMemoryContentContextEligible } from "./memory-content-safety";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
-import { constructContextBlocks } from "./pipeline/context-construction";
+import { constructContextBlocksViaOwner } from "./pipeline/context-construction";
 import { DEFAULT_DAMPENING, type ScoredRow, applyDampening } from "./pipeline/dampening";
-import { getGraphBoostIds, tokenizeGraphQuery } from "./pipeline/graph-search";
+import { getGraphBoostIdsViaOwner, tokenizeGraphQuery } from "./pipeline/graph-search";
 import {
 	type resolveFocalEntities,
 	resolveFocalEntitiesViaOwner,
@@ -60,9 +60,9 @@ import {
 } from "./pipeline/structured-evidence";
 import {
 	type StructuredClaimCandidate,
-	findStructuredClaimCandidates,
-	findStructuredPathCandidates,
-	scoreStructuredPathEvidence,
+	findStructuredClaimCandidatesViaOwner,
+	findStructuredPathCandidatesViaOwner,
+	scoreStructuredPathEvidenceViaOwner,
 } from "./pipeline/structured-path-evidence";
 import { type RecallDedupeMeta, applyRecallDedupe } from "./session-recall-dedupe";
 import { recordFirstSourceRecall } from "./source-lifecycle-telemetry";
@@ -1101,7 +1101,7 @@ async function buildSourceChunkVectorHits(
 				deadlineMs: 5_000,
 			},
 		);
-		const hasSafetyLedger = safetyTable == null ? false : true;
+		const hasSafetyLedger = safetyTable != null;
 		const safetySelect = hasSafetyLedger ? ", mcs.status AS safety_status, mcs.context_eligible" : "";
 		const safetyJoin = hasSafetyLedger
 			? "LEFT JOIN memory_content_safety mcs ON mcs.agent_id = ? AND mcs.source_kind = 'source_chunk' AND mcs.source_id = e.id"
@@ -1538,6 +1538,19 @@ export async function hybridRecall(
 		graphOwner ??= await getDbOwner(getDbAccessorPath());
 		return graphOwner;
 	};
+	const graphOwnerReadAll = async <Row extends object>(
+		sql: string,
+		params: readonly unknown[],
+		operation: string,
+		estimatedWorkUnits = 200,
+	): Promise<ReadonlyArray<Row>> =>
+		await ownerReadAll<Row>(await getGraphOwner(), sql, params, {
+			operation,
+			lane: "read",
+			workloadClass: "foreground",
+			deadlineMs: 30_000,
+			estimatedWorkUnits,
+		});
 	const recordGraphResult = (result: {
 		readonly timedOut: boolean;
 		readonly error?: { readonly code: string | number | null; readonly message: string };
@@ -1551,8 +1564,8 @@ export async function hybridRecall(
 			graphDegradation = "graph_traversal_failed";
 			graphError = {
 				channel: "graph_traversal",
-				code: result.error.code,
-				message: result.error.message,
+				code: "graph_traversal_failed",
+				message: "Knowledge graph traversal was unavailable.",
 			};
 		}
 	};
@@ -1918,19 +1931,13 @@ export async function hybridRecall(
 	if (cfg.pipelineV2.graph.enabled) {
 		try {
 			const agentId = params.agentId ?? "default";
-			const candidates = await timings.timeAsync(
-				"structured_path_candidates",
-				async () =>
-					await getDbAccessor().withReadDbAsync(
-						async (db) =>
-							findStructuredPathCandidates(db, query, agentId, {
-								limit: cfg.search.top_k,
-								minScore,
-								filterSql: filter.sql,
-								filterArgs: filter.args,
-							}),
-						{ siteToken: "memory-search.ts:1924" },
-					),
+			const candidates = await timings.timeAsync("structured_path_candidates", async () =>
+				findStructuredPathCandidatesViaOwner(await getGraphOwner(), query, agentId, {
+					limit: cfg.search.top_k,
+					minScore,
+					filterSql: filter.sql,
+					filterArgs: filter.args,
+				}),
 			);
 			for (const [id, score] of candidates) structuredCandidateMap.set(id, score);
 		} catch (e) {
@@ -1941,17 +1948,11 @@ export async function hybridRecall(
 		if (canUseOntologyClaimRecall(params) && temporalCandidateSet.size === 0 && !temporal.meta) {
 			try {
 				const agentId = params.agentId ?? "default";
-				ontologyClaimCandidates = await timings.timeAsync(
-					"ontology_claim_candidates",
-					async () =>
-						await getDbAccessor().withReadDbAsync(
-							async (db) =>
-								findStructuredClaimCandidates(db, query, agentId, {
-									limit: cfg.search.top_k,
-									minScore,
-								}),
-							{ siteToken: "memory-search.ts:1947" },
-						),
+				ontologyClaimCandidates = await timings.timeAsync("ontology_claim_candidates", async () =>
+					findStructuredClaimCandidatesViaOwner(await getGraphOwner(), query, agentId, {
+						limit: cfg.search.top_k,
+						minScore,
+					}),
 				);
 			} catch (e) {
 				logger.warn("memory", "Ontology claim candidate search failed (non-fatal)", {
@@ -2068,19 +2069,15 @@ export async function hybridRecall(
 								const ph = ids.map(() => "?").join(", ");
 								let embRows: Array<{ source_id: string; vector: Buffer | null }> = [];
 								try {
-									embRows = await getDbAccessor().withReadDbAsync(
-										async (db) =>
-											db
-												.prepare(
-													`SELECT source_id, vector FROM embeddings
-												 WHERE source_id IN (${ph}) AND vector IS NOT NULL`,
-												)
-												.all(...ids) as Array<{
-												source_id: string;
-												vector: Buffer | null;
-											}>,
-										{ siteToken: "memory-search.ts:2071" },
-									);
+									embRows = [
+										...(await graphOwnerReadAll<{ source_id: string; vector: Buffer | null }>(
+											`SELECT source_id, vector FROM embeddings
+											 WHERE source_id IN (${ph}) AND vector IS NOT NULL`,
+											ids,
+											"memory-search.traversal.embedding-rescore",
+											ids.length,
+										)),
+									];
 								} catch (e) {
 									logger.warn("memory", "Traversal embedding re-scoring failed (non-fatal)", {
 										error: e instanceof Error ? e.message : String(e),
@@ -2159,14 +2156,10 @@ export async function hybridRecall(
 		// --- Graph boost: pull up memories linked via knowledge graph ---
 		if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.graph.boostWeight > 0) {
 			try {
-				const graphResult = await timings.timeAsync(
-					"graph_boost",
-					async () =>
-						await getDbAccessor().withReadDbAsync(
-							async (db) => getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
-							{ siteToken: "memory-search.ts:2165" },
-						),
-				);
+				const graphResult = await timings.timeAsync("graph_boost", async () => {
+					const owner = await getGraphOwner();
+					return await getGraphBoostIdsViaOwner(query, owner, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId);
+				});
 				if (graphResult.graphLinkedIds.size > 0) {
 					const gw = cfg.pipelineV2.graph.boostWeight;
 					for (const s of scored) {
@@ -2227,30 +2220,27 @@ export async function hybridRecall(
 								const placeholders = missingIds.map(() => "?").join(", ");
 								let baseRows: Array<{ id: string; traversal_score: number }> = [];
 								try {
-									baseRows = await getDbAccessor().withReadDbAsync(
-										async (db) =>
-											db
-												.prepare(
-													`SELECT
-													 m.id,
-													 COALESCE(MAX(ea.importance), m.importance, 0.5) AS traversal_score
-											 FROM memories m
-											 LEFT JOIN entity_attributes ea
-											   ON ea.memory_id = m.id
-											  AND ea.agent_id = ?
-											  AND ea.status = 'active'
-											 WHERE m.id IN (${placeholders})
-											   AND m.is_deleted = 0
-											   ${memorySupersessionSql(db)}
-											 ${filter.sql}
-											 GROUP BY m.id, m.importance`,
-												)
-												.all(agentId, ...missingIds, ...filter.args) as Array<{
-												id: string;
-												traversal_score: number;
-											}>,
-										{ siteToken: "memory-search.ts:2230" },
-									);
+									baseRows = [
+										...(await graphOwnerReadAll<{ id: string; traversal_score: number }>(
+											`SELECT
+											 m.id,
+											 COALESCE(MAX(ea.importance), m.importance, 0.5) AS traversal_score
+										 FROM memories m
+										 LEFT JOIN entity_attributes ea
+										   ON ea.memory_id = m.id
+										  AND ea.agent_id = ?
+										  AND ea.status = 'active'
+										 WHERE m.id IN (${placeholders})
+										   AND m.is_deleted = 0
+										   AND m.superseded_by IS NULL
+										   AND m.stale_at IS NULL
+										   ${filter.sql}
+										 GROUP BY m.id, m.importance`,
+											[agentId, ...missingIds, ...filter.args],
+											"memory-search.traversal.candidate-hydration",
+											missingIds.length,
+										)),
+									];
 								} catch (e) {
 									logger.warn("memory", "KA traversal candidate hydration failed (non-fatal)", {
 										error: e instanceof Error ? e.message : String(e),
@@ -2323,7 +2313,7 @@ export async function hybridRecall(
 								 WHERE id IN (${placeholders})`,
 							)
 							.all(...candidateIds) as Array<{ id: string; content: string }>,
-					{ siteToken: "memory-search.ts:2318" },
+					{ siteToken: "memory-search.ts:2308" },
 				);
 				for (const row of contentRows) {
 					const score = scoreTemporalTopicEvidence(query, row.content);
@@ -2361,15 +2351,11 @@ export async function hybridRecall(
 			const candidates = [...byId.values()];
 			try {
 				const agentId = params.agentId ?? "default";
-				const structured = await getDbAccessor().withReadDbAsync(
-					async (db) =>
-						scoreStructuredPathEvidence(
-							db,
-							candidates.map((row) => row.id),
-							query,
-							agentId,
-						),
-					{ siteToken: "memory-search.ts:2364" },
+				const structured = await scoreStructuredPathEvidenceViaOwner(
+					await getGraphOwner(),
+					candidates.map((row) => row.id),
+					query,
+					agentId,
 				);
 				for (const [id, score] of structured) {
 					structuredEvidenceMap.set(id, score);
@@ -2405,7 +2391,7 @@ export async function hybridRecall(
 									 WHERE id IN (${placeholders})`,
 								)
 								.all(...coverageIds) as Array<{ id: string; content: string }>,
-						{ siteToken: "memory-search.ts:2400" },
+						{ siteToken: "memory-search.ts:2386" },
 					);
 					contentMap = new Map(contentRows.map((row) => [row.id, row.content]));
 				}
@@ -2455,7 +2441,7 @@ export async function hybridRecall(
 						id: string;
 						content: string;
 					}>,
-				{ siteToken: "memory-search.ts:2447" },
+				{ siteToken: "memory-search.ts:2433" },
 			);
 			const contentMap = new Map(contentRows.map((r) => [r.id, r.content]));
 
@@ -2535,7 +2521,7 @@ export async function hybridRecall(
 						content: string;
 						type: string;
 					}>,
-				{ siteToken: "memory-search.ts:2526" },
+				{ siteToken: "memory-search.ts:2512" },
 			);
 			const meta = new Map(dampenRows.map((r) => [r.id, r]));
 
@@ -2544,18 +2530,15 @@ export async function hybridRecall(
 			const degrees = new Map<string, number>();
 
 			if (cfg.pipelineV2.graph.enabled) {
-				const links = await getDbAccessor().withReadDbAsync(
-					async (db) =>
-						db
-							.prepare(
-								`SELECT memory_id, entity_id FROM memory_entity_mentions
-								 WHERE memory_id IN (${dampenPh})`,
-							)
-							.all(...dampenIds) as Array<{
-							memory_id: string;
-							entity_id: string;
-						}>,
-					{ siteToken: "memory-search.ts:2547" },
+				const links = await graphOwnerReadAll<{
+					memory_id: string;
+					entity_id: string;
+				}>(
+					`SELECT memory_id, entity_id FROM memory_entity_mentions
+					 WHERE memory_id IN (${dampenPh})`,
+					dampenIds,
+					"memory-search.dampening.links",
+					dampenIds.length,
 				);
 
 				const entityIds = new Set<string>();
@@ -2573,20 +2556,17 @@ export async function hybridRecall(
 				if (entityIds.size > 0) {
 					const eidList = [...entityIds];
 					const eidPh = eidList.map(() => "?").join(", ");
-					const degreeRows = await getDbAccessor().withReadDbAsync(
-						async (db) =>
-							db
-								.prepare(
-									`SELECT entity_id, COUNT(*) AS cnt
-									 FROM memory_entity_mentions
-									 WHERE entity_id IN (${eidPh})
-									 GROUP BY entity_id`,
-								)
-								.all(...eidList) as Array<{
-								entity_id: string;
-								cnt: number;
-							}>,
-						{ siteToken: "memory-search.ts:2576" },
+					const degreeRows = await graphOwnerReadAll<{
+						entity_id: string;
+						cnt: number;
+					}>(
+						`SELECT entity_id, COUNT(*) AS cnt
+						 FROM memory_entity_mentions
+						 WHERE entity_id IN (${eidPh})
+						 GROUP BY entity_id`,
+						eidList,
+						"memory-search.dampening.degrees",
+						eidList.length,
 					);
 					for (const row of degreeRows) {
 						degrees.set(row.entity_id, row.cnt);
@@ -2833,7 +2813,7 @@ export async function hybridRecall(
 						scope: string | null;
 						agent_id: string | null;
 					}>,
-				{ siteToken: "memory-search.ts:2813" },
+				{ siteToken: "memory-search.ts:2793" },
 			),
 	);
 
@@ -2847,7 +2827,7 @@ export async function hybridRecall(
 					content: row.content,
 				}),
 			),
-		{ siteToken: "memory-search.ts:2840" },
+		{ siteToken: "memory-search.ts:2820" },
 	);
 	const rowMap = new Map(safeRows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is
@@ -3035,61 +3015,66 @@ export async function hybridRecall(
 	if (decisionIds.length > 0 && cfg.pipelineV2.graph.enabled) {
 		const rationaleStart = performance.now();
 		try {
-			const supplementary = await getDbAccessor().withReadDbAsync(
-				async (db) => {
-					// Find entities linked to decision memories
-					const dPlaceholders = decisionIds.map(() => "?").join(", ");
-					const entityIds = db
-						.prepare(
-							`SELECT DISTINCT entity_id FROM memory_entity_mentions
-							 WHERE memory_id IN (${dPlaceholders})`,
-						)
-						.all(...decisionIds) as Array<{ entity_id: string }>;
-
-					if (entityIds.length === 0) return [];
-
-					// Find rationale memories linked to same entities
-					const ePlaceholders = entityIds.map(() => "?").join(", ");
-					const eIds = entityIds.map((r) => r.entity_id);
-
-					const queried = db
-						.prepare(
-							`SELECT DISTINCT m.id, m.content, m.type, m.tags, m.pinned,
-						        m.importance, m.who, m.project, m.created_at, m.visibility, m.scope, m.agent_id
-							 FROM memory_entity_mentions mem
-							 JOIN memories m ON m.id = mem.memory_id
-							 WHERE mem.entity_id IN (${ePlaceholders})
-							   AND m.type = 'rationale'
-							   AND m.is_deleted = 0
-							   ${memorySupersessionSql(db)}
-							   ${filter.sql}
-							 LIMIT 10`,
-						)
-						.all(...eIds, ...filter.args) as Array<{
-						id: string;
-						content: string;
-						type: string;
-						tags: string | null;
-						pinned: number;
-						importance: number;
-						who: string;
-						project: string | null;
-						created_at: string;
-						visibility?: string | null;
-						scope?: string | null;
-						agent_id: string | null;
-					}>;
-					return queried.filter((row) =>
-						isMemoryContentContextEligible(db, {
-							agentId: row.agent_id?.trim() || "default",
-							sourceKind: "memory",
-							sourceId: row.id,
-							content: row.content,
-						}),
-					);
-				},
-				{ siteToken: "memory-search.ts:3038" },
+			const dPlaceholders = decisionIds.map(() => "?").join(", ");
+			const entityIds = await graphOwnerReadAll<{ entity_id: string }>(
+				`SELECT DISTINCT entity_id FROM memory_entity_mentions
+				 WHERE memory_id IN (${dPlaceholders})`,
+				decisionIds,
+				"memory-search.rationale.entities",
+				decisionIds.length,
 			);
+			const supplementary =
+				entityIds.length === 0
+					? []
+					: await (async () => {
+							const eIds = entityIds.map((row) => row.entity_id);
+							const ePlaceholders = eIds.map(() => "?").join(", ");
+							const safetyTable = await graphOwnerReadAll<{ name: string }>(
+								"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_content_safety'",
+								[],
+								"memory-search.rationale.safety-table",
+								1,
+							);
+							const safetyJoin =
+								safetyTable.length > 0
+									? "LEFT JOIN memory_content_safety mcs ON mcs.agent_id = m.agent_id AND mcs.source_kind = 'memory' AND mcs.source_id = m.id"
+									: "";
+							const safetyFilter =
+								safetyTable.length > 0
+									? "AND (mcs.source_id IS NULL OR (mcs.status = 'clean' AND mcs.context_eligible = 1))"
+									: "";
+							return await graphOwnerReadAll<{
+								id: string;
+								content: string;
+								type: string;
+								tags: string | null;
+								pinned: number;
+								importance: number;
+								who: string;
+								project: string | null;
+								created_at: string;
+								visibility?: string | null;
+								scope?: string | null;
+								agent_id: string | null;
+							}>(
+								`SELECT DISTINCT m.id, m.content, m.type, m.tags, m.pinned,
+						        m.importance, m.who, m.project, m.created_at, m.visibility, m.scope, m.agent_id
+						 FROM memory_entity_mentions mem
+						 JOIN memories m ON m.id = mem.memory_id
+						 ${safetyJoin}
+						 WHERE mem.entity_id IN (${ePlaceholders})
+						   AND m.type = 'rationale'
+						   AND m.is_deleted = 0
+						   AND m.superseded_by IS NULL
+						   AND m.stale_at IS NULL
+						   ${filter.sql}
+						   ${safetyFilter}
+						 LIMIT 10`,
+								[...eIds, ...filter.args],
+								"memory-search.rationale.memories",
+								10,
+							);
+						})();
 
 			for (const r of supplementary) {
 				if (results.length >= limit) break;
@@ -3137,90 +3122,71 @@ export async function hybridRecall(
 				const owner = await getGraphOwner();
 				const focal = await getFocalEntities(owner, agentId);
 				if (focal.error) recordGraphResult({ timedOut: false, error: focal.error });
-				const ctx = await getDbAccessor().withReadDbAsync(
-					async (db) => {
-						if (focal.entityIds.length === 0) return null;
+				const ctx = await (async () => {
+					if (focal.entityIds.length === 0) return null;
+					let eids = focal.entityIds;
+					if (params.scope !== undefined || params.project) {
+						const ph = eids.map(() => "?").join(", ");
+						const scoped = await graphOwnerReadAll<{ entity_id: string }>(
+							`SELECT DISTINCT mem.entity_id
+							 FROM memory_entity_mentions mem
+							 JOIN memories m ON m.id = mem.memory_id
+							 WHERE mem.entity_id IN (${ph})
+							   AND m.is_deleted = 0
+							   AND m.superseded_by IS NULL
+							   AND m.stale_at IS NULL
+							   ${filter.sql}`,
+							[...eids, ...filter.args],
+							"memory-search.entity-context.scope",
+							eids.length,
+						);
+						eids = scoped.map((row) => row.entity_id);
+						if (eids.length === 0) return null;
+					}
 
-						// Project/scope-constrained recall should not let broad focal
-						// entities pull in structural context from outside that slice.
-						let eids = focal.entityIds;
-						if (params.scope !== undefined || params.project) {
-							const ph = eids.map(() => "?").join(", ");
-							const sr = db
-								.prepare(
-									`SELECT DISTINCT mem.entity_id
-								 FROM memory_entity_mentions mem
-								 JOIN memories m ON m.id = mem.memory_id
-								 WHERE mem.entity_id IN (${ph})
-								   AND m.is_deleted = 0${memorySupersessionSql(db)}${filter.sql}`,
-								)
-								.all(...eids, ...filter.args) as Array<{ entity_id: string }>;
-							eids = sr.map((r) => r.entity_id);
-							if (eids.length === 0) return null;
+					const placeholders = eids.map(() => "?").join(", ");
+					const entities = await graphOwnerReadAll<{ id: string; name: string; entity_type: string }>(
+						`SELECT id, name, entity_type FROM entities WHERE id IN (${placeholders})`,
+						eids,
+						"memory-search.entity-context.entities",
+						eids.length,
+					);
+					const structured = [];
+					for (const entity of entities) {
+						const aspects = await graphOwnerReadAll<{ id: string; name: string }>(
+							`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
+							 WHERE entity_id = ? AND agent_id = ?
+							 ORDER BY weight DESC LIMIT 10`,
+							[entity.id, agentId],
+							"memory-search.entity-context.aspects",
+							10,
+						);
+						const contextAspects = [];
+						for (const aspect of aspects) {
+							const attrs = await graphOwnerReadAll<{
+								content: string;
+								status: string;
+								importance: number;
+								memory_id: string | null;
+							}>(
+								`SELECT content, status, importance, memory_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
+								 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
+								 ORDER BY importance DESC LIMIT 5`,
+								[aspect.id, agentId],
+								"memory-search.entity-context.attributes",
+								5,
+							);
+							const attributes = attrs
+								.filter((attr) => scanMemoryContent(attr.content).contextEligible)
+								.map((attr) => ({ content: attr.content, status: attr.status, importance: attr.importance }));
+							if (attributes.length > 0) contextAspects.push({ name: aspect.name, attributes });
 						}
-
-						const placeholders = eids.map(() => "?").join(", ");
-						const entities = db
-							.prepare(
-								`SELECT id, name, entity_type FROM entities
-							 WHERE id IN (${placeholders})`,
-							)
-							.all(...eids) as Array<{
-							id: string;
-							name: string;
-							entity_type: string;
-						}>;
-
-						const structured = entities
-							.map((ent) => {
-								const aspects = db
-									.prepare(
-										`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
-								 WHERE entity_id = ? AND agent_id = ?
-								 ORDER BY weight DESC LIMIT 10`,
-									)
-									.all(ent.id, agentId) as Array<{ id: string; name: string }>;
-
-								return {
-									name: ent.name,
-									type: ent.entity_type,
-									aspects: aspects
-										.map((asp) => {
-											const attrs = db
-												.prepare(
-													`SELECT content, status, importance, memory_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
-									 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
-										 ORDER BY importance DESC LIMIT 5`,
-												)
-												.all(asp.id, agentId) as Array<{
-												content: string;
-												status: string;
-												importance: number;
-												memory_id: string | null;
-											}>;
-											return {
-												name: asp.name,
-												attributes: attrs.filter((attr) =>
-													attr.memory_id
-														? isMemoryContentContextEligible(db, {
-																agentId,
-																sourceKind: "memory",
-																sourceId: attr.memory_id,
-																content: attr.content,
-															})
-														: scanMemoryContent(attr.content).contextEligible,
-												),
-											};
-										})
-										.filter((a) => a.attributes.length > 0),
-								};
-							})
-							.filter((e) => e.aspects.length > 0);
-
-						return { eids, structured };
-					},
-					{ siteToken: "memory-search.ts:3140" },
-				);
+						if (contextAspects.length > 0) {
+							structured.push({ name: entity.name, type: entity.entity_type, aspects: contextAspects });
+						}
+					}
+					return { eids, structured };
+				})();
 
 				if (ctx) {
 					entityContext = ctx.structured;
@@ -3246,10 +3212,7 @@ export async function hybridRecall(
 		try {
 			const agentId = params.agentId ?? "default";
 			const cap = Math.max(3, Math.ceil(limit * 0.3));
-			const blocks = await getDbAccessor().withReadDbAsync(
-				async (db) => constructContextBlocks(db, agentId, focalEids, cap),
-				{ siteToken: "memory-search.ts:3249" },
-			);
+			const blocks = await constructContextBlocksViaOwner(await getGraphOwner(), agentId, focalEids, cap);
 			const now = new Date().toISOString();
 			const minReal = results.length > 0 ? Math.min(...results.map((r) => r.score)) : 0.5;
 			const maxConstructed = Math.max(0.01, minReal - 0.01);

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -2066,19 +2066,26 @@ export async function hybridRecall(
 							if (queryVecF32 && traversal.memoryScores.size > 0) {
 								const ids = [...traversal.memoryScores.keys()];
 								const ph = ids.map(() => "?").join(", ");
-								const embRows = await getDbAccessor().withReadDbAsync(
-									async (db) =>
-										db
-											.prepare(
-												`SELECT source_id, vector FROM embeddings
-											 WHERE source_id IN (${ph}) AND vector IS NOT NULL`,
-											)
-											.all(...ids) as Array<{
-											source_id: string;
-											vector: Buffer | null;
-										}>,
-									{ siteToken: "memory-search.ts:2069" },
-								);
+								let embRows: Array<{ source_id: string; vector: Buffer | null }> = [];
+								try {
+									embRows = await getDbAccessor().withReadDbAsync(
+										async (db) =>
+											db
+												.prepare(
+													`SELECT source_id, vector FROM embeddings
+												 WHERE source_id IN (${ph}) AND vector IS NOT NULL`,
+												)
+												.all(...ids) as Array<{
+												source_id: string;
+												vector: Buffer | null;
+											}>,
+										{ siteToken: "memory-search.ts:2069" },
+									);
+								} catch (e) {
+									logger.warn("memory", "Traversal embedding re-scoring failed (non-fatal)", {
+										error: e instanceof Error ? e.message : String(e),
+									});
+								}
 								const qv = queryVecF32;
 								for (const row of embRows) {
 									if (!row.vector) continue;
@@ -2218,13 +2225,15 @@ export async function hybridRecall(
 
 							if (missingIds.length > 0) {
 								const placeholders = missingIds.map(() => "?").join(", ");
-								const baseRows = await getDbAccessor().withReadDbAsync(
-									async (db) =>
-										db
-											.prepare(
-												`SELECT
-												 m.id,
-												 COALESCE(MAX(ea.importance), m.importance, 0.5) AS traversal_score
+								let baseRows: Array<{ id: string; traversal_score: number }> = [];
+								try {
+									baseRows = await getDbAccessor().withReadDbAsync(
+										async (db) =>
+											db
+												.prepare(
+													`SELECT
+													 m.id,
+													 COALESCE(MAX(ea.importance), m.importance, 0.5) AS traversal_score
 											 FROM memories m
 											 LEFT JOIN entity_attributes ea
 											   ON ea.memory_id = m.id
@@ -2235,13 +2244,18 @@ export async function hybridRecall(
 											   ${memorySupersessionSql(db)}
 											 ${filter.sql}
 											 GROUP BY m.id, m.importance`,
-											)
-											.all(agentId, ...missingIds, ...filter.args) as Array<{
-											id: string;
-											traversal_score: number;
-										}>,
-									{ siteToken: "memory-search.ts:2221" },
-								);
+												)
+												.all(agentId, ...missingIds, ...filter.args) as Array<{
+												id: string;
+												traversal_score: number;
+											}>,
+										{ siteToken: "memory-search.ts:2221" },
+									);
+								} catch (e) {
+									logger.warn("memory", "KA traversal candidate hydration failed (non-fatal)", {
+										error: e instanceof Error ? e.message : String(e),
+									});
+								}
 
 								for (const row of baseRows) {
 									const traversalScore = Math.max(minScore, Math.min(1, row.traversal_score));

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -2079,7 +2079,7 @@ export async function hybridRecall(
 												source_id: string;
 												vector: Buffer | null;
 											}>,
-										{ siteToken: "memory-search.ts:2069" },
+										{ siteToken: "memory-search.ts:2071" },
 									);
 								} catch (e) {
 									logger.warn("memory", "Traversal embedding re-scoring failed (non-fatal)", {
@@ -2164,7 +2164,7 @@ export async function hybridRecall(
 					async () =>
 						await getDbAccessor().withReadDbAsync(
 							async (db) => getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
-							{ siteToken: "memory-search.ts:2158" },
+							{ siteToken: "memory-search.ts:2165" },
 						),
 				);
 				if (graphResult.graphLinkedIds.size > 0) {
@@ -2249,7 +2249,7 @@ export async function hybridRecall(
 												id: string;
 												traversal_score: number;
 											}>,
-										{ siteToken: "memory-search.ts:2221" },
+										{ siteToken: "memory-search.ts:2230" },
 									);
 								} catch (e) {
 									logger.warn("memory", "KA traversal candidate hydration failed (non-fatal)", {
@@ -2323,7 +2323,7 @@ export async function hybridRecall(
 								 WHERE id IN (${placeholders})`,
 							)
 							.all(...candidateIds) as Array<{ id: string; content: string }>,
-					{ siteToken: "memory-search.ts:2304" },
+					{ siteToken: "memory-search.ts:2318" },
 				);
 				for (const row of contentRows) {
 					const score = scoreTemporalTopicEvidence(query, row.content);
@@ -2369,7 +2369,7 @@ export async function hybridRecall(
 							query,
 							agentId,
 						),
-					{ siteToken: "memory-search.ts:2350" },
+					{ siteToken: "memory-search.ts:2364" },
 				);
 				for (const [id, score] of structured) {
 					structuredEvidenceMap.set(id, score);
@@ -2405,7 +2405,7 @@ export async function hybridRecall(
 									 WHERE id IN (${placeholders})`,
 								)
 								.all(...coverageIds) as Array<{ id: string; content: string }>,
-						{ siteToken: "memory-search.ts:2386" },
+						{ siteToken: "memory-search.ts:2400" },
 					);
 					contentMap = new Map(contentRows.map((row) => [row.id, row.content]));
 				}
@@ -2455,7 +2455,7 @@ export async function hybridRecall(
 						id: string;
 						content: string;
 					}>,
-				{ siteToken: "memory-search.ts:2433" },
+				{ siteToken: "memory-search.ts:2447" },
 			);
 			const contentMap = new Map(contentRows.map((r) => [r.id, r.content]));
 
@@ -2535,7 +2535,7 @@ export async function hybridRecall(
 						content: string;
 						type: string;
 					}>,
-				{ siteToken: "memory-search.ts:2512" },
+				{ siteToken: "memory-search.ts:2526" },
 			);
 			const meta = new Map(dampenRows.map((r) => [r.id, r]));
 
@@ -2555,7 +2555,7 @@ export async function hybridRecall(
 							memory_id: string;
 							entity_id: string;
 						}>,
-					{ siteToken: "memory-search.ts:2533" },
+					{ siteToken: "memory-search.ts:2547" },
 				);
 
 				const entityIds = new Set<string>();
@@ -2586,7 +2586,7 @@ export async function hybridRecall(
 								entity_id: string;
 								cnt: number;
 							}>,
-						{ siteToken: "memory-search.ts:2562" },
+						{ siteToken: "memory-search.ts:2576" },
 					);
 					for (const row of degreeRows) {
 						degrees.set(row.entity_id, row.cnt);
@@ -2833,7 +2833,7 @@ export async function hybridRecall(
 						scope: string | null;
 						agent_id: string | null;
 					}>,
-				{ siteToken: "memory-search.ts:2799" },
+				{ siteToken: "memory-search.ts:2813" },
 			),
 	);
 
@@ -2847,7 +2847,7 @@ export async function hybridRecall(
 					content: row.content,
 				}),
 			),
-		{ siteToken: "memory-search.ts:2826" },
+		{ siteToken: "memory-search.ts:2840" },
 	);
 	const rowMap = new Map(safeRows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is
@@ -3088,7 +3088,7 @@ export async function hybridRecall(
 						}),
 					);
 				},
-				{ siteToken: "memory-search.ts:3024" },
+				{ siteToken: "memory-search.ts:3038" },
 			);
 
 			for (const r of supplementary) {
@@ -3219,7 +3219,7 @@ export async function hybridRecall(
 
 						return { eids, structured };
 					},
-					{ siteToken: "memory-search.ts:3126" },
+					{ siteToken: "memory-search.ts:3140" },
 				);
 
 				if (ctx) {
@@ -3248,7 +3248,7 @@ export async function hybridRecall(
 			const cap = Math.max(3, Math.ceil(limit * 0.3));
 			const blocks = await getDbAccessor().withReadDbAsync(
 				async (db) => constructContextBlocks(db, agentId, focalEids, cap),
-				{ siteToken: "memory-search.ts:3235" },
+				{ siteToken: "memory-search.ts:3249" },
 			);
 			const now = new Date().toISOString();
 			const minReal = results.length > 0 ? Math.min(...results.map((r) => r.score)) : 0.5;

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -3151,6 +3151,20 @@ export async function hybridRecall(
 						"memory-search.entity-context.entities",
 						eids.length,
 					);
+					const safetyTable = await graphOwnerReadAll<{ name: string }>(
+						"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_content_safety'",
+						[],
+						"memory-search.entity-context.safety-table",
+						1,
+					);
+					const safetyJoin =
+						safetyTable.length > 0
+							? "LEFT JOIN memory_content_safety safety ON safety.agent_id = ea.agent_id AND safety.source_kind = 'memory' AND safety.source_id = ea.memory_id"
+							: "";
+					const safetySelect =
+						safetyTable.length > 0
+							? ", safety.status AS safety_status, safety.context_eligible AS safety_context_eligible"
+							: "";
 					const structured = [];
 					for (const entity of entities) {
 						const aspects = await graphOwnerReadAll<{ id: string; name: string }>(
@@ -3168,16 +3182,25 @@ export async function hybridRecall(
 								status: string;
 								importance: number;
 								memory_id: string | null;
+								safety_status?: string | null;
+								safety_context_eligible?: number | null;
 							}>(
-								`SELECT content, status, importance, memory_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
-								 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
-								 ORDER BY importance DESC LIMIT 5`,
+								`SELECT ea.content, ea.status, ea.importance, ea.memory_id${safetySelect}
+								 FROM entity_attributes ea ${safetyJoin}
+								 WHERE ea.aspect_id = ? AND ea.agent_id = ? AND ea.status = 'active'
+								 ORDER BY ea.importance DESC LIMIT 5`,
 								[aspect.id, agentId],
 								"memory-search.entity-context.attributes",
 								5,
 							);
 							const attributes = attrs
-								.filter((attr) => scanMemoryContent(attr.content).contextEligible)
+								.filter(
+									(attr) =>
+										scanMemoryContent(attr.content).contextEligible &&
+										(!attr.memory_id ||
+											attr.safety_status == null ||
+											(attr.safety_status === "clean" && attr.safety_context_eligible === 1)),
+								)
 								.map((attr) => ({ content: attr.content, status: attr.status, importance: attr.importance }));
 							if (attributes.length > 0) contextAspects.push({ name: aspect.name, attributes });
 						}

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -1929,7 +1929,7 @@ export async function hybridRecall(
 								filterSql: filter.sql,
 								filterArgs: filter.args,
 							}),
-						{ siteToken: "memory-search.ts:1861" },
+						{ siteToken: "memory-search.ts:1924" },
 					),
 			);
 			for (const [id, score] of candidates) structuredCandidateMap.set(id, score);
@@ -1950,7 +1950,7 @@ export async function hybridRecall(
 									limit: cfg.search.top_k,
 									minScore,
 								}),
-							{ siteToken: "memory-search.ts:1884" },
+							{ siteToken: "memory-search.ts:1947" },
 						),
 				);
 			} catch (e) {
@@ -2077,7 +2077,7 @@ export async function hybridRecall(
 											source_id: string;
 											vector: Buffer | null;
 										}>,
-									{ siteToken: "memory-search.ts:2012" },
+									{ siteToken: "memory-search.ts:2069" },
 								);
 								const qv = queryVecF32;
 								for (const row of embRows) {
@@ -2157,7 +2157,7 @@ export async function hybridRecall(
 					async () =>
 						await getDbAccessor().withReadDbAsync(
 							async (db) => getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
-							{ siteToken: "memory-search.ts:2100" },
+							{ siteToken: "memory-search.ts:2158" },
 						),
 				);
 				if (graphResult.graphLinkedIds.size > 0) {
@@ -2240,7 +2240,7 @@ export async function hybridRecall(
 											id: string;
 											traversal_score: number;
 										}>,
-									{ siteToken: "memory-search.ts:2169" },
+									{ siteToken: "memory-search.ts:2221" },
 								);
 
 								for (const row of baseRows) {
@@ -2309,7 +2309,7 @@ export async function hybridRecall(
 								 WHERE id IN (${placeholders})`,
 							)
 							.all(...candidateIds) as Array<{ id: string; content: string }>,
-					{ siteToken: "memory-search.ts:2251" },
+					{ siteToken: "memory-search.ts:2304" },
 				);
 				for (const row of contentRows) {
 					const score = scoreTemporalTopicEvidence(query, row.content);
@@ -2355,7 +2355,7 @@ export async function hybridRecall(
 							query,
 							agentId,
 						),
-					{ siteToken: "memory-search.ts:2297" },
+					{ siteToken: "memory-search.ts:2350" },
 				);
 				for (const [id, score] of structured) {
 					structuredEvidenceMap.set(id, score);
@@ -2391,7 +2391,7 @@ export async function hybridRecall(
 									 WHERE id IN (${placeholders})`,
 								)
 								.all(...coverageIds) as Array<{ id: string; content: string }>,
-						{ siteToken: "memory-search.ts:2333" },
+						{ siteToken: "memory-search.ts:2386" },
 					);
 					contentMap = new Map(contentRows.map((row) => [row.id, row.content]));
 				}
@@ -2441,7 +2441,7 @@ export async function hybridRecall(
 						id: string;
 						content: string;
 					}>,
-				{ siteToken: "memory-search.ts:2380" },
+				{ siteToken: "memory-search.ts:2433" },
 			);
 			const contentMap = new Map(contentRows.map((r) => [r.id, r.content]));
 
@@ -2521,7 +2521,7 @@ export async function hybridRecall(
 						content: string;
 						type: string;
 					}>,
-				{ siteToken: "memory-search.ts:2459" },
+				{ siteToken: "memory-search.ts:2512" },
 			);
 			const meta = new Map(dampenRows.map((r) => [r.id, r]));
 
@@ -2541,7 +2541,7 @@ export async function hybridRecall(
 							memory_id: string;
 							entity_id: string;
 						}>,
-					{ siteToken: "memory-search.ts:2480" },
+					{ siteToken: "memory-search.ts:2533" },
 				);
 
 				const entityIds = new Set<string>();
@@ -2572,7 +2572,7 @@ export async function hybridRecall(
 								entity_id: string;
 								cnt: number;
 							}>,
-						{ siteToken: "memory-search.ts:2509" },
+						{ siteToken: "memory-search.ts:2562" },
 					);
 					for (const row of degreeRows) {
 						degrees.set(row.entity_id, row.cnt);
@@ -2819,7 +2819,7 @@ export async function hybridRecall(
 						scope: string | null;
 						agent_id: string | null;
 					}>,
-				{ siteToken: "memory-search.ts:2746" },
+				{ siteToken: "memory-search.ts:2799" },
 			),
 	);
 
@@ -2833,7 +2833,7 @@ export async function hybridRecall(
 					content: row.content,
 				}),
 			),
-		{ siteToken: "memory-search.ts:2773" },
+		{ siteToken: "memory-search.ts:2826" },
 	);
 	const rowMap = new Map(safeRows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is
@@ -3074,7 +3074,7 @@ export async function hybridRecall(
 						}),
 					);
 				},
-				{ siteToken: "memory-search.ts:2971" },
+				{ siteToken: "memory-search.ts:3024" },
 			);
 
 			for (const r of supplementary) {
@@ -3205,7 +3205,7 @@ export async function hybridRecall(
 
 						return { eids, structured };
 					},
-					{ siteToken: "memory-search.ts:3071" },
+					{ siteToken: "memory-search.ts:3126" },
 				);
 
 				if (ctx) {
@@ -3234,7 +3234,7 @@ export async function hybridRecall(
 			const cap = Math.max(3, Math.ceil(limit * 0.3));
 			const blocks = await getDbAccessor().withReadDbAsync(
 				async (db) => constructContextBlocks(db, agentId, focalEids, cap),
-				{ siteToken: "memory-search.ts:3180" },
+				{ siteToken: "memory-search.ts:3235" },
 			);
 			const now = new Date().toISOString();
 			const minReal = results.length > 0 ? Math.min(...results.map((r) => r.score)) : 0.5;

--- a/platform/daemon/src/pipeline/context-construction.ts
+++ b/platform/daemon/src/pipeline/context-construction.ts
@@ -10,6 +10,8 @@
  */
 
 import { scanMemoryContent } from "@signet/core";
+import type { DbOwnerClient } from "../db-owner-client";
+import { ownerReadAll } from "../db-owner-sql";
 import type { ReadDb } from "../db-accessor";
 import { isMemoryContentContextEligible } from "../memory-content-safety";
 
@@ -251,6 +253,151 @@ export function constructContextBlocks(
 	}
 
 	// Sort by density score descending, then truncate to limit
+	blocks.sort((a, b) => b.score - a.score);
+	return blocks.slice(0, limit);
+}
+
+/** Owner-bound constructed context for recall paths that cannot read parent SQLite. */
+export async function constructContextBlocksViaOwner(
+	owner: DbOwnerClient,
+	agentId: string,
+	focalEntityIds: ReadonlyArray<string>,
+	limit: number,
+): Promise<ReadonlyArray<ConstructedContext>> {
+	if (focalEntityIds.length === 0) return [];
+	const query = <Row extends object>(sql: string, params: readonly unknown[], operation: string) =>
+		ownerReadAll<Row>(owner, sql, params, {
+			operation,
+			lane: "read",
+			workloadClass: "foreground",
+			deadlineMs: 30_000,
+			estimatedWorkUnits: 200,
+		});
+	const ph = focalEntityIds.map(() => "?").join(", ");
+	const entities = await query<EntityRow>(
+		`SELECT id, name, entity_type FROM entities WHERE id IN (${ph})`,
+		focalEntityIds,
+		"memory-search.constructed.entities",
+	);
+	if (entities.length === 0) return [];
+
+	let safetyTableExists: boolean | null = null;
+	const eligible = async (content: string, memoryId: string | null): Promise<boolean> => {
+		if (!scanMemoryContent(content).contextEligible) return false;
+		if (!memoryId) return true;
+		if (safetyTableExists === null) {
+			try {
+				const rows = await query<{ name: string }>(
+					"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_content_safety'",
+					[],
+					"memory-search.constructed.safety-table",
+				);
+				safetyTableExists = rows.length > 0;
+			} catch {
+				safetyTableExists = false;
+			}
+		}
+		if (!safetyTableExists) return true;
+		try {
+			const rows = await query<{ status: string; context_eligible: number }>(
+				`SELECT status, context_eligible FROM memory_content_safety
+			 WHERE agent_id = ? AND source_kind = 'memory' AND source_id = ?`,
+				[agentId, memoryId],
+				"memory-search.constructed.safety-row",
+			);
+			const row = rows[0];
+			return !row || (row.status === "clean" && row.context_eligible === 1);
+		} catch {
+			return false;
+		}
+	};
+
+	const blocks: ConstructedContext[] = [];
+	for (const ent of entities) {
+		const aspects = await query<AspectRow>(
+			`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
+			 WHERE entity_id = ? AND agent_id = ?
+			 ORDER BY weight DESC LIMIT 10`,
+			[ent.id, agentId],
+			"memory-search.constructed.aspects",
+		);
+		const lines: string[] = [];
+		const aspectIds: string[] = [];
+		const aspectNames: string[] = [];
+		let totalAttrs = 0;
+
+		for (const asp of aspects) {
+			const attrs = await query<AttributeRow>(
+				`SELECT content, importance, memory_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
+				 WHERE aspect_id = ? AND agent_id = ?
+				   AND status = 'active' AND kind != 'constraint'
+				 ORDER BY importance DESC LIMIT 5`,
+				[asp.id, agentId],
+				"memory-search.constructed.attributes",
+			);
+			const values: string[] = [];
+			for (const attr of attrs) {
+				if (!(await eligible(attr.content, attr.memory_id))) continue;
+				const value = cleanValue(attr.content);
+				if (!isNoise(value)) values.push(value);
+			}
+			if (values.length === 0) continue;
+			aspectIds.push(asp.id);
+			aspectNames.push(asp.name);
+			totalAttrs += values.length;
+			lines.push(`- ${asp.name}: ${values.join("; ")}`);
+		}
+
+		const constraints = await query<ConstraintRow>(
+			`SELECT DISTINCT ea.content, ea.importance, ea.memory_id
+			 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
+			 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
+			   ON ea.aspect_id = asp.id
+			 WHERE asp.entity_id = ? AND ea.agent_id = ?
+			   AND ea.kind = 'constraint' AND ea.status = 'active'
+			 ORDER BY ea.importance DESC LIMIT 10`,
+			[ent.id, agentId],
+			"memory-search.constructed.constraints",
+		);
+		const cleanConstraints: string[] = [];
+		for (const constraint of constraints) {
+			if (!(await eligible(constraint.content, constraint.memory_id))) continue;
+			const value = cleanValue(constraint.content);
+			if (!isNoise(value)) cleanConstraints.push(value);
+		}
+		if (cleanConstraints.length > 0) lines.push(`- Constraints: ${cleanConstraints.join("; ")}`);
+
+		const deps = await query<DependencyRow>(
+			`SELECT ed.target_entity_id, e.name
+			 FROM entity_dependencies ed INDEXED BY idx_entity_dependencies_source
+			 JOIN entities e ON e.id = ed.target_entity_id
+			 WHERE ed.source_entity_id = ? AND ed.agent_id = ?
+			   AND ed.strength >= 0.3
+			 ORDER BY ed.strength DESC LIMIT 8`,
+			[ent.id, agentId],
+			"memory-search.constructed.dependencies",
+		);
+		if (deps.length > 0) lines.push(`- Related: ${deps.map((dep) => dep.name).join(", ")}`);
+		if (lines.length === 0) continue;
+
+		const built = trimBlock(`[${ent.name} (${ent.entity_type})]\n${lines.join("\n")}`);
+		blocks.push({
+			content: built.text,
+			truncated: built.truncated,
+			score: densityScore(aspectIds.length, totalAttrs, cleanConstraints.length),
+			source: "constructed",
+			provenance: {
+				entityId: ent.id,
+				entityName: ent.name,
+				entityType: ent.entity_type,
+				aspectIds,
+				aspectNames,
+				attributeCount: totalAttrs,
+				constraintCount: constraints.length,
+				dependencyEntityIds: deps.map((dep) => dep.target_entity_id),
+			},
+		});
+	}
 	blocks.sort((a, b) => b.score - a.score);
 	return blocks.slice(0, limit);
 }

--- a/platform/daemon/src/pipeline/graph-search.ts
+++ b/platform/daemon/src/pipeline/graph-search.ts
@@ -8,6 +8,8 @@
  */
 
 import type { ReadDb } from "../db-accessor";
+import type { DbOwnerClient } from "../db-owner-client";
+import { ownerReadAll } from "../db-owner-sql";
 import { FTS_STOP } from "./stop-words";
 
 // ---------------------------------------------------------------------------
@@ -135,6 +137,103 @@ export function getGraphBoostIds(query: string, db: ReadDb, timeoutMs: number, a
 			graphLinkedIds: new Set(memoryRows.map((r) => r.memory_id)),
 			entityHits: entityRows.length,
 			timedOut: false,
+		};
+	} catch {
+		return empty;
+	}
+}
+
+/** Owner-bound equivalent used by recall paths that must not touch parent SQLite. */
+export async function getGraphBoostIdsViaOwner(
+	query: string,
+	owner: DbOwnerClient,
+	timeoutMs: number,
+	agentId?: string,
+): Promise<GraphBoostResult> {
+	const empty: GraphBoostResult = {
+		graphLinkedIds: new Set(),
+		entityHits: 0,
+		timedOut: false,
+	};
+
+	try {
+		const deadline = Date.now() + timeoutMs;
+		const tokens = tokenizeGraphQuery(query);
+		if (tokens.length === 0) return empty;
+		const agentFilter = agentId ?? "default";
+		const remaining = () => Math.max(1, deadline - Date.now());
+		const options = (operation: string) => ({
+			operation,
+			lane: "read" as const,
+			workloadClass: "foreground" as const,
+			deadlineMs: remaining(),
+			estimatedWorkUnits: 200,
+		});
+
+		let entityRows: ReadonlyArray<{ id: string }> = [];
+		try {
+			entityRows = await ownerReadAll<{ id: string }>(
+				owner,
+				`SELECT e.id FROM entities_fts
+				 JOIN entities e ON e.rowid = entities_fts.rowid
+				 WHERE entities_fts MATCH ?
+				   AND e.agent_id = ?
+				 ORDER BY rank
+				 LIMIT 20`,
+				[tokens.join(" OR "), agentFilter],
+				options("memory-search.graph-boost.entities-fts"),
+			);
+		} catch {
+			const likePatterns = tokens.map((token) => `%${token}%`);
+			const likeClauses = likePatterns.map(() => "canonical_name LIKE ?").join(" OR ");
+			entityRows = await ownerReadAll<{ id: string }>(
+				owner,
+				`SELECT id FROM entities
+				 WHERE agent_id = ?
+				   AND (${likeClauses})
+				 ORDER BY mentions DESC
+				 LIMIT 20`,
+				[agentFilter, ...likePatterns],
+				options("memory-search.graph-boost.entities-like"),
+			);
+		}
+
+		if (entityRows.length === 0) return empty;
+		if (Date.now() > deadline) return { ...empty, entityHits: entityRows.length, timedOut: true };
+
+		const entityIds = new Set(entityRows.map((row) => row.id));
+		const placeholders = entityRows.map(() => "?").join(", ");
+		const ids = entityRows.map((row) => row.id);
+		const neighbors = await ownerReadAll<{ neighbor: string }>(
+			owner,
+			`SELECT target_entity_id AS neighbor FROM relations
+			 WHERE source_entity_id IN (${placeholders})
+			 UNION
+			 SELECT source_entity_id AS neighbor FROM relations
+			 WHERE target_entity_id IN (${placeholders})
+			 LIMIT 50`,
+			[...ids, ...ids],
+			options("memory-search.graph-boost.neighbors"),
+		);
+		for (const neighbor of neighbors) entityIds.add(neighbor.neighbor);
+		if (Date.now() > deadline) return { ...empty, entityHits: entityRows.length, timedOut: true };
+
+		const expandedIds = [...entityIds];
+		const memoryRows = await ownerReadAll<{ memory_id: string }>(
+			owner,
+			`SELECT DISTINCT mem.memory_id
+			 FROM memory_entity_mentions mem
+			 JOIN memories m ON m.id = mem.memory_id
+			 WHERE mem.entity_id IN (${expandedIds.map(() => "?").join(", ")})
+			   AND m.is_deleted = 0
+			 LIMIT 200`,
+			expandedIds,
+			options("memory-search.graph-boost.memories"),
+		);
+		return {
+			graphLinkedIds: new Set(memoryRows.map((row) => row.memory_id)),
+			entityHits: entityRows.length,
+			timedOut: Date.now() > deadline,
 		};
 	} catch {
 		return empty;

--- a/platform/daemon/src/pipeline/graph-traversal.test.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.test.ts
@@ -191,6 +191,7 @@ describe("traverseKnowledgeGraph event-loop yields (#1118)", () => {
 
 		expect(result.memoryIds.size).toBe(0);
 		expect(result.constraints).toEqual([]);
+		expect(result.error).toEqual({ code: null, message: "injected traversal failure" });
 		expect(activeReads).toBe(0);
 	});
 

--- a/platform/daemon/src/pipeline/graph-traversal.test.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.test.ts
@@ -66,11 +66,12 @@ function seedGraph(db: Database): void {
 	db.exec(`INSERT INTO memory_entity_mentions VALUES ('m1', 'e1', 0.9)`);
 }
 
-function createTestOwner(db: Database, operations: string[]): DbOwnerClient {
+function createTestOwner(db: Database, operations: string[], deadlines: number[] = []): DbOwnerClient {
 	return {
-		submit<Result>(request: DbOwnerRequest, options: { readonly operation: string }) {
+		submit<Result>(request: DbOwnerRequest, options: { readonly operation: string; readonly deadlineMs: number }) {
 			if (request.kind !== "query") throw new Error("test owner only supports query requests");
 			operations.push(options.operation);
+			deadlines.push(options.deadlineMs);
 			const params = request.statement.params ?? [];
 			if (params.some((param) => typeof param === "object")) throw new Error("unexpected test owner byte parameter");
 			const statement = db.prepare(request.statement.sql);
@@ -213,6 +214,19 @@ describe("traverseKnowledgeGraph event-loop yields (#1118)", () => {
 		expect(result.memoryIds.has("m1")).toBe(true);
 		expect(result.memoryIds.has("m3")).toBe(true);
 		expect(operations.every((operation) => operation.startsWith("session-start.graph-"))).toBe(true);
+	});
+
+	test("passes the traversal deadline budget to every owner query", async () => {
+		const deadlines: number[] = [];
+		const owner = createTestOwner(db, [], deadlines);
+		const result = await traverseKnowledgeGraphViaOwner(["e1"], owner, "default", {
+			...CONFIG,
+			timeoutMs: 50,
+		});
+
+		expect(result.memoryIds.has("m1")).toBe(true);
+		expect(deadlines.length).toBeGreaterThan(0);
+		expect(deadlines.every((deadline) => deadline > 0 && deadline <= 50)).toBe(true);
 	});
 
 	test("falls back to LIKE when the owner FTS index has no matching row", async () => {

--- a/platform/daemon/src/pipeline/graph-traversal.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.ts
@@ -82,6 +82,7 @@ type ReadAll = <Row extends object>(
 	params: readonly unknown[],
 	operation: string,
 	estimatedWorkUnits: number,
+	deadlineAt?: number,
 ) => Promise<ReadonlyArray<Row>>;
 
 async function withReadDbAsync<T>(source: ReadDbSource, fn: (db: ReadDb) => T): Promise<T> {
@@ -95,6 +96,7 @@ function readAllFromSource(source: ReadDbSource): ReadAll {
 		params: readonly unknown[],
 		_operation: string,
 		_estimatedWorkUnits: number,
+		_deadlineAt?: number,
 	): Promise<ReadonlyArray<Row>> =>
 		await withReadDbAsync(source, (db) => db.prepare(sql).all(...params) as ReadonlyArray<Row>);
 }
@@ -105,14 +107,17 @@ function readAllFromOwner(owner: DbOwnerClient): ReadAll {
 		params: readonly unknown[],
 		operation: string,
 		estimatedWorkUnits: number,
-	): Promise<ReadonlyArray<Row>> =>
-		await ownerReadAll<Row>(owner, sql, params, {
+		deadlineAt?: number,
+	): Promise<ReadonlyArray<Row>> => {
+		const deadlineMs = deadlineAt === undefined ? 5_000 : Math.max(1, deadlineAt - Date.now());
+		return await ownerReadAll<Row>(owner, sql, params, {
 			operation,
 			lane: "read",
 			workloadClass: "foreground",
-			deadlineMs: 5_000,
+			deadlineMs,
 			estimatedWorkUnits: Math.max(1, Math.min(1_200, estimatedWorkUnits)),
 		});
+	};
 }
 
 export interface FocalEntityResult {
@@ -580,6 +585,7 @@ async function batchCollectForEntities(
 	agentId: string,
 	config: TraversalConfig,
 	budget: number,
+	deadlineAt?: number,
 ): Promise<{
 	readonly memoryIds: Set<string>;
 	readonly memoryScores: Map<string, number>;
@@ -625,6 +631,7 @@ async function batchCollectForEntities(
 		[...entityIds, agentId, agentId],
 		"session-start.graph-traversal.constraints",
 		Math.max(1, entityIds.length * config.maxAttributesPerAspect),
+		deadlineAt,
 	);
 
 	for (const row of constraintRows) {
@@ -662,6 +669,7 @@ async function batchCollectForEntities(
 		aspectArgs,
 		"session-start.graph-traversal.aspects",
 		Math.max(1, entityIds.length * config.maxAspectsPerEntity),
+		deadlineAt,
 	);
 
 	// Apply maxAspectsPerEntity budget by grouping and slicing
@@ -719,6 +727,7 @@ async function batchCollectForEntities(
 					[...budgetedAspectIds, agentId, ...scopeArgs],
 					"session-start.graph-traversal.attributes",
 					Math.max(1, budgetedAspectIds.length * config.maxAttributesPerAspect),
+					deadlineAt,
 				)),
 			];
 		} else {
@@ -736,6 +745,7 @@ async function batchCollectForEntities(
 					[...budgetedAspectIds, agentId],
 					"session-start.graph-traversal.attributes",
 					Math.max(1, budgetedAspectIds.length * config.maxAttributesPerAspect),
+					deadlineAt,
 				)),
 			];
 		}
@@ -789,6 +799,7 @@ async function batchCollectForEntities(
 					[...entityIds, ...scopeArgs, mentionBudget],
 					"session-start.graph-traversal.mentions",
 					mentionBudget,
+					deadlineAt,
 				)),
 			];
 		} else {
@@ -808,6 +819,7 @@ async function batchCollectForEntities(
 					[...entityIds, mentionBudget],
 					"session-start.graph-traversal.mentions",
 					mentionBudget,
+					deadlineAt,
 				)),
 			];
 		}
@@ -853,6 +865,7 @@ async function traverseKnowledgeGraphWithReadAll(
 		focalEntityIds: [],
 	});
 
+	const deadline = Date.now() + config.timeoutMs;
 	try {
 		const tableRows = await readAll<{ readonly name: string }>(
 			`SELECT name FROM sqlite_master
@@ -861,6 +874,7 @@ async function traverseKnowledgeGraphWithReadAll(
 			[],
 			"session-start.graph-traversal.table-check",
 			4,
+			deadline,
 		);
 		const tableNames = new Set(tableRows.map((row) => row.name));
 		if (
@@ -874,11 +888,10 @@ async function traverseKnowledgeGraphWithReadAll(
 
 		const stageYield = yieldEvery(1);
 		const rowYield = yieldEvery(ROW_YIELD_BATCH);
-		const deadline = Date.now() + config.timeoutMs;
 		const budget = config.maxTraversalPaths;
 
 		// --- Phase 1: Batch-collect for focal entities ---
-		const phase1 = await batchCollectForEntities(readAll, focalIds, agentId, config, budget);
+		const phase1 = await batchCollectForEntities(readAll, focalIds, agentId, config, budget, deadline);
 		let timedOut = Date.now() > deadline;
 
 		await stageYield();
@@ -904,6 +917,7 @@ async function traverseKnowledgeGraphWithReadAll(
 				],
 				"session-start.graph-traversal.dependencies",
 				Math.max(1, config.maxBranching * focalIds.length),
+				deadline,
 			);
 
 			// Filter to hop targets not already visited
@@ -913,7 +927,7 @@ async function traverseKnowledgeGraphWithReadAll(
 
 			if (hopTargetIds.length > 0) {
 				const remainingBudget = budget - phase1.memoryIds.size;
-				const phase2 = await batchCollectForEntities(readAll, hopTargetIds, agentId, config, remainingBudget);
+				const phase2 = await batchCollectForEntities(readAll, hopTargetIds, agentId, config, remainingBudget, deadline);
 
 				// Merge phase2 results into phase1
 				for (const mid of phase2.memoryIds) {

--- a/platform/daemon/src/pipeline/graph-traversal.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.ts
@@ -38,6 +38,13 @@ export interface TraversalResult {
 	readonly activeAspectIds: ReadonlyArray<string>;
 	/** Entity IDs that seeded the walk (needed by context-construction, DP-7) */
 	readonly focalEntityIds: ReadonlyArray<string>;
+	/** Operational failure, when the walk could not complete normally. */
+	readonly error?: TraversalError;
+}
+
+export interface TraversalError {
+	readonly code: string | number | null;
+	readonly message: string;
 }
 
 export interface TraversalConfig {
@@ -113,6 +120,8 @@ export interface FocalEntityResult {
 	readonly entityNames: string[];
 	readonly pinnedEntityIds: string[];
 	readonly source: "project" | "checkpoint" | "query" | "session_key";
+	/** Operational failure, when focal resolution could not complete normally. */
+	readonly error?: TraversalError;
 }
 
 export interface TraversalStatusSnapshot {
@@ -128,6 +137,20 @@ export interface TraversalStatusSnapshot {
 }
 
 let lastTraversalStatus: TraversalStatusSnapshot | null = null;
+
+function describeTraversalError(error: unknown): TraversalError {
+	const code =
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(typeof error.code === "string" || typeof error.code === "number")
+			? error.code
+			: null;
+	return {
+		code,
+		message: error instanceof Error ? error.message : String(error),
+	};
+}
 let traversalTablesAvailableCache: boolean | null = null;
 
 export function setTraversalStatus(snapshot: TraversalStatusSnapshot): void {
@@ -363,12 +386,13 @@ export function resolveFocalEntities(
 			pinnedEntityIds,
 			source,
 		};
-	} catch {
+	} catch (error) {
 		return {
 			entityIds: [],
 			entityNames: [],
 			pinnedEntityIds: [],
 			source: "query",
+			error: describeTraversalError(error),
 		};
 	}
 }
@@ -501,8 +525,14 @@ export async function resolveFocalEntitiesViaOwner(
 			return typeof name === "string" && name.length > 0 ? [name] : [];
 		});
 		return { entityIds, entityNames, pinnedEntityIds, source };
-	} catch {
-		return { entityIds: [], entityNames: [], pinnedEntityIds: [], source: "query" };
+	} catch (error) {
+		return {
+			entityIds: [],
+			entityNames: [],
+			pinnedEntityIds: [],
+			source: "query",
+			error: describeTraversalError(error),
+		};
 	}
 }
 
@@ -812,7 +842,7 @@ async function traverseKnowledgeGraphWithReadAll(
 	agentId: string,
 	config: TraversalConfig,
 ): Promise<TraversalResult> {
-	const empty: TraversalResult = {
+	const empty = (): TraversalResult => ({
 		memoryIds: new Set<string>(),
 		memoryScores: new Map<string, number>(),
 		memoryPaths: new Map<string, TraversalPath>(),
@@ -821,7 +851,7 @@ async function traverseKnowledgeGraphWithReadAll(
 		timedOut: false,
 		activeAspectIds: [],
 		focalEntityIds: [],
-	};
+	});
 
 	try {
 		const tableRows = await readAll<{ readonly name: string }>(
@@ -837,10 +867,10 @@ async function traverseKnowledgeGraphWithReadAll(
 			tableRows.length < 4 ||
 			!["entities", "entity_aspects", "entity_attributes", "entity_dependencies"].every((name) => tableNames.has(name))
 		)
-			return empty;
+			return empty();
 
 		const focalIds = sanitizeEntityIds(focalEntityIds);
-		if (focalIds.length === 0) return empty;
+		if (focalIds.length === 0) return empty();
 
 		const stageYield = yieldEvery(1);
 		const rowYield = yieldEvery(ROW_YIELD_BATCH);
@@ -968,8 +998,8 @@ async function traverseKnowledgeGraphWithReadAll(
 			activeAspectIds: [...phase1.activeAspectIds],
 			focalEntityIds: focalIds,
 		};
-	} catch {
-		return empty;
+	} catch (error) {
+		return { ...empty(), error: describeTraversalError(error) };
 	}
 }
 

--- a/platform/daemon/src/pipeline/structured-path-evidence.test.ts
+++ b/platform/daemon/src/pipeline/structured-path-evidence.test.ts
@@ -2,10 +2,29 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runMigrations } from "../../../core/src/migrations";
 import type { ReadDb } from "../db-accessor";
-import { findStructuredClaimCandidates, scoreStructuredPathEvidence } from "./structured-path-evidence";
+import type { DbOwnerClient } from "../db-owner-client";
+import type { DbOwnerRequest } from "../db-owner-client";
+import {
+	findStructuredClaimCandidates,
+	scoreStructuredPathEvidence,
+	scoreStructuredPathEvidenceViaOwner,
+} from "./structured-path-evidence";
 
 function asReadDb(db: Database): ReadDb {
 	return db as unknown as ReadDb;
+}
+
+function asOwner(db: Database, operations: string[]): DbOwnerClient {
+	return {
+		submit<Result>(request: DbOwnerRequest, options: { readonly operation: string; readonly deadlineMs: number }) {
+			if (request.kind !== "query") throw new Error("test owner only supports query requests");
+			operations.push(options.operation);
+			const params = request.statement.params ?? [];
+			const statement = db.prepare(request.statement.sql);
+			const value = request.statement.result === "all" ? statement.all(...params) : statement.get(...params);
+			return { result: Promise.resolve(value as Result) } as never;
+		},
+	} as unknown as DbOwnerClient;
 }
 
 describe("structured path evidence", () => {
@@ -177,6 +196,29 @@ describe("structured path evidence", () => {
 		expect(candidates.map((row) => row.id)).toEqual(["attr-artbat-invoice"]);
 		expect(candidates[0]?.content).toContain("€1,000");
 		expect(candidates[0]?.content).toContain("€2,000");
+	});
+
+	it("runs owner-bound evidence scoring through the DB owner", async () => {
+		seedMemory("mem-owner", "The user prefers owner-bound graph evidence.");
+		seedAttribute({
+			id: "attr-owner",
+			memoryId: "mem-owner",
+			aspect: "preferences",
+			group: "owner_boundary",
+			claim: "owner_reads_only",
+			content: "Prefers owner-bound graph evidence.",
+		});
+
+		const operations: string[] = [];
+		const scores = await scoreStructuredPathEvidenceViaOwner(
+			asOwner(db, operations),
+			["mem-owner"],
+			"owner-bound graph evidence",
+			"memorybench",
+		);
+
+		expect(scores.get("mem-owner") ?? 0).toBeGreaterThan(0);
+		expect(operations).toEqual(["memory-search.structured-path-evidence"]);
 	});
 
 	it("returns an empty map when there are no candidate IDs", () => {

--- a/platform/daemon/src/pipeline/structured-path-evidence.ts
+++ b/platform/daemon/src/pipeline/structured-path-evidence.ts
@@ -1,4 +1,6 @@
 import type { ReadDb } from "../db-accessor";
+import type { DbOwnerClient } from "../db-owner-client";
+import { ownerReadAll } from "../db-owner-sql";
 import { FTS_STOP } from "./stop-words";
 
 const PUNCT = /[^a-z0-9\s]/g;
@@ -475,6 +477,258 @@ export function findStructuredClaimCandidates(
 			Math.max(options.limit * 32, 500),
 		) as StructuredClaimRow[];
 
+	const scores = scorePathRows(
+		rows.map((row) => ({ ...row, key: row.id })),
+		parsed.queryTokens,
+	);
+	const minScore = Math.max(options.minScore ?? 0, 0.65);
+	return rows
+		.flatMap((row): StructuredClaimCandidate[] => {
+			if (!claimHasSourcePointer(row)) return [];
+			const score = scoreStructuredClaimCandidate(row, parsed.queryTokens, scores.get(row.id) ?? 0);
+			if (score < minScore) return [];
+			return [
+				{
+					id: row.id,
+					score,
+					entityName: row.entity_name,
+					entityType: row.entity_type,
+					aspect: row.aspect,
+					groupKey: row.group_key,
+					claimKey: row.claim_key,
+					content: row.content,
+					kind: row.kind,
+					importance: row.importance,
+					confidence: row.confidence,
+					createdAt: row.created_at,
+					updatedAt: row.updated_at,
+					version: row.version,
+					sourceKind: row.source_kind,
+					sourceId: row.source_id,
+					sourcePath: row.source_path,
+					proposalEvidence: row.proposal_evidence,
+				},
+			];
+		})
+		.sort((a, b) => b.score - a.score)
+		.slice(0, options.limit);
+}
+
+/** Owner-bound path candidates for graph-enabled recall. */
+export async function findStructuredPathCandidatesViaOwner(
+	owner: DbOwnerClient,
+	query: string,
+	agentId: string,
+	options: {
+		readonly limit: number;
+		readonly minScore?: number;
+		readonly filterSql?: string;
+		readonly filterArgs?: readonly unknown[];
+	} = { limit: 20 },
+): Promise<Map<string, number>> {
+	const parsed = queryTokensForPathSearch(query, options.limit);
+	if (!parsed) return new Map();
+	const haystack = pathSearchHaystack();
+	const like = parsed.tokens.map(() => `${haystack} LIKE ? ESCAPE '\\'`).join(" OR ");
+	const rows = await ownerReadAll<StructuredPathRow>(
+		owner,
+		`SELECT
+			 ea.memory_id,
+			 e.name AS entity_name,
+			 asp.canonical_name AS aspect,
+			 ea.group_key,
+			 ea.claim_key,
+			 ea.content,
+			 ea.kind,
+			 ea.importance,
+			 ea.confidence
+		 FROM entity_attributes ea
+		 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+		 JOIN entities e ON e.id = asp.entity_id
+		 JOIN memories m ON m.id = ea.memory_id
+		 WHERE ea.agent_id = ?
+		   AND asp.agent_id = ?
+		   AND e.agent_id = ?
+		   AND ea.status = 'active'
+		   AND ea.memory_id IS NOT NULL
+		   AND m.is_deleted = 0
+		   ${options.filterSql ?? ""}
+		   AND (${like})
+		 LIMIT ?`,
+		[
+			agentId,
+			agentId,
+			agentId,
+			...(options.filterArgs ?? []),
+			...parsed.tokens.map((token) => `%${escapeLikeToken(token)}%`),
+			Math.max(options.limit * 8, options.limit),
+		],
+		{
+			operation: "memory-search.structured-path-candidates",
+			lane: "read",
+			workloadClass: "foreground",
+			deadlineMs: 30_000,
+			estimatedWorkUnits: Math.max(options.limit * 8, options.limit),
+		},
+	);
+	const ids = [...new Set(rows.map((row) => row.memory_id))];
+	const evidenceRows =
+		ids.length === 0
+			? []
+			: await ownerReadAll<StructuredPathRow>(
+					owner,
+					`SELECT
+						 ea.memory_id,
+						 e.name AS entity_name,
+						 asp.canonical_name AS aspect,
+						 ea.group_key,
+						 ea.claim_key,
+						 ea.content,
+						 ea.kind,
+						 ea.importance,
+						 ea.confidence
+					 FROM entity_attributes ea
+					 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+					 JOIN entities e ON e.id = asp.entity_id
+					 WHERE ea.memory_id IN (${ids.map(() => "?").join(", ")})
+					   AND ea.agent_id = ?
+					   AND asp.agent_id = ?
+					   AND e.agent_id = ?
+					   AND ea.status = 'active'`,
+					[...ids, agentId, agentId, agentId],
+					{
+						operation: "memory-search.structured-path-evidence",
+						lane: "read",
+						workloadClass: "foreground",
+						deadlineMs: 30_000,
+						estimatedWorkUnits: ids.length,
+					},
+				);
+	const scores = scorePathRows(
+		evidenceRows.map((row) => ({ ...row, key: row.memory_id })),
+		parsed.queryTokens,
+	);
+	const minScore = options.minScore ?? 0;
+	return new Map(
+		[...scores.entries()]
+			.filter(([, score]) => score >= minScore)
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, options.limit),
+	);
+}
+
+/** Owner-bound evidence scoring for graph-enabled recall. */
+export async function scoreStructuredPathEvidenceViaOwner(
+	owner: DbOwnerClient,
+	memoryIds: readonly string[],
+	query: string,
+	agentId: string,
+): Promise<Map<string, number>> {
+	const queryTokens = [...new Set(tokenize(query))];
+	const uniqueIds = [...new Set(memoryIds.filter((id) => typeof id === "string" && id.length > 0))];
+	if (uniqueIds.length === 0 || queryTokens.length === 0) return new Map();
+	const placeholders = uniqueIds.map(() => "?").join(", ");
+	const rows = await ownerReadAll<StructuredPathRow>(
+		owner,
+		`SELECT
+			 ea.memory_id,
+			 e.name AS entity_name,
+			 asp.canonical_name AS aspect,
+			 ea.group_key,
+			 ea.claim_key,
+			 ea.content,
+			 ea.kind,
+			 ea.importance,
+			 ea.confidence
+		 FROM entity_attributes ea
+		 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+		 JOIN entities e ON e.id = asp.entity_id
+		 WHERE ea.memory_id IN (${placeholders})
+		   AND ea.agent_id = ?
+		   AND asp.agent_id = ?
+		   AND e.agent_id = ?
+		   AND ea.status = 'active'`,
+		[...uniqueIds, agentId, agentId, agentId],
+		{
+			operation: "memory-search.structured-path-evidence",
+			lane: "read",
+			workloadClass: "foreground",
+			deadlineMs: 30_000,
+			estimatedWorkUnits: uniqueIds.length,
+		},
+	);
+	return scorePathRows(
+		rows.map((row) => ({ ...row, key: row.memory_id })),
+		queryTokens,
+	);
+}
+
+/** Owner-bound claim candidates for graph-enabled recall. */
+export async function findStructuredClaimCandidatesViaOwner(
+	owner: DbOwnerClient,
+	query: string,
+	agentId: string,
+	options: { readonly limit: number; readonly minScore?: number } = { limit: 20 },
+): Promise<StructuredClaimCandidate[]> {
+	const parsed = queryTokensForPathSearch(query, options.limit);
+	if (!parsed) return [];
+	const haystack = pathSearchHaystack();
+	const like = parsed.tokens.map(() => `${haystack} LIKE ? ESCAPE '\\'`).join(" OR ");
+	const roughScore = parsed.tokens.map(() => `CASE WHEN ${haystack} LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END`).join(" + ");
+	const rows = await ownerReadAll<StructuredClaimRow>(
+		owner,
+		`SELECT
+			 ea.id,
+			 e.name AS entity_name,
+			 e.entity_type,
+			 asp.canonical_name AS aspect,
+			 ea.group_key,
+			 ea.claim_key,
+			 ea.content,
+			 ea.kind,
+			 ea.importance,
+			 ea.confidence,
+			 ea.created_at,
+			 ea.updated_at,
+			 ea.version,
+			 ea.source_kind,
+			 ea.source_id,
+			 ea.source_path,
+			 ea.proposal_evidence
+		 FROM entity_attributes ea
+		 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+		 JOIN entities e ON e.id = asp.entity_id
+		 WHERE ea.agent_id = ?
+		   AND asp.agent_id = ?
+		   AND e.agent_id = ?
+		   AND ea.status = 'active'
+		   AND asp.status = 'active'
+		   AND e.status = 'active'
+		   AND ea.memory_id IS NULL
+		   AND (
+		     ea.source_id IS NOT NULL OR
+		     ea.source_path IS NOT NULL OR
+		     (ea.proposal_evidence IS NOT NULL AND ea.proposal_evidence != '[]')
+		   )
+		   AND (${like})
+		 ORDER BY (${roughScore}) DESC, ea.importance DESC, ea.updated_at DESC
+		 LIMIT ?`,
+		[
+			agentId,
+			agentId,
+			agentId,
+			...parsed.tokens.map((token) => `%${escapeLikeToken(token)}%`),
+			...parsed.tokens.map((token) => `%${escapeLikeToken(token)}%`),
+			Math.max(options.limit * 32, 500),
+		],
+		{
+			operation: "memory-search.structured-claim-candidates",
+			lane: "read",
+			workloadClass: "foreground",
+			deadlineMs: 30_000,
+			estimatedWorkUnits: Math.max(options.limit * 32, 500),
+		},
+	);
 	const scores = scorePathRows(
 		rows.map((row) => ({ ...row, key: row.id })),
 		parsed.queryTokens,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -3506,7 +3506,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			});
 			if (returnedResult.meta.partial === true) {
 				c.header("x-signet-operation-degraded", "1");
-				c.header("x-signet-operation-cause", "fts_index_incomplete");
+				c.header("x-signet-operation-cause", returnedResult.meta.degradation ?? "fts_index_incomplete");
 			}
 			recordFirstUseTelemetry("recall");
 			return c.json(returnedResult);
@@ -3605,7 +3605,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			});
 			if (result.meta.partial === true) {
 				c.header("x-signet-operation-degraded", "1");
-				c.header("x-signet-operation-cause", "fts_index_incomplete");
+				c.header("x-signet-operation-cause", result.meta.degradation ?? "fts_index_incomplete");
 			}
 			return c.json(result);
 		} catch (e) {

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(853);
+	expect(baseline).toHaveLength(864);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
-	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
-	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(144);
+	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(40);
+	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(0);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(143);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,16 +353,16 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 853 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 164 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 171");
+	expect(report).toContain("Exact ledger inventory: 864 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 184 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 182");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 182 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 337");
-	expect(report).toContain("ON-PARENT callback execution: 335");
+	expect(report).toContain("Database accessor sites classified: 348");
+	expect(report).toContain("ON-PARENT callback execution: 346");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(865);
+	expect(baseline).toHaveLength(853);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
-	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(40);
-	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(0);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(145);
+	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(50);
+	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(144);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,16 +353,16 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 865 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 186 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 184");
+	expect(report).toContain("Exact ledger inventory: 853 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 164 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 171");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 184 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 350");
-	expect(report).toContain("ON-PARENT callback execution: 348");
+	expect(report).toContain("Database accessor sites classified: 337");
+	expect(report).toContain("ON-PARENT callback execution: 335");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(864);
+	expect(baseline).toHaveLength(853);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(40);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(0);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(143);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(132);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -353,16 +353,16 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 864 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 184 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 182");
+	expect(report).toContain("Exact ledger inventory: 853 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 171");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 182 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 348");
-	expect(report).toContain("ON-PARENT callback execution: 346");
+	expect(report).toContain("Database accessor sites classified: 337");
+	expect(report).toContain("ON-PARENT callback execution: 335");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,7 +16,7 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(853);
+	expect(baseline).toHaveLength(852);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(40);
@@ -353,7 +353,7 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 853 sites");
+	expect(report).toContain("Exact ledger inventory: 852 sites");
 	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites");
 	expect(report).toContain("Async-named ON-PARENT DB sites: 171");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -2127,105 +2127,105 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2069,
+      "line": 2071,
       "api": "withReadDbAsync",
-      "source": "const embRows = await getDbAccessor().withReadDbAsync(",
+      "source": "embRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2158,
+      "line": 2165,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2221,
+      "line": 2230,
       "api": "withReadDbAsync",
-      "source": "const baseRows = await getDbAccessor().withReadDbAsync(",
+      "source": "baseRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2304,
+      "line": 2318,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2350,
+      "line": 2364,
       "api": "withReadDbAsync",
       "source": "const structured = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2386,
+      "line": 2400,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2433,
+      "line": 2447,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2512,
+      "line": 2526,
       "api": "withReadDbAsync",
       "source": "const dampenRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2533,
+      "line": 2547,
       "api": "withReadDbAsync",
       "source": "const links = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2562,
+      "line": 2576,
       "api": "withReadDbAsync",
       "source": "const degreeRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2799,
+      "line": 2813,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2826,
+      "line": 2840,
       "api": "withReadDbAsync",
       "source": "const safeRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 3024,
+      "line": 3038,
       "api": "withReadDbAsync",
       "source": "const supplementary = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 3126,
+      "line": 3140,
       "api": "withReadDbAsync",
       "source": "const ctx = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 3235,
+      "line": 3249,
       "api": "withReadDbAsync",
       "source": "const blocks = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
@@ -2869,7 +2869,7 @@
     },
     {
       "path": "pipeline/graph-traversal.ts",
-      "line": 99,
+      "line": 101,
       "api": "withReadDbAsync",
       "source": "await withReadDbAsync(source, (db) => db.prepare(sql).all(...params) as ReadonlyArray<Row>);",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -2113,121 +2113,44 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 1924,
-      "api": "withReadDbAsync",
-      "source": "await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1947,
-      "api": "withReadDbAsync",
-      "source": "await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2071,
-      "api": "withReadDbAsync",
-      "source": "embRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2165,
-      "api": "withReadDbAsync",
-      "source": "await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2230,
-      "api": "withReadDbAsync",
-      "source": "baseRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2318,
+      "line": 2308,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2364,
-      "api": "withReadDbAsync",
-      "source": "const structured = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2400,
+      "line": 2386,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2447,
+      "line": 2433,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2526,
+      "line": 2512,
       "api": "withReadDbAsync",
       "source": "const dampenRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2547,
-      "api": "withReadDbAsync",
-      "source": "const links = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2576,
-      "api": "withReadDbAsync",
-      "source": "const degreeRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2813,
+      "line": 2793,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2840,
+      "line": 2820,
       "api": "withReadDbAsync",
       "source": "const safeRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 3038,
-      "api": "withReadDbAsync",
-      "source": "const supplementary = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 3140,
-      "api": "withReadDbAsync",
-      "source": "const ctx = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 3249,
-      "api": "withReadDbAsync",
-      "source": "const blocks = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -2113,133 +2113,119 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 1861,
+      "line": 1924,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1884,
+      "line": 1947,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1985,
-      "api": "withReadDbAsync",
-      "source": "getDbAccessor().withReadDbAsync(readFn, {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2012,
+      "line": 2069,
       "api": "withReadDbAsync",
       "source": "const embRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2100,
+      "line": 2158,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2136,
-      "api": "withReadDbAsync",
-      "source": "getDbAccessor().withReadDbAsync(readFn, {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2169,
+      "line": 2221,
       "api": "withReadDbAsync",
       "source": "const baseRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2251,
+      "line": 2304,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2297,
+      "line": 2350,
       "api": "withReadDbAsync",
       "source": "const structured = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2333,
+      "line": 2386,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2380,
+      "line": 2433,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2459,
+      "line": 2512,
       "api": "withReadDbAsync",
       "source": "const dampenRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2480,
+      "line": 2533,
       "api": "withReadDbAsync",
       "source": "const links = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2509,
+      "line": 2562,
       "api": "withReadDbAsync",
       "source": "const degreeRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2746,
+      "line": 2799,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2773,
+      "line": 2826,
       "api": "withReadDbAsync",
       "source": "const safeRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2971,
+      "line": 3024,
       "api": "withReadDbAsync",
       "source": "const supplementary = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 3071,
+      "line": 3126,
       "api": "withReadDbAsync",
       "source": "const ctx = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 3180,
+      "line": 3235,
       "api": "withReadDbAsync",
       "source": "const blocks = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
@@ -2883,7 +2869,7 @@
     },
     {
       "path": "pipeline/graph-traversal.ts",
-      "line": 92,
+      "line": 99,
       "api": "withReadDbAsync",
       "source": "await withReadDbAsync(source, (db) => db.prepare(sql).all(...params) as ReadonlyArray<Row>);",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

Route both memory-search knowledge-graph traversal branches through the existing serialized DB-owner API so recall no longer executes graph traversal stages through parent SQLite adapters.

## Changes

- Replace both generic traversal calls with `traverseKnowledgeGraphViaOwner` using one resolved owner per recall.
- Preserve traversal bounds, agent identity, and scope behavior.
- Surface focal/traversal operational failures as recall partial/error metadata.
- Add a static architecture invariant and traversal error regression coverage.
- Use graph degradation metadata for recall operation headers.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun run --filter '@signet/daemon' typecheck`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `bun test platform/daemon/src/pipeline/graph-traversal.test.ts`
- [x] Focused memory-search traversal tests with `--test-name-pattern`
- [ ] Full `memory-search.test.ts` suite is not clean in this environment because its existing un-awaited DB-owner teardown races produce `DbAccessor is closed` / `DB_OWNER_DIED` failures across tests.

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

No frontend changes. Stop at review gate; do not merge without adversarial review at the exact head.


