### PR TITLE
fix(daemon): bound embedding projection compute

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 852 sites
+- Exact ledger inventory: 849 sites
 - Synchronous `withWriteTx()` sites: 65
 - Synchronous `withReadDb()` sites: 99
-- Async-named DB sites: 173
-- Async-named ON-PARENT DB sites: 171
+- Async-named DB sites: 169
+- Async-named ON-PARENT DB sites: 167
 - Async-named OFF-PARENT DB sites: 2
-- Synchronous filesystem/process sites: 515
+- Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 164
   - `withWriteTx`: 65
   - `withReadDb`: 99
 
-The 852-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 849-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 169 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 167 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 337
-- ON-PARENT callback execution: 335
+- Database accessor sites classified: 333
+- ON-PARENT callback execution: 331
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -242,29 +242,25 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `routes/marketplace.ts:1128` (withWriteTx)
 - `routes/mcp-analytics.ts:89` (withReadDb)
 - `routes/mcp-analytics.ts:171` (withReadDb)
-- `routes/memory-routes.ts:121` (withReadDbAsync)
-- `routes/memory-routes.ts:1022` (withReadDbAsync)
-- `routes/memory-routes.ts:1102` (withReadDbAsync)
-- `routes/memory-routes.ts:1157` (withReadDbAsync)
-- `routes/memory-routes.ts:1258` (withReadDbAsync)
-- `routes/memory-routes.ts:1368` (withReadDbAsync)
-- `routes/memory-routes.ts:1670` (withReadDbAsync)
-- `routes/memory-routes.ts:1678` (withReadDbAsync)
-- `routes/memory-routes.ts:1712` (withReadDbAsync)
-- `routes/memory-routes.ts:1919` (withReadDbAsync)
-- `routes/memory-routes.ts:2044` (withReadDbAsync)
-- `routes/memory-routes.ts:2263` (withReadDbAsync)
-- `routes/memory-routes.ts:2442` (withReadDbAsync)
-- `routes/memory-routes.ts:3641` (withReadDbAsync)
-- `routes/memory-routes.ts:3675` (withReadDbAsync)
-- `routes/memory-routes.ts:3693` (withReadDbAsync)
-- `routes/memory-routes.ts:3774` (withReadDbAsync)
-- `routes/memory-routes.ts:3859` (withReadDbAsync)
-- `routes/memory-routes.ts:3877` (withReadDbAsync)
-- `routes/memory-routes.ts:3940` (withReadDbAsync)
-- `routes/memory-routes.ts:3980` (withReadDbAsync)
-- `routes/memory-routes.ts:4021` (withReadDbAsync)
-- `routes/memory-routes.ts:4024` (withReadDbAsync)
+- `routes/memory-routes.ts:128` (withReadDbAsync)
+- `routes/memory-routes.ts:1186` (withReadDbAsync)
+- `routes/memory-routes.ts:1266` (withReadDbAsync)
+- `routes/memory-routes.ts:1321` (withReadDbAsync)
+- `routes/memory-routes.ts:1422` (withReadDbAsync)
+- `routes/memory-routes.ts:1532` (withReadDbAsync)
+- `routes/memory-routes.ts:1834` (withReadDbAsync)
+- `routes/memory-routes.ts:1842` (withReadDbAsync)
+- `routes/memory-routes.ts:1876` (withReadDbAsync)
+- `routes/memory-routes.ts:2083` (withReadDbAsync)
+- `routes/memory-routes.ts:2208` (withReadDbAsync)
+- `routes/memory-routes.ts:2427` (withReadDbAsync)
+- `routes/memory-routes.ts:2606` (withReadDbAsync)
+- `routes/memory-routes.ts:3805` (withReadDbAsync)
+- `routes/memory-routes.ts:3839` (withReadDbAsync)
+- `routes/memory-routes.ts:3857` (withReadDbAsync)
+- `routes/memory-routes.ts:3938` (withReadDbAsync)
+- `routes/memory-routes.ts:4023` (withReadDbAsync)
+- `routes/memory-routes.ts:4041` (withReadDbAsync)
 - `routes/pipeline-routes.ts:121` (withReadDb)
 - `routes/pipeline-routes.ts:346` (withReadDbAsync)
 - `routes/pipeline-routes.ts:520` (withReadDb)
@@ -290,7 +286,7 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `routes/session-routes.ts:349` (withReadDb)
 - `routes/session-routes.ts:359` (withReadDb)
 - `routes/skill-analytics.ts:121` (withReadDb)
-- `routes/state.ts:457` (withReadDb)
+- `routes/state.ts:453` (withReadDb)
 - `routes/telemetry-routes.ts:200` (withReadDb)
 - `routes/telemetry-routes.ts:221` (withReadDb)
 - `routes/telemetry-routes.ts:265` (withReadDb)

--- a/libs/sdk/src/__tests__/embeddings.test.ts
+++ b/libs/sdk/src/__tests__/embeddings.test.ts
@@ -108,4 +108,16 @@ describe("Embeddings API", () => {
 		expect(req.query.dimensions).toBe("2");
 		expect(projection.status).toBe("ready");
 	});
+
+	test("cancelEmbeddingProjection() accepts the successful cancellation response", async () => {
+		const { client } = mockDaemon((req) => {
+			if (req.path === "/api/embeddings/projection/job-123") return { status: "cancelled", jobId: "job-123" };
+			return { ok: true };
+		});
+
+		const result = await client.cancelEmbeddingProjection("job-123");
+
+		expect(lastRequest()).toMatchObject({ method: "DELETE", path: "/api/embeddings/projection/job-123" });
+		expect(result).toEqual({ status: "cancelled", jobId: "job-123" });
+	});
 });

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -576,10 +576,24 @@ export class SignetClient extends SignetClientHelpers {
 	 * }
 	 * ```
 	 */
-	async getEmbeddingProjection(opts?: { readonly dimensions?: 2 | 3 }): Promise<EmbeddingProjectionResponse> {
+	async getEmbeddingProjection(opts?: {
+		readonly dimensions?: 2 | 3;
+		readonly jobId?: string;
+		readonly limit?: number;
+		readonly offset?: number;
+	}): Promise<EmbeddingProjectionResponse> {
 		return this.transport.get<EmbeddingProjectionResponse>("/api/embeddings/projection", {
 			dimensions: opts?.dimensions,
+			jobId: opts?.jobId,
+			limit: opts?.limit,
+			offset: opts?.offset,
 		});
+	}
+
+	async cancelEmbeddingProjection(jobId: string): Promise<{ readonly status: "cancelled"; readonly jobId: string }> {
+		return this.transport.del<{ readonly status: "cancelled"; readonly jobId: string }>(
+			`/api/embeddings/projection/${jobId}`,
+		);
 	}
 
 	// --- Harnesses ---

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -769,25 +769,30 @@ export interface EmbeddingProjectionReadyResponse {
 	readonly limit: number;
 	readonly offset: number;
 	readonly hasMore: boolean;
+	readonly sampled: boolean;
 	readonly nodes: readonly EmbeddingProjectionNode[];
 	readonly edges: readonly EmbeddingProjectionEdge[];
 	readonly cachedAt?: string;
 }
 
-export interface EmbeddingProjectionComputingResponse {
-	readonly status: "computing";
+export interface EmbeddingProjectionAcceptedResponse {
+	readonly status: "accepted" | "running";
+	readonly jobId: string;
 	readonly dimensions: 2 | 3;
+	readonly limit: number;
+	readonly offset: number;
 }
 
-export interface EmbeddingProjectionErrorResponse {
-	readonly status: "error";
+export interface EmbeddingProjectionFailureResponse {
+	readonly status: "timeout" | "cancelled" | "error" | "overloaded";
 	readonly message: string;
+	readonly jobId?: string;
 }
 
 export type EmbeddingProjectionResponse =
 	| EmbeddingProjectionReadyResponse
-	| EmbeddingProjectionComputingResponse
-	| EmbeddingProjectionErrorResponse;
+	| EmbeddingProjectionAcceptedResponse
+	| EmbeddingProjectionFailureResponse;
 
 // Harness types
 

--- a/platform/daemon/build.ts
+++ b/platform/daemon/build.ts
@@ -29,6 +29,7 @@ const targets: Array<{
 	{ entrypoint: "./src/synthesis-render-worker.ts", outfile: "./dist/synthesis-render-worker.js" },
 	{ entrypoint: "./src/database-integrity-worker.ts", outfile: "./dist/database-integrity-worker.js" },
 	{ entrypoint: "./src/db-owner-worker.ts", outfile: "./dist/db-owner-worker.js" },
+	{ entrypoint: "./src/embedding-projection-worker.ts", outfile: "./dist/embedding-projection-worker.js" },
 	{ entrypoint: "./src/native-memory-source-worker.ts", outfile: "./dist/native-memory-source-worker.js" },
 	{ entrypoint: "./src/pipeline/dreaming-token-worker.ts", outfile: "./dist/dreaming-token-worker.js" },
 	{ entrypoint: "./src/transcript-recovery-child.ts", outfile: "./dist/transcript-recovery-child.js" },

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -415,6 +415,23 @@ inference:
 			expect(body.error).toContain("validUntil must be after validFrom");
 		});
 
+		it("GET /api/embeddings/projection requires recall permission", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode projection test");
+
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			registerMemoryRoutes(app);
+			const res = await app.request("/api/embeddings/projection");
+
+			expect(res.status).toBe(401);
+			const body = (await res.json()) as { error?: string };
+			expect(body.error).toContain("authentication required");
+		});
+
 		it("POST /api/memory/recall aggregate save requires remember permission", async () => {
 			const app = await makeApp();
 			const state = await import("./routes/state.js");

--- a/platform/daemon/src/db-owner-sql.ts
+++ b/platform/daemon/src/db-owner-sql.ts
@@ -1,6 +1,6 @@
 /** Typed SQL helpers for work that must execute inside the DB owner process. */
 
-import type { DbOwnerClient } from "./db-owner-client";
+import type { DbOwnerClient, DbOwnerJobHandle } from "./db-owner-client";
 import type { DbOwnerParameter, DbOwnerRequest, DbOwnerWorkloadClass } from "./db-owner-protocol";
 
 export interface DbOwnerRunResult {
@@ -27,6 +27,14 @@ function parameter(value: unknown): DbOwnerParameter {
 }
 
 function submit<Result>(client: DbOwnerClient, request: DbOwnerRequest, options: DbOwnerSqlOptions): Promise<Result> {
+	return submitHandle<Result>(client, request, options).result;
+}
+
+function submitHandle<Result>(
+	client: DbOwnerClient,
+	request: DbOwnerRequest,
+	options: DbOwnerSqlOptions,
+): DbOwnerJobHandle<Result> {
 	const handle = client.submit<Result>(request, {
 		operation: options.operation,
 		lane: options.lane ?? "maintenance",
@@ -34,7 +42,20 @@ function submit<Result>(client: DbOwnerClient, request: DbOwnerRequest, options:
 		deadlineMs: options.deadlineMs ?? 30_000,
 		estimatedWorkUnits: options.estimatedWorkUnits,
 	});
-	return handle.result;
+	return handle;
+}
+
+export function ownerReadAllHandle<Row extends object>(
+	client: DbOwnerClient,
+	sql: string,
+	params: readonly unknown[] = [],
+	options: DbOwnerSqlOptions,
+): DbOwnerJobHandle<readonly Row[]> {
+	return submitHandle<readonly Row[]>(
+		client,
+		{ kind: "query", statement: { sql, params: params.map(parameter), result: "all" } },
+		{ ...options, lane: "read" },
+	);
 }
 
 export function ownerReadAll<Row extends object>(
@@ -43,9 +64,18 @@ export function ownerReadAll<Row extends object>(
 	params: readonly unknown[] = [],
 	options: DbOwnerSqlOptions,
 ): Promise<readonly Row[]> {
-	return submit<readonly Row[]>(
+	return ownerReadAllHandle<Row>(client, sql, params, options).result;
+}
+
+export function ownerReadOneHandle<Row extends object>(
+	client: DbOwnerClient,
+	sql: string,
+	params: readonly unknown[] = [],
+	options: DbOwnerSqlOptions,
+): DbOwnerJobHandle<Row | null> {
+	return submitHandle<Row | null>(
 		client,
-		{ kind: "query", statement: { sql, params: params.map(parameter), result: "all" } },
+		{ kind: "query", statement: { sql, params: params.map(parameter), result: "get" } },
 		{ ...options, lane: "read" },
 	);
 }
@@ -56,12 +86,7 @@ export async function ownerReadOne<Row extends object>(
 	params: readonly unknown[] = [],
 	options: DbOwnerSqlOptions,
 ): Promise<Row | null> {
-	const result = await submit<Row | null>(
-		client,
-		{ kind: "query", statement: { sql, params: params.map(parameter), result: "get" } },
-		{ ...options, lane: "read" },
-	);
-	return result;
+	return await ownerReadOneHandle<Row>(client, sql, params, options).result;
 }
 
 export function ownerRun(
@@ -86,6 +111,18 @@ export function ownerBatch(
 	}[],
 	options: DbOwnerSqlOptions & { readonly requireChanges?: boolean },
 ): Promise<readonly DbOwnerRunResult[]> {
+	return ownerBatchHandle(client, statements, options).result;
+}
+
+export function ownerBatchHandle(
+	client: DbOwnerClient,
+	statements: readonly {
+		readonly sql: string;
+		readonly params?: readonly unknown[];
+		readonly requireChanges?: boolean;
+	}[],
+	options: DbOwnerSqlOptions & { readonly requireChanges?: boolean },
+): DbOwnerJobHandle<readonly DbOwnerRunResult[]> {
 	const request: DbOwnerRequest = {
 		kind: "batch",
 		statements: statements.map((statement) => ({
@@ -96,7 +133,7 @@ export function ownerBatch(
 		})),
 		requireChanges: options.requireChanges,
 	};
-	return submit<readonly DbOwnerRunResult[]>(client, request, options);
+	return submitHandle<readonly DbOwnerRunResult[]>(client, request, options);
 }
 
 export function ownerBytesFromHex(value: string): Uint8Array {

--- a/platform/daemon/src/embedding-projection-jobs.test.ts
+++ b/platform/daemon/src/embedding-projection-jobs.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	ProjectionAdmissionError,
+	ProjectionJobManager,
+	ProjectionWorkerCancelledError,
+	ProjectionWorkerTimeoutError,
+	runProjectionWorker,
+} from "./embedding-projection-jobs";
+import type { ProjectionWorkerInput } from "./embedding-projection-worker";
+
+function vectorHex(values: readonly number[]): string {
+	return Buffer.from(new Float32Array(values).buffer).toString("hex");
+}
+
+function input(): ProjectionWorkerInput {
+	return {
+		dimensions: 2,
+		rows: [
+			{
+				id: "one",
+				content: "one",
+				who: null,
+				importance: null,
+				type: null,
+				tags: null,
+				pinned: null,
+				source_type: "memory",
+				source_id: "one",
+				created_at: "2026-01-01T00:00:00.000Z",
+				vectorHex: vectorHex([1, 0, 0]),
+				dimensions: 3,
+			},
+			{
+				id: "two",
+				content: "two",
+				who: null,
+				importance: null,
+				type: null,
+				tags: null,
+				pinned: null,
+				source_type: "memory",
+				source_id: "two",
+				created_at: "2026-01-02T00:00:00.000Z",
+				vectorHex: vectorHex([0, 1, 0]),
+				dimensions: 3,
+			},
+		],
+	};
+}
+
+const handles: Array<ReturnType<typeof runProjectionWorker>> = [];
+
+afterEach(() => {
+	for (const handle of handles) handle.cancel();
+	handles.length = 0;
+});
+
+describe("embedding projection worker boundary", () => {
+	test("protects the projection route with recall permission", () => {
+		const source = readFileSync(join(import.meta.dir, "routes/memory-routes.ts"), "utf8");
+		expect(source).toContain('app.use("/api/embeddings", async (c, next) =>');
+		expect(source).toContain('requirePermission("recall", authConfig)(c, next)');
+	});
+
+	test("runs projection in the worker process and returns a bounded result", async () => {
+		const handle = runProjectionWorker(input(), { timeoutMs: 2_000 });
+		handles.push(handle);
+		const result = await handle.result;
+		expect(result.nodes).toHaveLength(2);
+		expect(result.edges).toEqual([[0, 1]]);
+	});
+
+	test("keeps the parent event loop responsive while the worker is held", async () => {
+		const startedAt = performance.now();
+		let tickDelay = Number.POSITIVE_INFINITY;
+		setTimeout(() => {
+			tickDelay = performance.now() - startedAt;
+		}, 0);
+		const handle = runProjectionWorker(input(), { holdForTests: true, timeoutMs: 2_000 });
+		handles.push(handle);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(tickDelay).toBeLessThan(80);
+		handle.cancel();
+		await expect(handle.result).rejects.toBeInstanceOf(ProjectionWorkerCancelledError);
+	});
+
+	test("keeps a 1,000-row snapshot off the parent event loop", async () => {
+		const seed = input().rows;
+		const largeInput: ProjectionWorkerInput = {
+			dimensions: 2,
+			rows: Array.from({ length: 1_000 }, (_, index) => ({
+				...seed[index % seed.length],
+				id: `row-${index}`,
+				source_id: `row-${index}`,
+			})),
+		};
+		const startedAt = performance.now();
+		let tickDelay = Number.POSITIVE_INFINITY;
+		setTimeout(() => {
+			tickDelay = performance.now() - startedAt;
+		}, 0);
+		const handle = runProjectionWorker(largeInput, { holdForTests: true, timeoutMs: 2_000 });
+		handles.push(handle);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(tickDelay).toBeLessThan(80);
+		handle.cancel();
+		await expect(handle.result).rejects.toBeInstanceOf(ProjectionWorkerCancelledError);
+	});
+
+	test("kills a worker at the hard deadline", async () => {
+		const handle = runProjectionWorker(input(), { holdForTests: true, timeoutMs: 50 });
+		handles.push(handle);
+		await expect(handle.result).rejects.toBeInstanceOf(ProjectionWorkerTimeoutError);
+	});
+});
+
+describe("ProjectionJobManager", () => {
+	test("single-flights equivalent jobs and bounds global concurrency", async () => {
+		const manager = new ProjectionJobManager(2);
+		let active = 0;
+		let peak = 0;
+		const resolvers: Array<() => void> = [];
+		const run = () => {
+			active += 1;
+			peak = Math.max(peak, active);
+			const result = new Promise((resolve) => resolvers.push(() => resolve({ nodes: [], edges: [] })));
+			return { result, cancel: () => undefined };
+		};
+		const first = manager.start("same", 2, run);
+		const duplicate = manager.start("same", 2, run);
+		manager.start("other", 2, run);
+		expect(duplicate.jobId).toBe(first.jobId);
+		expect(peak).toBe(2);
+		expect(() => manager.start("third", 2, run)).toThrow(ProjectionAdmissionError);
+		for (const resolve of resolvers.splice(0)) resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(manager.get(first.jobId)?.status).toBe("ready");
+		expect(peak).toBe(2);
+	});
+});

--- a/platform/daemon/src/embedding-projection-jobs.test.ts
+++ b/platform/daemon/src/embedding-projection-jobs.test.ts
@@ -6,9 +6,11 @@ import {
 	ProjectionJobManager,
 	ProjectionWorkerCancelledError,
 	ProjectionWorkerTimeoutError,
+	runBoundedProjectionJob,
 	runProjectionWorker,
 } from "./embedding-projection-jobs";
 import type { ProjectionWorkerInput } from "./embedding-projection-worker";
+import type { ProjectionResult } from "./umap-projection";
 
 function vectorHex(values: readonly number[]): string {
 	return Buffer.from(new Float32Array(values).buffer).toString("hex");
@@ -62,6 +64,17 @@ describe("embedding projection worker boundary", () => {
 		const source = readFileSync(join(import.meta.dir, "routes/memory-routes.ts"), "utf8");
 		expect(source).toContain('app.use("/api/embeddings", async (c, next) =>');
 		expect(source).toContain('requirePermission("recall", authConfig)(c, next)');
+		const projectionStart = source.indexOf('app.get("/api/embeddings/projection",');
+		const projectionRoute = source.slice(projectionStart, source.indexOf("// POST /api/documents", projectionStart));
+		expect(projectionRoute).toContain("ownerBatchHandle");
+		expect(projectionRoute).not.toContain("runWriteTxAsync");
+		const cancellationRoute = source.slice(
+			source.indexOf('app.delete("/api/embeddings/projection/:jobId"'),
+			projectionStart,
+		);
+		expect(cancellationRoute).toContain(
+			'return c.json({ status: "cancelled", jobId: job.jobId, dimensions: job.dimensions });',
+		);
 	});
 
 	test("runs projection in the worker process and returns a bounded result", async () => {
@@ -114,6 +127,45 @@ describe("embedding projection worker boundary", () => {
 		handles.push(handle);
 		await expect(handle.result).rejects.toBeInstanceOf(ProjectionWorkerTimeoutError);
 	});
+
+	test("bounds the complete job when the DB-owner snapshot is held", async () => {
+		let cancellationCalls = 0;
+		const startedAt = performance.now();
+		const handle = runBoundedProjectionJob(
+			async (control) => {
+				control.onCancel(() => {
+					cancellationCalls += 1;
+				});
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return input();
+			},
+			{ deadlineMs: 30 },
+		);
+
+		await expect(handle.result).rejects.toBeInstanceOf(ProjectionWorkerTimeoutError);
+		expect(performance.now() - startedAt).toBeLessThan(80);
+		expect(cancellationCalls).toBe(1);
+	});
+
+	test("cancels a job while its DB-owner snapshot is in flight", async () => {
+		let cancellationCalls = 0;
+		const startedAt = performance.now();
+		const handle = runBoundedProjectionJob(
+			async (control) => {
+				control.onCancel(() => {
+					cancellationCalls += 1;
+				});
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return input();
+			},
+			{ deadlineMs: 2_000 },
+		);
+
+		handle.cancel();
+		await expect(handle.result).rejects.toBeInstanceOf(ProjectionWorkerCancelledError);
+		expect(performance.now() - startedAt).toBeLessThan(50);
+		expect(cancellationCalls).toBe(1);
+	});
 });
 
 describe("ProjectionJobManager", () => {
@@ -125,7 +177,9 @@ describe("ProjectionJobManager", () => {
 		const run = () => {
 			active += 1;
 			peak = Math.max(peak, active);
-			const result = new Promise((resolve) => resolvers.push(() => resolve({ nodes: [], edges: [] })));
+			const result = new Promise<ProjectionResult>((resolve) =>
+				resolvers.push(() => resolve({ nodes: [], edges: [] })),
+			);
 			return { result, cancel: () => undefined };
 		};
 		const first = manager.start("same", 2, run);

--- a/platform/daemon/src/embedding-projection-jobs.ts
+++ b/platform/daemon/src/embedding-projection-jobs.ts
@@ -65,13 +65,18 @@ function killChild(child: ChildProcess): void {
 export function runProjectionWorker(
 	input: ProjectionWorkerInput,
 	options: ProjectionWorkerOptions = {},
-): { readonly result: Promise<ProjectionResult>; readonly cancel: () => void } {
+): {
+	readonly result: Promise<ProjectionResult>;
+	readonly serializedResult: Promise<string>;
+	readonly cancel: () => void;
+} {
 	const timeoutMs = options.timeoutMs ?? PROJECTION_DEADLINE_MS;
 	const serialized = JSON.stringify(input);
 	let child: ChildProcess | null = null;
 	let cancelRequested = false;
 	let settled = false;
 	let timer: ReturnType<typeof setTimeout> | undefined;
+	let serializedOutput: string | null = null;
 
 	const result = new Promise<ProjectionResult>((resolve, reject) => {
 		child = spawn(options.runtimePath ?? process.execPath, workerArguments(options.workerPath), {
@@ -112,10 +117,12 @@ export function runProjectionWorker(
 					return;
 				}
 				try {
-					const message = JSON.parse(output.trim()) as { type?: unknown; result?: ProjectionResult };
-					if (message.type !== "result" || message.result === undefined)
+					const lines = output.trim().split("\n");
+					const message = JSON.parse(lines.shift() ?? "") as { type?: unknown };
+					serializedOutput = lines.join("\n").trim();
+					if (message.type !== "result" || serializedOutput.length === 0)
 						throw new Error("invalid projection worker result");
-					resolve(message.result);
+					resolve(JSON.parse(serializedOutput) as ProjectionResult);
 				} catch (error) {
 					reject(error);
 				}
@@ -133,10 +140,127 @@ export function runProjectionWorker(
 
 	return {
 		result,
+		serializedResult: result.then(
+			() => {
+				if (serializedOutput === null) throw new Error("projection worker did not publish a serialized result");
+				return serializedOutput;
+			},
+			() => "",
+		),
 		cancel: () => {
 			if (settled || child === null) return;
 			cancelRequested = true;
 			killChild(child);
+		},
+	};
+}
+
+export interface ProjectionJobControl {
+	readonly deadlineAt: number;
+	readonly remainingMs: () => number;
+	readonly isCancelled: () => boolean;
+	readonly onCancel: (callback: () => void) => void;
+}
+
+export interface BoundedProjectionJobOptions {
+	readonly deadlineMs?: number;
+	readonly workerOptions?: Omit<ProjectionWorkerOptions, "timeoutMs">;
+	readonly publish?: (
+		result: ProjectionResult,
+		serializedResult: string,
+		control: ProjectionJobControl,
+	) => Promise<void>;
+}
+
+/** Run snapshot, compute, and optional publication under one killable deadline. */
+export function runBoundedProjectionJob(
+	load: (control: ProjectionJobControl) => Promise<ProjectionWorkerInput>,
+	options: BoundedProjectionJobOptions = {},
+): { readonly result: Promise<ProjectionResult>; readonly cancel: () => void } {
+	const deadlineMs = options.deadlineMs ?? PROJECTION_DEADLINE_MS;
+	const deadlineAt = Date.now() + deadlineMs;
+	let cancelled = false;
+	let settled = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let rejectResult: ((error: unknown) => void) | undefined;
+	let worker: ReturnType<typeof runProjectionWorker> | null = null;
+	const cancellationCallbacks: Array<() => void> = [];
+
+	const control: ProjectionJobControl = {
+		deadlineAt,
+		remainingMs: () => Math.max(0, deadlineAt - Date.now()),
+		isCancelled: () => cancelled,
+		onCancel: (callback) => {
+			if (cancelled) {
+				callback();
+				return;
+			}
+			cancellationCallbacks.push(callback);
+		},
+	};
+	const cancelOutstanding = (): void => {
+		for (const callback of cancellationCallbacks) {
+			try {
+				callback();
+			} catch {
+				// The operation may already have settled at the cancellation boundary.
+			}
+		}
+		worker?.cancel();
+	};
+
+	const result = new Promise<ProjectionResult>((resolve, reject) => {
+		const finishReject = (error: unknown): void => {
+			if (settled) return;
+			settled = true;
+			if (timer !== undefined) clearTimeout(timer);
+			cancelOutstanding();
+			reject(error);
+		};
+		rejectResult = finishReject;
+		timer = setTimeout(() => {
+			cancelled = true;
+			finishReject(new ProjectionWorkerTimeoutError(deadlineMs));
+		}, deadlineMs);
+		void (async () => {
+			try {
+				const input = await load(control);
+				if (cancelled) throw new ProjectionWorkerCancelledError();
+				const remainingMs = control.remainingMs();
+				if (remainingMs <= 0) throw new ProjectionWorkerTimeoutError(deadlineMs);
+				worker = runProjectionWorker(input, { ...options.workerOptions, timeoutMs: remainingMs });
+				const projection = await worker.result;
+				const serializedResult = await worker.serializedResult;
+				if (cancelled) throw new ProjectionWorkerCancelledError();
+				if (options.publish !== undefined) await options.publish(projection, serializedResult, control);
+				if (settled) return;
+				settled = true;
+				if (timer !== undefined) clearTimeout(timer);
+				resolve(projection);
+			} catch (error) {
+				if (error instanceof ProjectionWorkerTimeoutError || error instanceof ProjectionWorkerCancelledError) {
+					finishReject(error);
+					return;
+				}
+				if (cancelled) {
+					finishReject(new ProjectionWorkerCancelledError());
+					return;
+				}
+				if (control.remainingMs() <= 0) {
+					finishReject(new ProjectionWorkerTimeoutError(deadlineMs));
+					return;
+				}
+				finishReject(error);
+			}
+		})();
+	});
+
+	return {
+		result,
+		cancel: () => {
+			if (settled) return;
+			cancelled = true;
+			rejectResult?.(new ProjectionWorkerCancelledError());
 		},
 	};
 }

--- a/platform/daemon/src/embedding-projection-jobs.ts
+++ b/platform/daemon/src/embedding-projection-jobs.ts
@@ -1,0 +1,289 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveEmbeddedWorkerPath } from "./native-runtime-assets";
+import type { ProjectionResult } from "./umap-projection";
+import type { ProjectionWorkerInput } from "./embedding-projection-worker";
+
+export const PROJECTION_MAX_ROWS = 1_000;
+export const PROJECTION_MAX_IN_FLIGHT = 2;
+export const PROJECTION_DEADLINE_MS = 10_000;
+export const PROJECTION_JOB_TTL_MS = 60_000;
+
+export class ProjectionWorkerTimeoutError extends Error {
+	readonly code = "PROJECTION_TIMEOUT" as const;
+
+	constructor(timeoutMs: number) {
+		super(`Embedding projection exceeded its ${timeoutMs}ms deadline`);
+		this.name = "ProjectionWorkerTimeoutError";
+	}
+}
+
+export class ProjectionWorkerCancelledError extends Error {
+	readonly code = "PROJECTION_CANCELLED" as const;
+
+	constructor() {
+		super("Embedding projection was cancelled");
+		this.name = "ProjectionWorkerCancelledError";
+	}
+}
+
+export class ProjectionAdmissionError extends Error {
+	readonly code = "PROJECTION_OVERLOADED" as const;
+
+	constructor() {
+		super("Embedding projection capacity is full; retry after an active job completes");
+		this.name = "ProjectionAdmissionError";
+	}
+}
+
+export interface ProjectionWorkerOptions {
+	readonly runtimePath?: string;
+	readonly workerPath?: string;
+	readonly timeoutMs?: number;
+	readonly holdForTests?: boolean;
+}
+
+function workerArguments(workerPath?: string): readonly string[] {
+	if (workerPath !== undefined) return [workerPath];
+	if (resolveEmbeddedWorkerPath("embedding-projection-worker") !== null) return [];
+	const directory = dirname(fileURLToPath(import.meta.url));
+	const bundled = join(directory, "embedding-projection-worker.js");
+	return [existsSync(bundled) ? bundled : join(directory, "embedding-projection-worker.ts")];
+}
+
+function killChild(child: ChildProcess): void {
+	if (child.exitCode !== null) return;
+	try {
+		child.kill("SIGKILL");
+	} catch {
+		// The process may have exited between the check and the signal.
+	}
+}
+
+export function runProjectionWorker(
+	input: ProjectionWorkerInput,
+	options: ProjectionWorkerOptions = {},
+): { readonly result: Promise<ProjectionResult>; readonly cancel: () => void } {
+	const timeoutMs = options.timeoutMs ?? PROJECTION_DEADLINE_MS;
+	const serialized = JSON.stringify(input);
+	let child: ChildProcess | null = null;
+	let cancelRequested = false;
+	let settled = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const result = new Promise<ProjectionResult>((resolve, reject) => {
+		child = spawn(options.runtimePath ?? process.execPath, workerArguments(options.workerPath), {
+			env: {
+				...process.env,
+				SIGNET_EMBEDDING_PROJECTION_WORKER: "1",
+				...(options.holdForTests === true ? { SIGNET_PROJECTION_WORKER_HOLD: "1" } : {}),
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		let output = "";
+		let errorOutput = "";
+		const finish = (fn: () => void): void => {
+			if (settled) return;
+			settled = true;
+			if (timer !== undefined) clearTimeout(timer);
+			fn();
+		};
+		child.stdout?.setEncoding("utf8");
+		child.stdout?.on("data", (chunk: string) => {
+			output += chunk;
+		});
+		child.stderr?.setEncoding("utf8");
+		child.stderr?.on("data", (chunk: string) => {
+			errorOutput += chunk;
+		});
+		child.once("error", (error) => finish(() => reject(error)));
+		child.once("close", (code) => {
+			if (settled) return;
+			finish(() => {
+				if (cancelRequested) {
+					reject(new ProjectionWorkerCancelledError());
+					return;
+				}
+				if (code !== 0) {
+					const detail = errorOutput.trim();
+					reject(new Error(`Projection worker exited with code ${code ?? "unknown"}${detail ? `: ${detail}` : ""}`));
+					return;
+				}
+				try {
+					const message = JSON.parse(output.trim()) as { type?: unknown; result?: ProjectionResult };
+					if (message.type !== "result" || message.result === undefined)
+						throw new Error("invalid projection worker result");
+					resolve(message.result);
+				} catch (error) {
+					reject(error);
+				}
+			});
+		});
+		child.stderr?.resume();
+		timer = setTimeout(() => {
+			if (settled) return;
+			cancelRequested = true;
+			finish(() => reject(new ProjectionWorkerTimeoutError(timeoutMs)));
+			killChild(child as ChildProcess);
+		}, timeoutMs);
+		child.stdin?.end(`${serialized}\n`);
+	});
+
+	return {
+		result,
+		cancel: () => {
+			if (settled || child === null) return;
+			cancelRequested = true;
+			killChild(child);
+		},
+	};
+}
+
+type ProjectionJobState = "accepted" | "running" | "ready" | "timeout" | "cancelled" | "error";
+
+export interface ProjectionJobStatus {
+	readonly jobId: string;
+	readonly key: string;
+	readonly status: ProjectionJobState;
+	readonly createdAt: string;
+	readonly dimensions: 2 | 3;
+	readonly total?: number;
+	readonly count?: number;
+	readonly limit?: number;
+	readonly offset?: number;
+	readonly hasMore?: boolean;
+	readonly sampled?: boolean;
+	readonly result?: ProjectionResult;
+	readonly message?: string;
+}
+
+interface ProjectionJob extends ProjectionJobStatus {
+	readonly cancel: () => void;
+	readonly expiresAt: number;
+}
+
+export class ProjectionJobManager {
+	private readonly jobs = new Map<string, ProjectionJob>();
+	private sequence = 0;
+	private active = 0;
+
+	constructor(private readonly maxInFlight = PROJECTION_MAX_IN_FLIGHT) {}
+
+	start(
+		key: string,
+		dimensions: 2 | 3,
+		run: () => { readonly result: Promise<ProjectionResult>; readonly cancel: () => void },
+		metadata: Pick<ProjectionJobStatus, "total" | "count" | "limit" | "offset" | "hasMore" | "sampled"> = {},
+	): ProjectionJobStatus {
+		this.prune();
+		const existing = this.jobs.get(key);
+		if (existing !== undefined && (existing.status === "accepted" || existing.status === "running")) return existing;
+		if (this.active >= this.maxInFlight) throw new ProjectionAdmissionError();
+		const jobId = `projection-${Date.now()}-${this.sequence++}`;
+		const started: ProjectionJob = {
+			jobId,
+			key,
+			status: "accepted",
+			createdAt: new Date().toISOString(),
+			dimensions,
+			...metadata,
+			cancel: () => undefined,
+			expiresAt: Date.now() + PROJECTION_JOB_TTL_MS,
+		};
+		this.jobs.set(key, started);
+		this.active += 1;
+		let handle: { readonly result: Promise<ProjectionResult>; readonly cancel: () => void };
+		try {
+			handle = run();
+		} catch (error) {
+			this.active = Math.max(0, this.active - 1);
+			const failed = {
+				...started,
+				status: "error" as const,
+				message: error instanceof Error ? error.message : String(error),
+			};
+			this.jobs.set(key, failed);
+			return failed;
+		}
+		const running = { ...started, status: "running" as const, cancel: handle.cancel };
+		this.jobs.set(key, running);
+		void handle.result.then(
+			(result) => {
+				this.active = Math.max(0, this.active - 1);
+				const current = this.jobs.get(key);
+				if (current?.jobId !== jobId) return;
+				this.jobs.set(key, { ...current, status: "ready", result, expiresAt: Date.now() + PROJECTION_JOB_TTL_MS });
+			},
+			(error: unknown) => {
+				this.active = Math.max(0, this.active - 1);
+				const current = this.jobs.get(key);
+				if (current?.jobId !== jobId) return;
+				const status: ProjectionJobState =
+					error instanceof ProjectionWorkerTimeoutError
+						? "timeout"
+						: error instanceof ProjectionWorkerCancelledError
+							? "cancelled"
+							: "error";
+				this.jobs.set(key, {
+					...current,
+					status,
+					message: error instanceof Error ? error.message : String(error),
+					expiresAt: Date.now() + PROJECTION_JOB_TTL_MS,
+				});
+			},
+		);
+		return running;
+	}
+
+	get(jobId: string): ProjectionJobStatus | null {
+		this.prune();
+		for (const job of this.jobs.values()) if (job.jobId === jobId) return job;
+		return null;
+	}
+
+	updateMetadata(
+		jobId: string,
+		metadata: Pick<ProjectionJobStatus, "total" | "count" | "limit" | "offset" | "hasMore" | "sampled">,
+	): void {
+		for (const job of this.jobs.values()) {
+			if (job.jobId !== jobId) continue;
+			this.jobs.set(job.key, { ...job, ...metadata });
+			return;
+		}
+	}
+
+	updateMetadataByKey(
+		key: string,
+		metadata: Pick<ProjectionJobStatus, "total" | "count" | "limit" | "offset" | "hasMore" | "sampled">,
+	): void {
+		const job = this.jobs.get(key);
+		if (job !== undefined) this.jobs.set(key, { ...job, ...metadata });
+	}
+
+	cancel(jobId: string): ProjectionJobStatus | null {
+		for (const job of this.jobs.values()) {
+			if (job.jobId !== jobId) continue;
+			if (job.status === "accepted" || job.status === "running") {
+				job.cancel();
+				const cancelled = { ...job, status: "cancelled" as const, message: "Embedding projection was cancelled" };
+				this.jobs.set(job.key, cancelled);
+				return cancelled;
+			}
+			return job;
+		}
+		return null;
+	}
+
+	reset(): void {
+		for (const job of this.jobs.values()) if (job.status === "accepted" || job.status === "running") job.cancel();
+		this.jobs.clear();
+		this.active = 0;
+	}
+
+	private prune(): void {
+		const now = Date.now();
+		for (const [key, job] of this.jobs) if (job.expiresAt <= now) this.jobs.delete(key);
+	}
+}

--- a/platform/daemon/src/embedding-projection-worker.ts
+++ b/platform/daemon/src/embedding-projection-worker.ts
@@ -80,7 +80,10 @@ export async function runEmbeddingProjectionWorker(): Promise<void> {
 		await new Promise<void>(() => setInterval(() => undefined, 1_000));
 	}
 	const result = computeProjectionWorkerInput(input);
-	process.stdout.write(`${JSON.stringify({ type: "result", result })}\n`);
+	// Keep the already-serialized payload available to the parent so it can
+	// publish it through the DB owner without serializing a large projection in
+	// the daemon event loop a second time.
+	process.stdout.write(`${JSON.stringify({ type: "result" })}\n${JSON.stringify(result)}\n`);
 }
 
 const entrypoint = process.argv[1] ?? "";

--- a/platform/daemon/src/embedding-projection-worker.ts
+++ b/platform/daemon/src/embedding-projection-worker.ts
@@ -1,0 +1,97 @@
+import { createInterface } from "node:readline";
+import { computeProjectionFromRows, type EmbeddingProjectionRow, type ProjectionResult } from "./umap-projection";
+
+export interface ProjectionWorkerRow extends Omit<EmbeddingProjectionRow, "vector"> {
+	readonly vectorHex: string;
+}
+
+export interface ProjectionWorkerInput {
+	readonly dimensions: 2 | 3;
+	readonly rows: readonly ProjectionWorkerRow[];
+}
+
+export class ProjectionWorkerInputError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ProjectionWorkerInputError";
+	}
+}
+
+function hexToBytes(value: string): Uint8Array {
+	if (!/^(?:[0-9a-f]{2})*$/i.test(value))
+		throw new ProjectionWorkerInputError("projection worker received an invalid vector");
+	const bytes = new Uint8Array(value.length / 2);
+	for (let index = 0; index < bytes.length; index += 1) {
+		bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+	}
+	return bytes;
+}
+
+function parseInput(value: unknown): ProjectionWorkerInput {
+	if (typeof value !== "object" || value === null)
+		throw new ProjectionWorkerInputError("projection worker input is not an object");
+	const input = value as Record<string, unknown>;
+	if (input.dimensions !== 2 && input.dimensions !== 3) {
+		throw new ProjectionWorkerInputError("projection worker dimensions must be 2 or 3");
+	}
+	if (!Array.isArray(input.rows)) throw new ProjectionWorkerInputError("projection worker rows are missing");
+	const rows = input.rows.map((raw, index) => {
+		if (typeof raw !== "object" || raw === null)
+			throw new ProjectionWorkerInputError(`projection worker row ${index} is invalid`);
+		const row = raw as Record<string, unknown>;
+		if (typeof row.vectorHex !== "string")
+			throw new ProjectionWorkerInputError(`projection worker row ${index} has no vector`);
+		return {
+			id: String(row.id ?? ""),
+			content: String(row.content ?? ""),
+			who: typeof row.who === "string" ? row.who : null,
+			importance: typeof row.importance === "number" ? row.importance : null,
+			type: typeof row.type === "string" ? row.type : null,
+			tags: typeof row.tags === "string" ? row.tags : null,
+			pinned: typeof row.pinned === "number" ? row.pinned : null,
+			source_type: typeof row.source_type === "string" ? row.source_type : null,
+			source_id: typeof row.source_id === "string" ? row.source_id : null,
+			created_at: String(row.created_at ?? ""),
+			vectorHex: row.vectorHex,
+			dimensions: typeof row.dimensions === "number" ? row.dimensions : null,
+		};
+	});
+	return { dimensions: input.dimensions, rows };
+}
+
+export function computeProjectionWorkerInput(input: ProjectionWorkerInput): ProjectionResult {
+	return computeProjectionFromRows(
+		input.rows.map(({ vectorHex, ...row }) => ({ ...row, vector: hexToBytes(vectorHex) })),
+		input.dimensions,
+	);
+}
+
+async function readStdin(): Promise<string> {
+	const chunks: string[] = [];
+	const reader = createInterface({ input: process.stdin });
+	for await (const line of reader) chunks.push(line);
+	return chunks.join("\n");
+}
+
+export async function runEmbeddingProjectionWorker(): Promise<void> {
+	const encoded = await readStdin();
+	const input = parseInput(JSON.parse(encoded));
+	if (process.env.SIGNET_PROJECTION_WORKER_HOLD === "1") {
+		await new Promise<void>(() => setInterval(() => undefined, 1_000));
+	}
+	const result = computeProjectionWorkerInput(input);
+	process.stdout.write(`${JSON.stringify({ type: "result", result })}\n`);
+}
+
+const entrypoint = process.argv[1] ?? "";
+if (
+	process.env.SIGNET_EMBEDDING_PROJECTION_WORKER === "1" &&
+	(entrypoint.endsWith("embedding-projection-worker.ts") ||
+		entrypoint.endsWith("embedding-projection-worker.js") ||
+		entrypoint.endsWith("embedding-projection-worker.mjs"))
+) {
+	void runEmbeddingProjectionWorker().catch((error: unknown) => {
+		process.stderr.write(`${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -10,7 +10,8 @@ import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
 import type { DbOwnerClient } from "../db-owner-client";
 import { DB_OWNER_MAX_WORK_UNITS } from "../db-owner-protocol";
-import { dbOwnerQuery } from "../db-owner-runtime";
+import { dbOwnerQuery, getDbRecallOwner } from "../db-owner-runtime";
+import { ownerReadAll, ownerReadOne } from "../db-owner-sql";
 import { hybridRecallThroughDbOwner, vectorSearchThroughDbOwner } from "../db-owner-recall";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type ReadDb, type WriteDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "../db-accessor";
@@ -65,12 +66,24 @@ import {
 	txRecoverMemory,
 	txSupersedeMemory,
 } from "../transactions";
-import { cacheProjection, computeProjection, computeProjectionForQuery, getCachedProjection } from "../umap-projection";
+import {
+	buildProjectionWhere,
+	cacheProjection,
+	parseCachedProjection,
+	type ProjectionFilters,
+} from "../umap-projection";
+import {
+	PROJECTION_DEADLINE_MS,
+	PROJECTION_MAX_ROWS,
+	ProjectionAdmissionError,
+	ProjectionJobManager,
+	ProjectionWorkerCancelledError,
+	runProjectionWorker,
+} from "../embedding-projection-jobs";
 import {
 	AGENTS_DIR,
 	INTERNAL_SELF_HOST,
 	PORT,
-	PROJECTION_ERROR_TTL_MS,
 	authBatchForgetLimiter,
 	authConfig,
 	authForgetLimiter,
@@ -78,8 +91,6 @@ import {
 	authRecallLlmLimiter,
 	embeddingTrackerHandle,
 	hasMemoriesSessionIdColumnCache,
-	projectionErrors,
-	projectionInFlight,
 } from "./state";
 
 import {
@@ -119,7 +130,7 @@ async function withActiveEmbeddingConfig(cfg: ResolvedMemoryConfig): Promise<Res
 	return {
 		...cfg,
 		embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding), {
-			siteToken: "routes/memory-routes.ts:121",
+			siteToken: "routes/memory-routes.ts:132",
 		}),
 	};
 }
@@ -129,6 +140,115 @@ export const MEMORY_CAPTURE_MAX_IN_FLIGHT = 8;
 const FORGET_CONFIRM_THRESHOLD = 25;
 const SOFT_DELETE_RETENTION_DAYS = 30;
 const SOFT_DELETE_RETENTION_MS = SOFT_DELETE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+const projectionJobs = new ProjectionJobManager();
+
+const PROJECTION_FROM_SQL = `
+	FROM embeddings e
+	INNER JOIN memories m ON m.id = e.source_id
+	WHERE e.source_type = 'memory'
+  AND e.vector IS NOT NULL AND typeof(e.vector) = 'blob' AND length(e.vector) > 0
+`;
+const PROJECTION_SNAPSHOT_BATCH = 32;
+
+interface ProjectionSnapshotRow {
+	readonly id: string;
+	readonly content: string;
+	readonly who: string | null;
+	readonly importance: number | null;
+	readonly type: string | null;
+	readonly tags: string | null;
+	readonly pinned: number | null;
+	readonly source_type: string | null;
+	readonly source_id: string | null;
+	readonly created_at: string;
+	readonly vectorHex: string;
+	readonly dimensions: number | null;
+}
+
+interface ProjectionSnapshot {
+	readonly rows: readonly ProjectionSnapshotRow[];
+	readonly total: number;
+	readonly limit: number;
+	readonly offset: number;
+	readonly hasMore: boolean;
+}
+
+async function loadProjectionSnapshot(
+	owner: DbOwnerClient,
+	filters: ProjectionFilters | undefined,
+	requestedLimit: number | undefined,
+	offset: number,
+): Promise<ProjectionSnapshot> {
+	const { clause, params } = buildProjectionWhere(filters);
+	const limit = Math.min(requestedLimit ?? PROJECTION_MAX_ROWS, PROJECTION_MAX_ROWS);
+	const countPromise = ownerReadOne<{ readonly count: number }>(
+		owner,
+		`SELECT COUNT(*) AS count ${PROJECTION_FROM_SQL}${clause}`,
+		params,
+		{ operation: "embedding_projection.count", deadlineMs: 2_000, estimatedWorkUnits: 1 },
+	);
+	const rows: ProjectionSnapshotRow[] = [];
+	let nextOffset = offset;
+	while (rows.length < limit) {
+		const pageLimit = Math.min(PROJECTION_SNAPSHOT_BATCH, limit - rows.length);
+		const page = await ownerReadAll<ProjectionSnapshotRow>(
+			owner,
+			`SELECT m.id, substr(m.content, 1, 4096) AS content, m.who, m.importance, m.type, m.tags, m.pinned,
+			        m.source_type, m.source_id, m.created_at, hex(e.vector) AS vectorHex, e.dimensions
+			 ${PROJECTION_FROM_SQL}${clause} ORDER BY m.created_at DESC LIMIT ? OFFSET ?`,
+			[...params, pageLimit, nextOffset],
+			{ operation: "embedding_projection.snapshot", deadlineMs: 5_000, estimatedWorkUnits: pageLimit },
+		);
+		rows.push(...page);
+		nextOffset += page.length;
+		if (page.length < pageLimit) break;
+	}
+	const countRow = await countPromise;
+	const total = countRow !== null && typeof countRow.count === "number" ? countRow.count : 0;
+	return { rows, total, limit, offset, hasMore: offset + rows.length < total };
+}
+
+function projectionFiltersFromQuery(filters: {
+	readonly query: string | undefined;
+	readonly who: readonly string[];
+	readonly types: readonly string[];
+	readonly sourceTypes: readonly string[];
+	readonly tags: readonly string[];
+	readonly pinned: boolean | undefined;
+	readonly since: string | undefined;
+	readonly until: string | undefined;
+	readonly importanceMin: number | undefined;
+	readonly importanceMax: number | undefined;
+}): ProjectionFilters | undefined {
+	const value: ProjectionFilters = filters;
+	return Object.values(value).some((item) => (Array.isArray(item) ? item.length > 0 : item !== undefined))
+		? value
+		: undefined;
+}
+
+function projectionJobResponse(job: ReturnType<typeof projectionJobs.get>): Response | null {
+	if (job === null) return null;
+	const metadata = {
+		jobId: job.jobId,
+		dimensions: job.dimensions,
+		...(job.total !== undefined ? { total: job.total } : {}),
+		...(job.count !== undefined ? { count: job.count } : {}),
+		...(job.limit !== undefined ? { limit: job.limit } : {}),
+		...(job.offset !== undefined ? { offset: job.offset } : {}),
+		...(job.hasMore !== undefined ? { hasMore: job.hasMore } : {}),
+		...(job.sampled !== undefined ? { sampled: job.sampled } : {}),
+	};
+	if (job.status === "ready" && job.result !== undefined) {
+		return Response.json({ status: "ready", ...metadata, nodes: job.result.nodes, edges: job.result.edges });
+	}
+	if (job.status === "timeout")
+		return Response.json({ status: "timeout", ...metadata, message: job.message }, { status: 504 });
+	if (job.status === "cancelled")
+		return Response.json({ status: "cancelled", ...metadata, message: job.message }, { status: 409 });
+	if (job.status === "error")
+		return Response.json({ status: "error", ...metadata, message: job.message }, { status: 500 });
+	return Response.json({ status: job.status, ...metadata }, { status: 202 });
+}
 
 export interface MemoryRoutesDeps {
 	readonly aggregateRecall?: typeof aggregateRecall;
@@ -801,6 +921,12 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	app.use("/api/memory/recall", async (c, next) => {
 		return requirePermission("recall", authConfig)(c, next);
 	});
+	app.use("/api/embeddings", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
+	app.use("/api/embeddings/*", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
 
 	async function recordRequestOperation(
 		c: Context,
@@ -1078,7 +1204,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						},
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1022" },
+				{ siteToken: "routes/memory-routes.ts:1148" },
 			);
 
 			return c.json(result);
@@ -1123,7 +1249,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						)
 						.map(({ agent_id: _agentId, ...row }) => row);
 				},
-				{ siteToken: "routes/memory-routes.ts:1102" },
+				{ siteToken: "routes/memory-routes.ts:1228" },
 			);
 			return c.json({ memories });
 		} catch (e) {
@@ -1233,7 +1359,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						highUsed: filterSafe(highUsed).map(({ agent_id: _agentId, ...row }) => row),
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1157" },
+				{ siteToken: "routes/memory-routes.ts:1283" },
 			);
 			return c.json({ agentId, minSessions, limit, ...slices });
 		} catch (e) {
@@ -1263,7 +1389,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						readPolicy: agentScope.readPolicy,
 						policyGroup: agentScope.policyGroup ?? undefined,
 					}),
-				{ siteToken: "routes/memory-routes.ts:1258" },
+				{ siteToken: "routes/memory-routes.ts:1384" },
 			);
 			return c.json(timeline);
 		} catch (e) {
@@ -1435,7 +1561,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							return publicRow;
 						});
 				},
-				{ siteToken: "routes/memory-routes.ts:1368" },
+				{ siteToken: "routes/memory-routes.ts:1494" },
 			);
 
 			recordRecallOutcome({
@@ -1669,7 +1795,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1670" },
+				{ siteToken: "routes/memory-routes.ts:1796" },
 			);
 			if (baseIdempotencyMemory) {
 				return c.json({ error: "idempotencyKey already used for non-chunk content" }, 409);
@@ -1677,7 +1803,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const existingChunks = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1678" },
+				{ siteToken: "routes/memory-routes.ts:1804" },
 			);
 			if (existingChunks.length > 0) {
 				const groupIds = new Set(existingChunks.map((row) => row.sourceId).filter((id): id is string => !!id));
@@ -1711,7 +1837,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				contentHashes.add(plan.normalized.contentHash);
 				const byHash = await getDbAccessor().withReadDbAsync(
 					async (db) => getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope),
-					{ siteToken: "routes/memory-routes.ts:1712" },
+					{ siteToken: "routes/memory-routes.ts:1838" },
 				);
 				if (byHash) {
 					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
@@ -1918,7 +2044,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				? []
 				: await getDbAccessor().withReadDbAsync(
 						async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-						{ siteToken: "routes/memory-routes.ts:1919" },
+						{ siteToken: "routes/memory-routes.ts:2045" },
 					);
 		if (chunkedIdempotencyMemory.length > 0) {
 			return c.json({ error: "idempotencyKey already used for chunked content" }, 409);
@@ -2047,7 +2173,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						if (byIdempotencyKey) return byIdempotencyKey;
 						return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 					},
-					{ siteToken: "routes/memory-routes.ts:2044" },
+					{ siteToken: "routes/memory-routes.ts:2170" },
 				);
 				if (existing) {
 					c.header("x-signet-operation-skipped", "1");
@@ -2291,7 +2417,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					: null;
 				return { row, safety };
 			},
-			{ siteToken: "routes/memory-routes.ts:2263" },
+			{ siteToken: "routes/memory-routes.ts:2389" },
 		);
 		const row = memoryRead.row;
 
@@ -2484,7 +2610,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				// order — creation time is.
 				return [...byId.values()].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.version - b.version);
 			},
-			{ siteToken: "routes/memory-routes.ts:2442" },
+			{ siteToken: "routes/memory-routes.ts:2568" },
 		);
 
 		return c.json({
@@ -3651,7 +3777,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
         LIMIT 1
       `)
 						.get(id) as { vector: Buffer } | undefined,
-				{ siteToken: "routes/memory-routes.ts:3641" },
+				{ siteToken: "routes/memory-routes.ts:3767" },
 			);
 
 			if (!embeddingRow) {
@@ -3673,7 +3799,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const searchData =
 				recallOwner === undefined
 					? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions), {
-							siteToken: "routes/memory-routes.ts:3675",
+							siteToken: "routes/memory-routes.ts:3801",
 						})
 					: await vectorSearchThroughDbOwner(recallOwner, [...queryVector], searchOptions);
 
@@ -3716,7 +3842,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						}),
 					);
 				},
-				{ siteToken: "routes/memory-routes.ts:3693" },
+				{ siteToken: "routes/memory-routes.ts:3819" },
 			);
 
 			const rowMap = new Map(rows.map((r) => [r.id, r]));
@@ -3811,7 +3937,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 					return { total: totalRow?.count ?? 0, rows: rowData };
 				},
-				{ siteToken: "routes/memory-routes.ts:3774" },
+				{ siteToken: "routes/memory-routes.ts:3900" },
 			);
 
 			const embeddings = rows.map((row) => ({
@@ -3863,7 +3989,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					? { ...state, coverage: stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint) }
 					: state;
 			},
-			{ siteToken: "routes/memory-routes.ts:3859" },
+			{ siteToken: "routes/memory-routes.ts:3985" },
 		);
 		return c.json({ ...status, tracker, index });
 	});
@@ -3876,7 +4002,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const providerStatus = await checkEmbeddingProvider(cfg.embedding);
 		const report = await getDbAccessor().withReadDbAsync(
 			async (db) => buildEmbeddingHealth(db, cfg.embedding, providerStatus),
-			{ siteToken: "routes/memory-routes.ts:3877" },
+			{ siteToken: "routes/memory-routes.ts:4003" },
 		);
 		return c.json(report);
 	});
@@ -3884,10 +4010,22 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/embeddings/projection
 	// =========================================================================
+	app.delete("/api/embeddings/projection/:jobId", (c) => {
+		const job = projectionJobs.cancel(c.req.param("jobId"));
+		if (job === null) return c.json({ status: "not_found" }, 404);
+		return c.json({ status: "cancelled", jobId: job.jobId, dimensions: job.dimensions }, 409);
+	});
+
 	app.get("/api/embeddings/projection", async (c) => {
+		const requestedJobId = parseOptionalString(c.req.query("jobId"));
+		if (requestedJobId !== undefined) {
+			const response = projectionJobResponse(projectionJobs.get(requestedJobId));
+			return response ?? c.json({ status: "not_found", jobId: requestedJobId }, 404);
+		}
+
 		const dimParam = c.req.query("dimensions");
 		const nComponents: 2 | 3 = dimParam === "3" ? 3 : 2;
-		const limit = parseOptionalBoundedInt(c.req.query("limit"), 1, 5000);
+		const limit = parseOptionalBoundedInt(c.req.query("limit"), 1, PROJECTION_MAX_ROWS);
 		const offset = parseOptionalBoundedInt(c.req.query("offset"), 0, 100000) ?? 0;
 
 		const query = parseOptionalString(c.req.query("q"));
@@ -3922,130 +4060,120 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			importanceMax = swap;
 		}
 
-		const hasFilters =
-			query !== undefined ||
-			whoFilters.length > 0 ||
-			typeFilters.length > 0 ||
-			sourceTypeFilters.length > 0 ||
-			tagFilters.length > 0 ||
-			pinned !== undefined ||
-			since !== undefined ||
-			until !== undefined ||
-			importanceMin !== undefined ||
-			importanceMax !== undefined;
-		const useCachedProjection = !hasFilters && limit === undefined && offset === 0;
+		const filters = projectionFiltersFromQuery({
+			query,
+			who: whoFilters,
+			types: typeFilters,
+			sourceTypes: sourceTypeFilters,
+			tags: tagFilters,
+			pinned,
+			since,
+			until,
+			importanceMin,
+			importanceMax,
+		});
+		const useCachedProjection = filters === undefined && limit === undefined && offset === 0;
+		const owner = recallOwner ?? (await getDbRecallOwner());
 
-		if (!useCachedProjection) {
-			try {
-				const projection = await getDbAccessor().withReadDbAsync(
-					async (db) =>
-						computeProjectionForQuery(db, nComponents, {
-							limit,
-							offset,
-							filters: hasFilters
-								? {
-										query,
-										who: whoFilters,
-										types: typeFilters,
-										sourceTypes: sourceTypeFilters,
-										tags: tagFilters,
-										pinned,
-										since,
-										until,
-										importanceMin,
-										importanceMax,
-									}
-								: undefined,
-						}),
-					{ siteToken: "routes/memory-routes.ts:3940" },
-				);
-
+		if (useCachedProjection) {
+			const [cachedRow, countRow] = await Promise.all([
+				ownerReadOne<{
+					readonly dimensions: number;
+					readonly embedding_count: number;
+					readonly payload: string;
+					readonly created_at: string;
+				}>(
+					owner,
+					"SELECT dimensions, embedding_count, payload, created_at FROM umap_cache WHERE dimensions = ? LIMIT 1",
+					[nComponents],
+					{ operation: "embedding_projection.cache", deadlineMs: 2_000, estimatedWorkUnits: 1 },
+				),
+				ownerReadOne<{ readonly count: number }>(
+					owner,
+					"SELECT COUNT(*) AS count FROM embeddings WHERE source_type = 'memory' AND typeof(vector) = 'blob'",
+					[],
+					{ operation: "embedding_projection.count", deadlineMs: 2_000, estimatedWorkUnits: 1 },
+				),
+			]);
+			const cached = parseCachedProjection(cachedRow);
+			const total = countRow?.count ?? 0;
+			if (cached !== null && cached.embeddingCount === total) {
 				return c.json({
 					status: "ready",
 					dimensions: nComponents,
-					count: projection.count,
-					total: projection.total,
-					limit: projection.limit,
-					offset: projection.offset,
-					hasMore: projection.hasMore,
-					nodes: projection.result.nodes,
-					edges: projection.result.edges,
+					count: cached.result.nodes.length,
+					total,
+					limit: PROJECTION_MAX_ROWS,
+					offset: 0,
+					hasMore: total > PROJECTION_MAX_ROWS,
+					sampled: total > PROJECTION_MAX_ROWS,
+					nodes: cached.result.nodes,
+					edges: cached.result.edges,
+					cachedAt: cached.cachedAt,
 				});
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				return c.json({ status: "error", message }, 500);
 			}
 		}
 
-		const { cached, total } = await getDbAccessor().withReadDbAsync(
-			async (db) => {
-				const cachedResult = getCachedProjection(db, nComponents);
-				const countRow = db.prepare("SELECT COUNT(*) as count FROM embeddings WHERE source_type = 'memory'").get();
-				const count =
-					typeof countRow === "object" && countRow !== null && "count" in countRow && typeof countRow.count === "number"
-						? countRow.count
-						: 0;
-				return { cached: cachedResult, total: count };
-			},
-			{ siteToken: "routes/memory-routes.ts:3980" },
-		);
-
-		if (cached !== null && cached.embeddingCount === total) {
-			return c.json({
-				status: "ready",
-				dimensions: nComponents,
-				count: total,
-				total,
-				limit: total,
-				offset: 0,
-				hasMore: false,
-				nodes: cached.result.nodes,
-				edges: cached.result.edges,
-				cachedAt: cached.cachedAt,
-			});
-		}
-
-		const recentError = projectionErrors.get(nComponents);
-		if (recentError) {
-			if (Date.now() > recentError.expires) {
-				projectionErrors.delete(nComponents);
-			} else {
-				return c.json({ status: "error", message: recentError.message }, 500);
-			}
-		}
-
-		if (!projectionInFlight.has(nComponents)) {
-			projectionErrors.delete(nComponents);
-			const computation = (async () => {
-				try {
-					const result = await getDbAccessor().withReadDbAsync(async (db) => computeProjection(db, nComponents), {
-						siteToken: "routes/memory-routes.ts:4021",
+		const snapshotLimit = Math.min(limit ?? PROJECTION_MAX_ROWS, PROJECTION_MAX_ROWS);
+		const key = JSON.stringify({ dimensions: nComponents, limit: snapshotLimit, offset, filters });
+		try {
+			const job = projectionJobs.start(
+				key,
+				nComponents,
+				() => {
+					let worker: ReturnType<typeof runProjectionWorker> | null = null;
+					let cancelled = false;
+					const snapshotPromise = loadProjectionSnapshot(owner, filters, snapshotLimit, offset);
+					const result = snapshotPromise.then(async (snapshot) => {
+						if (cancelled) throw new ProjectionWorkerCancelledError();
+						projectionJobs.updateMetadataByKey(key, {
+							total: snapshot.total,
+							count: snapshot.rows.length,
+							limit: snapshot.limit,
+							offset: snapshot.offset,
+							hasMore: snapshot.hasMore,
+							sampled: snapshot.hasMore,
+						});
+						worker = runProjectionWorker(
+							{ dimensions: nComponents, rows: snapshot.rows },
+							{ timeoutMs: PROJECTION_DEADLINE_MS },
+						);
+						const projection = await worker.result;
+						if (useCachedProjection) {
+							await runWriteTxAsync(getDbAccessor(), (db) =>
+								cacheProjection(db, nComponents, projection, snapshot.total),
+							);
+						}
+						return projection;
 					});
-					const count = await getDbAccessor().withReadDbAsync(
-						async (db) => {
-							const row = db.prepare("SELECT COUNT(*) as count FROM embeddings WHERE source_type = 'memory'").get();
-							return typeof row === "object" && row !== null && "count" in row && typeof row.count === "number"
-								? row.count
-								: 0;
+					return {
+						result,
+						cancel: () => {
+							cancelled = true;
+							worker?.cancel();
 						},
-						{ siteToken: "routes/memory-routes.ts:4024" },
-					);
-					await runWriteTxAsync(getDbAccessor(), (db) => cacheProjection(db, nComponents, result, count));
-				} catch (err) {
-					const msg = err instanceof Error ? err.message : String(err);
-					logger.error("projection", "UMAP computation failed", err instanceof Error ? err : new Error(msg));
-					projectionErrors.set(nComponents, {
-						message: msg,
-						expires: Date.now() + PROJECTION_ERROR_TTL_MS,
-					});
-				} finally {
-					projectionInFlight.delete(nComponents);
-				}
-			})();
-			projectionInFlight.set(nComponents, computation);
+					};
+				},
+				{ limit: snapshotLimit, offset },
+			);
+			return c.json(
+				{
+					status: "accepted",
+					jobId: job.jobId,
+					dimensions: nComponents,
+					limit: snapshotLimit,
+					offset,
+				},
+				202,
+			);
+		} catch (error) {
+			if (error instanceof ProjectionAdmissionError) {
+				return c.json({ status: "overloaded", message: error.message }, 429);
+			}
+			const message = error instanceof Error ? error.message : String(error);
+			logger.error("projection", "UMAP computation failed", error instanceof Error ? error : new Error(message));
+			return c.json({ status: "error", message }, 500);
 		}
-
-		return c.json({ status: "computing", dimensions: nComponents }, 202);
 	});
 
 	// =========================================================================

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -8,10 +8,10 @@ import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "../agent-i
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
-import type { DbOwnerClient } from "../db-owner-client";
+import { DbOwnerCancelledError, DbOwnerDeadlineError, type DbOwnerClient } from "../db-owner-client";
 import { DB_OWNER_MAX_WORK_UNITS } from "../db-owner-protocol";
 import { dbOwnerQuery, getDbRecallOwner } from "../db-owner-runtime";
-import { ownerReadAll, ownerReadOne } from "../db-owner-sql";
+import { ownerBatchHandle, ownerReadAllHandle, ownerReadOne, ownerReadOneHandle } from "../db-owner-sql";
 import { hybridRecallThroughDbOwner, vectorSearchThroughDbOwner } from "../db-owner-recall";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type ReadDb, type WriteDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "../db-accessor";
@@ -66,19 +66,15 @@ import {
 	txRecoverMemory,
 	txSupersedeMemory,
 } from "../transactions";
-import {
-	buildProjectionWhere,
-	cacheProjection,
-	parseCachedProjection,
-	type ProjectionFilters,
-} from "../umap-projection";
+import { buildProjectionWhere, parseCachedProjection, type ProjectionFilters } from "../umap-projection";
 import {
 	PROJECTION_DEADLINE_MS,
 	PROJECTION_MAX_ROWS,
 	ProjectionAdmissionError,
 	ProjectionJobManager,
 	ProjectionWorkerCancelledError,
-	runProjectionWorker,
+	ProjectionWorkerTimeoutError,
+	runBoundedProjectionJob,
 } from "../embedding-projection-jobs";
 import {
 	AGENTS_DIR,
@@ -173,31 +169,73 @@ interface ProjectionSnapshot {
 	readonly hasMore: boolean;
 }
 
+interface ProjectionSnapshotControl {
+	readonly remainingMs: () => number;
+	readonly isCancelled: () => boolean;
+	readonly onCancel: (callback: () => void) => void;
+}
+
+function projectionOwnerDeadline(control: ProjectionSnapshotControl, operationMs: number): number {
+	const remainingMs = Math.min(operationMs, control.remainingMs());
+	if (remainingMs <= 0) throw new Error("Embedding projection deadline expired before DB owner work started");
+	return Math.max(1, Math.floor(remainingMs));
+}
+
+async function projectionOwnerResult<Result>(
+	control: ProjectionSnapshotControl,
+	handle: { readonly result: Promise<Result>; readonly cancel: () => void },
+): Promise<Result> {
+	control.onCancel(handle.cancel);
+	try {
+		return await handle.result;
+	} catch (error) {
+		if (error instanceof DbOwnerCancelledError || control.isCancelled()) throw new ProjectionWorkerCancelledError();
+		if (error instanceof DbOwnerDeadlineError || control.remainingMs() <= 0)
+			throw new ProjectionWorkerTimeoutError(PROJECTION_DEADLINE_MS);
+		throw error;
+	}
+}
+
 async function loadProjectionSnapshot(
 	owner: DbOwnerClient,
 	filters: ProjectionFilters | undefined,
 	requestedLimit: number | undefined,
 	offset: number,
+	control: ProjectionSnapshotControl,
 ): Promise<ProjectionSnapshot> {
 	const { clause, params } = buildProjectionWhere(filters);
 	const limit = Math.min(requestedLimit ?? PROJECTION_MAX_ROWS, PROJECTION_MAX_ROWS);
-	const countPromise = ownerReadOne<{ readonly count: number }>(
-		owner,
-		`SELECT COUNT(*) AS count ${PROJECTION_FROM_SQL}${clause}`,
-		params,
-		{ operation: "embedding_projection.count", deadlineMs: 2_000, estimatedWorkUnits: 1 },
+	const countPromise = projectionOwnerResult(
+		control,
+		ownerReadOneHandle<{ readonly count: number }>(
+			owner,
+			`SELECT COUNT(*) AS count ${PROJECTION_FROM_SQL}${clause}`,
+			params,
+			{
+				operation: "embedding_projection.count",
+				deadlineMs: projectionOwnerDeadline(control, 2_000),
+				estimatedWorkUnits: 1,
+			},
+		),
 	);
 	const rows: ProjectionSnapshotRow[] = [];
 	let nextOffset = offset;
 	while (rows.length < limit) {
 		const pageLimit = Math.min(PROJECTION_SNAPSHOT_BATCH, limit - rows.length);
-		const page = await ownerReadAll<ProjectionSnapshotRow>(
-			owner,
-			`SELECT m.id, substr(m.content, 1, 4096) AS content, m.who, m.importance, m.type, m.tags, m.pinned,
-			        m.source_type, m.source_id, m.created_at, hex(e.vector) AS vectorHex, e.dimensions
-			 ${PROJECTION_FROM_SQL}${clause} ORDER BY m.created_at DESC LIMIT ? OFFSET ?`,
-			[...params, pageLimit, nextOffset],
-			{ operation: "embedding_projection.snapshot", deadlineMs: 5_000, estimatedWorkUnits: pageLimit },
+		const page = await projectionOwnerResult(
+			control,
+			ownerReadAllHandle<ProjectionSnapshotRow>(
+				owner,
+				`SELECT m.id, substr(m.content, 1, 4096) AS content, m.who, m.importance, m.type, m.tags, m.pinned,
+				        m.source_type, m.source_id, m.created_at, hex(e.vector) AS vectorHex, e.dimensions
+				 ${PROJECTION_FROM_SQL}${clause} ORDER BY m.created_at DESC LIMIT ? OFFSET ?`,
+				[...params, pageLimit, nextOffset],
+				{
+					operation: "embedding_projection.snapshot",
+					deadlineMs: projectionOwnerDeadline(control, 5_000),
+					estimatedWorkUnits: pageLimit,
+				},
+			),
 		);
 		rows.push(...page);
 		nextOffset += page.length;
@@ -4013,7 +4051,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	app.delete("/api/embeddings/projection/:jobId", (c) => {
 		const job = projectionJobs.cancel(c.req.param("jobId"));
 		if (job === null) return c.json({ status: "not_found" }, 404);
-		return c.json({ status: "cancelled", jobId: job.jobId, dimensions: job.dimensions }, 409);
+		return c.json({ status: "cancelled", jobId: job.jobId, dimensions: job.dimensions });
 	});
 
 	app.get("/api/embeddings/projection", async (c) => {
@@ -4117,43 +4155,52 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const snapshotLimit = Math.min(limit ?? PROJECTION_MAX_ROWS, PROJECTION_MAX_ROWS);
 		const key = JSON.stringify({ dimensions: nComponents, limit: snapshotLimit, offset, filters });
 		try {
+			let snapshotTotal = 0;
 			const job = projectionJobs.start(
 				key,
 				nComponents,
-				() => {
-					let worker: ReturnType<typeof runProjectionWorker> | null = null;
-					let cancelled = false;
-					const snapshotPromise = loadProjectionSnapshot(owner, filters, snapshotLimit, offset);
-					const result = snapshotPromise.then(async (snapshot) => {
-						if (cancelled) throw new ProjectionWorkerCancelledError();
-						projectionJobs.updateMetadataByKey(key, {
-							total: snapshot.total,
-							count: snapshot.rows.length,
-							limit: snapshot.limit,
-							offset: snapshot.offset,
-							hasMore: snapshot.hasMore,
-							sampled: snapshot.hasMore,
-						});
-						worker = runProjectionWorker(
-							{ dimensions: nComponents, rows: snapshot.rows },
-							{ timeoutMs: PROJECTION_DEADLINE_MS },
-						);
-						const projection = await worker.result;
-						if (useCachedProjection) {
-							await runWriteTxAsync(getDbAccessor(), (db) =>
-								cacheProjection(db, nComponents, projection, snapshot.total),
-							);
-						}
-						return projection;
-					});
-					return {
-						result,
-						cancel: () => {
-							cancelled = true;
-							worker?.cancel();
+				() =>
+					runBoundedProjectionJob(
+						async (control) => {
+							const snapshot = await loadProjectionSnapshot(owner, filters, snapshotLimit, offset, control);
+							snapshotTotal = snapshot.total;
+							projectionJobs.updateMetadataByKey(key, {
+								total: snapshot.total,
+								count: snapshot.rows.length,
+								limit: snapshot.limit,
+								offset: snapshot.offset,
+								hasMore: snapshot.hasMore,
+								sampled: snapshot.hasMore,
+							});
+							return { dimensions: nComponents, rows: snapshot.rows };
 						},
-					};
-				},
+						{
+							deadlineMs: PROJECTION_DEADLINE_MS,
+							publish: async (projection, serializedResult, control) => {
+								if (!useCachedProjection) return;
+								const cacheHandle = ownerBatchHandle(
+									owner,
+									[
+										{ sql: "DELETE FROM umap_cache WHERE dimensions = ?", params: [nComponents] },
+										{
+											sql: "INSERT INTO umap_cache (dimensions, embedding_count, payload, created_at) VALUES (?, ?, ?, ?)",
+											params: [nComponents, snapshotTotal, serializedResult, new Date().toISOString()],
+										},
+									],
+									{
+										operation: "embedding_projection.cache_publish",
+										lane: "write",
+										workloadClass: "foreground",
+										deadlineMs: projectionOwnerDeadline(control, 2_000),
+										estimatedWorkUnits: Math.max(1, Math.ceil(serializedResult.length / 65_536)),
+									},
+								);
+								control.onCancel(cacheHandle.cancel);
+								await cacheHandle.result;
+								void projection;
+							},
+						},
+					),
 				{ limit: snapshotLimit, offset },
 			);
 			return c.json(

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -126,7 +126,7 @@ async function withActiveEmbeddingConfig(cfg: ResolvedMemoryConfig): Promise<Res
 	return {
 		...cfg,
 		embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding), {
-			siteToken: "routes/memory-routes.ts:132",
+			siteToken: "routes/memory-routes.ts:128",
 		}),
 	};
 }
@@ -1242,7 +1242,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						},
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1148" },
+				{ siteToken: "routes/memory-routes.ts:1186" },
 			);
 
 			return c.json(result);
@@ -1287,7 +1287,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						)
 						.map(({ agent_id: _agentId, ...row }) => row);
 				},
-				{ siteToken: "routes/memory-routes.ts:1228" },
+				{ siteToken: "routes/memory-routes.ts:1266" },
 			);
 			return c.json({ memories });
 		} catch (e) {
@@ -1397,7 +1397,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						highUsed: filterSafe(highUsed).map(({ agent_id: _agentId, ...row }) => row),
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1283" },
+				{ siteToken: "routes/memory-routes.ts:1321" },
 			);
 			return c.json({ agentId, minSessions, limit, ...slices });
 		} catch (e) {
@@ -1427,7 +1427,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						readPolicy: agentScope.readPolicy,
 						policyGroup: agentScope.policyGroup ?? undefined,
 					}),
-				{ siteToken: "routes/memory-routes.ts:1384" },
+				{ siteToken: "routes/memory-routes.ts:1422" },
 			);
 			return c.json(timeline);
 		} catch (e) {
@@ -1599,7 +1599,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							return publicRow;
 						});
 				},
-				{ siteToken: "routes/memory-routes.ts:1494" },
+				{ siteToken: "routes/memory-routes.ts:1532" },
 			);
 
 			recordRecallOutcome({
@@ -1833,7 +1833,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1796" },
+				{ siteToken: "routes/memory-routes.ts:1834" },
 			);
 			if (baseIdempotencyMemory) {
 				return c.json({ error: "idempotencyKey already used for non-chunk content" }, 409);
@@ -1841,7 +1841,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const existingChunks = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1804" },
+				{ siteToken: "routes/memory-routes.ts:1842" },
 			);
 			if (existingChunks.length > 0) {
 				const groupIds = new Set(existingChunks.map((row) => row.sourceId).filter((id): id is string => !!id));
@@ -1875,7 +1875,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				contentHashes.add(plan.normalized.contentHash);
 				const byHash = await getDbAccessor().withReadDbAsync(
 					async (db) => getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope),
-					{ siteToken: "routes/memory-routes.ts:1838" },
+					{ siteToken: "routes/memory-routes.ts:1876" },
 				);
 				if (byHash) {
 					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
@@ -2082,7 +2082,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				? []
 				: await getDbAccessor().withReadDbAsync(
 						async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-						{ siteToken: "routes/memory-routes.ts:2045" },
+						{ siteToken: "routes/memory-routes.ts:2083" },
 					);
 		if (chunkedIdempotencyMemory.length > 0) {
 			return c.json({ error: "idempotencyKey already used for chunked content" }, 409);
@@ -2211,7 +2211,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						if (byIdempotencyKey) return byIdempotencyKey;
 						return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 					},
-					{ siteToken: "routes/memory-routes.ts:2170" },
+					{ siteToken: "routes/memory-routes.ts:2208" },
 				);
 				if (existing) {
 					c.header("x-signet-operation-skipped", "1");
@@ -2455,7 +2455,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					: null;
 				return { row, safety };
 			},
-			{ siteToken: "routes/memory-routes.ts:2389" },
+			{ siteToken: "routes/memory-routes.ts:2427" },
 		);
 		const row = memoryRead.row;
 
@@ -2648,7 +2648,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				// order — creation time is.
 				return [...byId.values()].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.version - b.version);
 			},
-			{ siteToken: "routes/memory-routes.ts:2568" },
+			{ siteToken: "routes/memory-routes.ts:2606" },
 		);
 
 		return c.json({
@@ -3815,7 +3815,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
         LIMIT 1
       `)
 						.get(id) as { vector: Buffer } | undefined,
-				{ siteToken: "routes/memory-routes.ts:3767" },
+				{ siteToken: "routes/memory-routes.ts:3805" },
 			);
 
 			if (!embeddingRow) {
@@ -3837,7 +3837,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const searchData =
 				recallOwner === undefined
 					? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions), {
-							siteToken: "routes/memory-routes.ts:3801",
+							siteToken: "routes/memory-routes.ts:3839",
 						})
 					: await vectorSearchThroughDbOwner(recallOwner, [...queryVector], searchOptions);
 
@@ -3880,7 +3880,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						}),
 					);
 				},
-				{ siteToken: "routes/memory-routes.ts:3819" },
+				{ siteToken: "routes/memory-routes.ts:3857" },
 			);
 
 			const rowMap = new Map(rows.map((r) => [r.id, r]));
@@ -3975,7 +3975,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 					return { total: totalRow?.count ?? 0, rows: rowData };
 				},
-				{ siteToken: "routes/memory-routes.ts:3900" },
+				{ siteToken: "routes/memory-routes.ts:3938" },
 			);
 
 			const embeddings = rows.map((row) => ({
@@ -4027,7 +4027,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					? { ...state, coverage: stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint) }
 					: state;
 			},
-			{ siteToken: "routes/memory-routes.ts:3985" },
+			{ siteToken: "routes/memory-routes.ts:4023" },
 		);
 		return c.json({ ...status, tracker, index });
 	});
@@ -4040,7 +4040,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const providerStatus = await checkEmbeddingProvider(cfg.embedding);
 		const report = await getDbAccessor().withReadDbAsync(
 			async (db) => buildEmbeddingHealth(db, cfg.embedding, providerStatus),
-			{ siteToken: "routes/memory-routes.ts:4003" },
+			{ siteToken: "routes/memory-routes.ts:4041" },
 		);
 		return c.json(report);
 	});

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -342,10 +342,6 @@ export interface OpenClawHeartbeatData {
 export let openClawHeartbeat: { timestamp: string; data: OpenClawHeartbeatData } | null = null;
 export const OPENCLAW_STALE_MS = 10 * 60 * 1000;
 
-// Projection state
-export const projectionInFlight = new Map<number, Promise<void>>();
-export const projectionErrors = new Map<number, { message: string; expires: number }>();
-export const PROJECTION_ERROR_TTL_MS = 30_000;
 export const hasMemoriesSessionIdColumnCache: boolean | null = null;
 
 // Auth state
@@ -457,7 +453,7 @@ export function getCachedDiagnosticsReport(): DiagnosticsReport {
 	const report = getDbAccessor().withReadDb(
 		(db: import("../db-accessor").ReadDb) =>
 			getDiagnostics(db, providerTracker, getUpdateState(), buildOpenClawHealth(), diagnosticsOptions),
-		"routes/state.ts:457",
+		"routes/state.ts:453",
 	);
 	diagnosticsCache = {
 		report,

--- a/platform/daemon/src/umap-projection.ts
+++ b/platform/daemon/src/umap-projection.ts
@@ -249,7 +249,7 @@ function buildKnnEdges(projected: readonly number[][], k: number): [number, numb
 // Row type + validation
 // ---------------------------------------------------------------------------
 
-interface EmbeddingRow {
+export interface EmbeddingProjectionRow {
 	id: string;
 	content: string;
 	who: string | null;
@@ -268,7 +268,7 @@ function isBlob(v: unknown): v is Uint8Array {
 	return v instanceof Uint8Array || Buffer.isBuffer(v);
 }
 
-function toEmbeddingRow(raw: Record<string, unknown>): EmbeddingRow | null {
+function toEmbeddingRow(raw: Record<string, unknown>): EmbeddingProjectionRow | null {
 	const { id, content, created_at, vector } = raw;
 	if (typeof id !== "string" || typeof content !== "string" || typeof created_at !== "string" || !isBlob(vector)) {
 		return null;
@@ -312,7 +312,7 @@ function normalizeFilterValues(values: readonly string[] | undefined): string[] 
 	return [...new Set(normalized)];
 }
 
-function buildProjectionWhere(filters: ProjectionFilters | undefined): {
+export function buildProjectionWhere(filters: ProjectionFilters | undefined): {
 	clause: string;
 	params: unknown[];
 } {
@@ -386,7 +386,7 @@ function buildProjectionWhere(filters: ProjectionFilters | undefined): {
 }
 
 interface ProjectionRowsResult {
-	readonly rows: EmbeddingRow[];
+	readonly rows: EmbeddingProjectionRow[];
 	/** Stable DB COUNT using typeof(e.vector)='blob' for dashboard display; over-fetch-by-1 sentinel for hasMore. */
 	readonly total: number;
 	readonly offset: number;
@@ -413,7 +413,7 @@ function loadProjectionRows(db: ReadDb, query: ProjectionQuery): ProjectionRowsR
 	}
 
 	const rawRows = db.prepare(sql).all(...rowParams) as Record<string, unknown>[];
-	const rows = rawRows.map(toEmbeddingRow).filter((row): row is EmbeddingRow => row !== null);
+	const rows = rawRows.map(toEmbeddingRow).filter((row): row is EmbeddingProjectionRow => row !== null);
 	const trimmedRows = requestedLimit !== null ? rows.slice(0, requestedLimit) : rows;
 
 	let effectiveTotal: number;
@@ -442,7 +442,7 @@ function loadProjectionRows(db: ReadDb, query: ProjectionQuery): ProjectionRowsR
 }
 
 function buildNodesFromRows(
-	rows: readonly EmbeddingRow[],
+	rows: readonly EmbeddingProjectionRow[],
 	xs: readonly number[],
 	ys: readonly number[],
 	zs: readonly number[] | null,
@@ -466,7 +466,10 @@ function buildNodesFromRows(
 	});
 }
 
-function computeProjectionFromRows(rows: readonly EmbeddingRow[], nComponents: 2 | 3): ProjectionResult {
+export function computeProjectionFromRows(
+	rows: readonly EmbeddingProjectionRow[],
+	nComponents: 2 | 3,
+): ProjectionResult {
 	if (rows.length === 0) return { nodes: [], edges: [] };
 	if (rows.length === 1) {
 		return {
@@ -552,9 +555,22 @@ export function getCachedProjection(db: ReadDb, nComponents: 2 | 3): CachedProje
 		return null;
 	}
 
+	return parseCachedProjection({ payload, embedding_count: embeddingCount, created_at: cachedAt });
+}
+
+export function parseCachedProjection(raw: unknown): CachedProjection | null {
+	if (raw === null || typeof raw !== "object") return null;
+	const row = raw as Record<string, unknown>;
+	if (
+		typeof row.payload !== "string" ||
+		typeof row.embedding_count !== "number" ||
+		typeof row.created_at !== "string"
+	) {
+		return null;
+	}
 	try {
-		const result: ProjectionResult = JSON.parse(payload);
-		return { result, embeddingCount, cachedAt };
+		const result: ProjectionResult = JSON.parse(row.payload);
+		return { result, embeddingCount: row.embedding_count, cachedAt: row.created_at };
 	} catch {
 		return null;
 	}

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(852);
+	expect(baseline).toHaveLength(849);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(65);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(99);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(40);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(0);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(132);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(128);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -352,17 +352,17 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
-	expect(report).toContain("Exact ledger inventory: 852 sites");
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites");
-	expect(report).toContain("Async-named ON-PARENT DB sites: 171");
+	const report = renderReport(baseline, { total: 164, withWriteTx: 65, withReadDb: 99 });
+	expect(report).toContain("Exact ledger inventory: 849 sites");
+	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 169 async-named DB sites");
+	expect(report).toContain("Async-named ON-PARENT DB sites: 167");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
-		"The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
+		"The async-named DB counts above separate the 167 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 337");
-	expect(report).toContain("ON-PARENT callback execution: 335");
+	expect(report).toContain("Database accessor sites classified: 333");
+	expect(report).toContain("ON-PARENT callback execution: 331");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toMatch(/`db-owner-worker\.ts:\d+` \(withReadDbAsync\)/);
 	expect(report).not.toMatch(/`daemon\.ts:\d+` \(withReadDbAsync\)/);

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -99,6 +99,7 @@ const workerEntries = [
 	["synthesis-render-worker", "platform/daemon/src/synthesis-render-worker.ts"],
 	["database-integrity-worker", "platform/daemon/src/database-integrity-worker.ts"],
 	["db-owner-worker", "platform/daemon/src/db-owner-worker.ts"],
+	["embedding-projection-worker", "platform/daemon/src/embedding-projection-worker.ts"],
 	["native-memory-source-worker", "platform/daemon/src/native-memory-source-worker.ts"],
 	// Native ONNX embedding runs in a worker so model download / WASM compile /
 	// inference can never block the daemon's main event loop (see
@@ -415,6 +416,9 @@ if (process.env.SIGNET_INSPECTOR_PROXY_PUBLIC || process.env.SIGNET_INSPECTOR_PR
 } else if (process.env.SIGNET_DB_OWNER_WORKER) {
 	const { runDbOwnerWorker } = await import("../platform/daemon/src/db-owner-worker");
 	runDbOwnerWorker();
+} else if (process.env.SIGNET_EMBEDDING_PROJECTION_WORKER) {
+	const { runEmbeddingProjectionWorker } = await import("../platform/daemon/src/embedding-projection-worker");
+	await runEmbeddingProjectionWorker();
 } else if (process.env.SIGNET_NATIVE_SOURCE_WORKER) {
 	const { runNativeSourceWorker } = await import("../platform/daemon/src/native-memory-source-worker");
 	runNativeSourceWorker();

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1095,6 +1095,13 @@
       "category": "hot-path"
     },
     {
+      "path": "embedding-projection-jobs.ts",
+      "line": 53,
+      "api": "existsSync",
+      "source": "return [existsSync(bundled) ? bundled : join(directory, \"embedding-projection-worker.ts\")];",
+      "category": "hot-path"
+    },
+    {
       "path": "embedding-repair-state.ts",
       "line": 101,
       "api": "withWriteTx",
@@ -3760,177 +3767,149 @@
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 121,
+      "line": 128,
       "api": "withReadDbAsync",
       "source": "embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding), {",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 290,
+      "line": 448,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 306,
+      "line": 464,
       "api": "writeFileSync",
       "source": "writeFileSync(path, noteContent, { encoding: \"utf-8\", flag: \"wx\" });",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1022,
+      "line": 1186,
       "api": "withReadDbAsync",
       "source": "const result = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1102,
+      "line": 1266,
       "api": "withReadDbAsync",
       "source": "const memories = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1157,
+      "line": 1321,
       "api": "withReadDbAsync",
       "source": "const slices = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1258,
+      "line": 1422,
       "api": "withReadDbAsync",
       "source": "const timeline = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1368,
+      "line": 1532,
       "api": "withReadDbAsync",
       "source": "const results = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1670,
+      "line": 1834,
       "api": "withReadDbAsync",
       "source": "const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1678,
+      "line": 1842,
       "api": "withReadDbAsync",
       "source": "const existingChunks = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1712,
+      "line": 1876,
       "api": "withReadDbAsync",
       "source": "const byHash = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1919,
+      "line": 2083,
       "api": "withReadDbAsync",
       "source": ": await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2044,
+      "line": 2208,
       "api": "withReadDbAsync",
       "source": "const existing = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2263,
+      "line": 2427,
       "api": "withReadDbAsync",
       "source": "const memoryRead = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2442,
+      "line": 2606,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3641,
+      "line": 3805,
       "api": "withReadDbAsync",
       "source": "const embeddingRow = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3675,
+      "line": 3839,
       "api": "withReadDbAsync",
       "source": "? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions), {",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3693,
+      "line": 3857,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3774,
+      "line": 3938,
       "api": "withReadDbAsync",
       "source": "const { total, rows } = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3859,
+      "line": 4023,
       "api": "withReadDbAsync",
       "source": "const index = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3877,
+      "line": 4041,
       "api": "withReadDbAsync",
       "source": "const report = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3940,
-      "api": "withReadDbAsync",
-      "source": "const projection = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3980,
-      "api": "withReadDbAsync",
-      "source": "const { cached, total } = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4021,
-      "api": "withReadDbAsync",
-      "source": "const result = await getDbAccessor().withReadDbAsync(async (db) => computeProjection(db, nComponents), {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4024,
-      "api": "withReadDbAsync",
-      "source": "const count = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
@@ -4474,21 +4453,21 @@
     },
     {
       "path": "routes/state.ts",
-      "line": 384,
+      "line": 380,
       "api": "existsSync",
       "source": "if (!existsSync(candidate)) continue;",
       "category": "hot-path"
     },
     {
       "path": "routes/state.ts",
-      "line": 386,
+      "line": 382,
       "api": "readFileSync",
       "source": "const raw = readFileSync(candidate, \"utf8\");",
       "category": "hot-path"
     },
     {
       "path": "routes/state.ts",
-      "line": 457,
+      "line": 453,
       "api": "withReadDb",
       "source": "const report = getDbAccessor().withReadDb(",
       "category": "hot-path"

--- a/web/docs/src/content/docs/api/memory/embeddings.md
+++ b/web/docs/src/content/docs/api/memory/embeddings.md
@@ -130,10 +130,11 @@ Poll with the same endpoint and `?jobId=...`. Poll responses use
 a hard 10-second deadline) or `error`; when the two-job global capacity is
 full, new work returns `429` with `status: "overloaded"`.
 
-Cancel an active job with `DELETE /api/embeddings/projection/:jobId`.
-Cancellation kills the worker and returns `status: "cancelled"`. Only
-successful worker results are written to `umap_cache`; cache writes are never
-performed for timeout, cancellation, or failure.
+Cancel an active job with `DELETE /api/embeddings/projection/:jobId`. A successful
+cancellation returns `200` with `status: "cancelled"`; an unknown job returns
+`404`. Cancellation kills the worker and cancels any in-flight DB-owner read or
+write. Only successful worker results are written to `umap_cache`; cache writes
+are never performed for timeout, cancellation, or failure.
 
 **Response (ready)**
 

--- a/web/docs/src/content/docs/api/memory/embeddings.md
+++ b/web/docs/src/content/docs/api/memory/embeddings.md
@@ -90,57 +90,65 @@ embedding requests degrade without repeating those probes.
 
 ### GET /api/embeddings/health
 
-Returns embedding health metrics including coverage and staleness.
+Returns embedding health metrics including coverage and staleness. Requires
+`recall` permission.
 
 **Response** — embedding health object with coverage percentage, stale
 count, and provider status.
 
 ### GET /api/embeddings/projection
 
-Returns a server-computed UMAP projection of all stored embeddings.
-Results are cached in the `umap_cache` table; cache is invalidated when
-the embedding count changes. Requires `recall` permission.
+Returns a UMAP projection of stored memory embeddings. Requires `recall`
+permission. SQLite reads and the immutable embedding snapshot run through the
+DB owner; UMAP runs in a killable worker so this endpoint cannot block the
+daemon event loop.
+
+Each job is capped at 1,000 rows. A request without `limit` uses that cap and
+sets `sampled: true` when more rows match. `limit` is clamped to 1,000. There
+is no unbounded or all-row mode.
 
 **Query parameters**
 
-| Parameter    | Type    | Default | Description                    |
-|--------------|---------|---------|--------------------------------|
-| `dimensions` | integer | 2       | Output dimensions: `2` or `3`  |
+| Parameter    | Type    | Default | Description                                      |
+|--------------|---------|---------|--------------------------------------------------|
+| `dimensions` | integer | 2       | Output dimensions: `2` or `3`                    |
+| `limit`      | integer | 1,000   | Maximum rows in the immutable snapshot            |
+| `offset`     | integer | 0       | Offset, capped at 100,000                        |
+| `q` and filters | string | —     | Existing embedding filters, applied in the owner |
+| `jobId`      | string  | —       | Poll an accepted job                         |
 
-If the projection is still computing, the endpoint returns `202 Accepted`
-with `status: "computing"`. Poll again when ready.
+A cache hit returns `status: "ready"`. A cache miss is admitted with
+`202 Accepted` and returns a `jobId`:
 
-**Response (computed)**
+```json
+{ "status": "accepted", "jobId": "projection-...", "dimensions": 2,
+  "limit": 1000, "offset": 0 }
+```
+
+Poll with the same endpoint and `?jobId=...`. Poll responses use
+`accepted`, `running`, or `ready`. Failed jobs report `timeout` (the worker has
+a hard 10-second deadline) or `error`; when the two-job global capacity is
+full, new work returns `429` with `status: "overloaded"`.
+
+Cancel an active job with `DELETE /api/embeddings/projection/:jobId`.
+Cancellation kills the worker and returns `status: "cancelled"`. Only
+successful worker results are written to `umap_cache`; cache writes are never
+performed for timeout, cancellation, or failure.
+
+**Response (ready)**
 
 ```json
 {
-  "status": "cached",
+  "status": "ready",
   "dimensions": 2,
   "count": 847,
-  "total": 847,
-  "nodes": [
-    {
-      "id": "uuid",
-      "x": 42.1,
-      "y": -18.7,
-      "content": "User prefers vim keybindings",
-      "who": "claude-code",
-      "importance": 0.8,
-      "type": "preference",
-      "tags": ["preference"],
-      "pinned": false,
-      "sourceType": "memory",
-      "sourceId": "uuid",
-      "createdAt": "2026-02-21T10:00:00.000Z"
-    }
-  ],
-  "edges": [[0, 3], [0, 7]],
+  "total": 1200,
+  "limit": 1000,
+  "offset": 0,
+  "hasMore": true,
+  "sampled": true,
+  "nodes": [],
+  "edges": [],
   "cachedAt": "2026-02-21T10:05:00.000Z"
 }
-```
-
-**Response (computing)**
-
-```json
-{ "status": "computing", "dimensions": 2, "count": 0, "total": 847 }
 ```


### PR DESCRIPTION
## Summary

Fixes #1775 by moving embedding projection snapshots and UMAP computation behind bounded, killable job boundaries. The projection route now uses the DB owner for bounded immutable reads, a worker process for UMAP, typed async status, cancellation, overload, timeout, and recall permission enforcement.

## Changes

- Added a bounded projection worker/job manager with a 1,000-row cap, two-job global admission limit, equivalent-request single-flight, 10-second deadline, cancellation, and success-only cache publication.
- Moved projection snapshot reads through the DB owner in sequential bounded pages and preserved filtered pagination metadata and sampling semantics.
- Added typed SDK polling/cancellation responses and documented the route contract and recall permission.
- Added production and native Bun worker packaging entries.
- Added focused worker, responsiveness, concurrency, cancellation, permission, SDK, and projection regression coverage.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/sdk`
- [x] `@signet/web`
- [ ] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/connector-*`
- [ ] `predictor`
- [ ] Other: 

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No migrations.

## Testing

- [x] Focused `bun test` suites pass
- [x] `bun run typecheck` passes
- [x] `bunx biome check` passes with only two pre-existing warnings in `memory-routes.ts`
- [x] Production daemon build passes
- [x] Targeted native compiled projection launcher smoke passes
- [x] Event-loop contract audit passes
- [ ] Tested against running daemon
- [ ] N/A

Mutation proof:

- Restoring the old timeout classification made the timeout test fail with `ProjectionWorkerCancelledError`.
- Removing projection admission made the concurrency test fail because the third job was accepted.
- Omitting child termination made cancellation tests fail with `ProjectionWorkerTimeoutError`.
- Injecting a 100ms parent busy loop made both event-loop responsiveness tests fail with measured ~101ms timer delay.
- Removing the recall permission middleware made the permission contract test fail because the guard source was absent.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The complete `build:native-bun` command was attempted and reached all worker bundles, including `embedding-projection-worker.mjs`, but the final CLI compile is blocked in this worktree by missing built workspace connector packages (`@signet/connector-*`). The targeted compiled projection launcher and production daemon build both pass. No merge performed.
