### PR TITLE
fix(cli): pause setup spinner while prompting

### DIFF
--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -28,6 +28,7 @@ import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary, refreshSnapshotProtection } from "./setup-protection.js";
 import { formatWorkspaceSourceRepoSync, readErr, readRecord } from "./setup-shared.js";
+import { withSetupPrompt } from "./setup-terminal.js";
 import type { SetupDeps } from "./setup-types.js";
 
 export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext, deps: SetupDeps): Promise<void> {
@@ -228,12 +229,14 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 		// users can audit exactly what is recorded and sent.
 		let telemetryEnabled = true;
 		if (!context.nonInteractive) {
-			telemetryEnabled = await import("@inquirer/prompts").then(({ confirm }) =>
-				confirm({
-					message:
-						"Help improve Signet by sharing anonymous usage statistics (version and command names) with PostHog? No memory content, code, arguments, paths, or personal data. Events are logged to ~/.agents/.daemon/telemetry/events.jsonl and, when remote delivery is configured and the workspace database is available, queued locally before best-effort delivery; disable anytime with telemetryEnabled: false.",
-					default: true,
-				}),
+			telemetryEnabled = await withSetupPrompt(spinner, () =>
+				import("@inquirer/prompts").then(({ confirm }) =>
+					confirm({
+						message:
+							"Help improve Signet by sharing anonymous usage statistics (version and command names) with PostHog? No memory content, code, arguments, paths, or personal data. Events are logged to ~/.agents/.daemon/telemetry/events.jsonl and, when remote delivery is configured and the workspace database is available, queued locally before best-effort delivery; disable anytime with telemetryEnabled: false.",
+						default: true,
+					}),
+				),
 			);
 		}
 		// The daemon reads telemetryEnabled from memory.pipelineV2 — writing it
@@ -300,13 +303,15 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			db.close();
 		}
 
-		let protection = await enforceSetupProtection({
-			basePath: context.basePath,
-			nonInteractive: context.nonInteractive,
-			allowUnprotectedWorkspace: context.allowUnprotectedWorkspace,
-			createLocalBackup: context.createLocalBackup,
-			assumeOpenClawLinked: plan.configureOpenClawWs && context.openclawConfigCount > 0,
-		});
+		let protection = await withSetupPrompt(spinner, () =>
+			enforceSetupProtection({
+				basePath: context.basePath,
+				nonInteractive: context.nonInteractive,
+				allowUnprotectedWorkspace: context.allowUnprotectedWorkspace,
+				createLocalBackup: context.createLocalBackup,
+				assumeOpenClawLinked: plan.configureOpenClawWs && context.openclawConfigCount > 0,
+			}),
+		);
 
 		spinner.text = "Configuring harness hooks...";
 		// Hooks are installed before the daemon starts. This is safe because
@@ -447,8 +452,8 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 				await openUrlWithFallback(`http://127.0.0.1:${deps.DEFAULT_PORT}`);
 			}
 		} else {
-			const launchNow = await import("@inquirer/prompts").then(({ confirm }) =>
-				confirm({ message: "Open the dashboard?", default: true }),
+			const launchNow = await withSetupPrompt(spinner, () =>
+				import("@inquirer/prompts").then(({ confirm }) => confirm({ message: "Open the dashboard?", default: true })),
 			);
 			if (launchNow) {
 				await openUrlWithFallback(`http://127.0.0.1:${deps.DEFAULT_PORT}`);

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -42,6 +42,7 @@ import {
 	readRecord,
 	readString,
 } from "./setup-shared.js";
+import { withSetupPrompt } from "./setup-terminal.js";
 import type { SetupDeps } from "./setup-types.js";
 
 export function detectedHarnessesForExistingSetup(
@@ -317,12 +318,14 @@ export async function runExistingSetupWizard(
 		runMigrations(db);
 		db.close();
 
-		let protection = await enforceSetupProtection({
-			basePath,
-			nonInteractive: options?.nonInteractive === true,
-			allowUnprotectedWorkspace: options?.allowUnprotectedWorkspace === true,
-			createLocalBackup: options?.createLocalBackup === true,
-		});
+		let protection = await withSetupPrompt(spinner, () =>
+			enforceSetupProtection({
+				basePath,
+				nonInteractive: options?.nonInteractive === true,
+				allowUnprotectedWorkspace: options?.allowUnprotectedWorkspace === true,
+				createLocalBackup: options?.createLocalBackup === true,
+			}),
+		);
 
 		let importResult: ImportResult | null = null;
 		if (detection.hasMemoryDir && detection.memoryLogCount > 0) {
@@ -462,7 +465,9 @@ export async function runExistingSetupWizard(
 				await openUrlWithFallback(`http://127.0.0.1:${deps.DEFAULT_PORT}`);
 			}
 		} else {
-			const launchNow = await confirm({ message: "Open the dashboard?", default: true });
+			const launchNow = await withSetupPrompt(spinner, () =>
+				confirm({ message: "Open the dashboard?", default: true }),
+			);
 			if (launchNow) {
 				await openUrlWithFallback(`http://127.0.0.1:${deps.DEFAULT_PORT}`);
 			}

--- a/surfaces/cli/src/features/setup-terminal.test.ts
+++ b/surfaces/cli/src/features/setup-terminal.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import { withSetupPrompt } from "./setup-terminal.js";
+
+function fakeSpinner(events: string[], spinning = true) {
+	return {
+		get isSpinning() {
+			return spinning;
+		},
+		stop() {
+			events.push("stop");
+			spinning = false;
+			return this;
+		},
+		start() {
+			events.push("start");
+			spinning = true;
+			return this;
+		},
+	};
+}
+
+describe("setup prompt terminal ownership", () => {
+	it("stops the spinner before rendering a prompt and resumes after it returns", async () => {
+		const events: string[] = [];
+		const spinner = fakeSpinner(events);
+
+		const answer = await withSetupPrompt(spinner, async () => {
+			expect(spinner.isSpinning).toBe(false);
+			events.push("prompt");
+			return "answer";
+		});
+
+		expect(answer).toBe("answer");
+		expect(events).toEqual(["stop", "prompt", "start"]);
+		expect(spinner.isSpinning).toBe(true);
+	});
+
+	it("keeps the spinner stopped for the whole prompt lifetime", async () => {
+		const events: string[] = [];
+		const spinner = fakeSpinner(events);
+		let finishPrompt: (() => void) | undefined;
+		const promptDone = new Promise<void>((resolve) => {
+			finishPrompt = resolve;
+		});
+
+		const answerPromise = withSetupPrompt(spinner, async () => {
+			events.push("prompt-start");
+			await promptDone;
+			events.push("prompt-end");
+			return "answer";
+		});
+		await Promise.resolve();
+
+		expect(spinner.isSpinning).toBe(false);
+		expect(events).toEqual(["stop", "prompt-start"]);
+		finishPrompt?.();
+		await expect(answerPromise).resolves.toBe("answer");
+		expect(events).toEqual(["stop", "prompt-start", "prompt-end", "start"]);
+	});
+
+	it("does not start a spinner that was already stopped", async () => {
+		const events: string[] = [];
+		const spinner = fakeSpinner(events, false);
+
+		await withSetupPrompt(spinner, async () => {
+			expect(spinner.isSpinning).toBe(false);
+			events.push("prompt");
+		});
+
+		expect(events).toEqual(["prompt"]);
+		expect(spinner.isSpinning).toBe(false);
+	});
+
+	it("restores spinner ownership after a prompt throws", async () => {
+		const events: string[] = [];
+		const spinner = fakeSpinner(events);
+		const failure = new Error("prompt cancelled");
+
+		await expect(
+			withSetupPrompt(spinner, async () => {
+				expect(spinner.isSpinning).toBe(false);
+				events.push("prompt");
+				throw failure;
+			}),
+		).rejects.toBe(failure);
+
+		expect(events).toEqual(["stop", "prompt", "start"]);
+		expect(spinner.isSpinning).toBe(true);
+	});
+});

--- a/surfaces/cli/src/features/setup-terminal.ts
+++ b/surfaces/cli/src/features/setup-terminal.ts
@@ -1,0 +1,21 @@
+export interface SetupSpinner {
+	readonly isSpinning: boolean;
+	stop(): SetupSpinner;
+	start(text?: string): SetupSpinner;
+}
+
+/** Run an interactive prompt without allowing spinner frames to redraw over it. */
+export async function withSetupPrompt<T>(spinner: SetupSpinner, prompt: () => Promise<T>): Promise<T> {
+	const wasSpinning = spinner.isSpinning;
+	if (wasSpinning) {
+		spinner.stop();
+	}
+
+	try {
+		return await prompt();
+	} finally {
+		if (wasSpinning) {
+			spinner.start();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1808

## Summary

Pause the setup `ora` spinner whenever an interactive prompt owns the terminal, so spinner frames cannot overwrite prompt text or choices.

## Changes

- Added `withSetupPrompt`, a shared terminal-ownership boundary that stops active spinners before prompts and restores them after success, cancellation, or thrown errors.
- Applied it to fresh setup telemetry, workspace-protection, and dashboard prompts.
- Applied it to existing-workspace protection and dashboard prompts.
- Added lifecycle regression coverage for prompt lifetime, already-stopped spinners, and thrown prompts.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/cli` / dashboard

## Screenshots

N/A: terminal-only CLI behavior; no dashboard or web UI changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`): CLI-only change; no spec or dependency contract changed.
- [x] Agent scoping verified on all new/changed data queries: no data queries changed.
- [x] Input/config validation and bounds checks added: no new input/config surface.
- [x] Error handling and fallback paths tested (no silent swallow): prompt throws are propagated and spinner ownership is restored in `finally`.
- [x] Security checks applied to admin/mutation endpoints: no endpoint or mutation changed.
- [x] Docs updated for API/spec/status changes: no API/spec/status change.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally: targeted tests and Biome pass; CLI build passes; focused helper TypeScript check passes.

## Migration Notes (if applicable)

N/A: no migrations or persisted state changes.

## Testing

- [x] `bun test` passes: targeted setup suites pass (59 tests) and prompt-boundary suite passes (4 tests).
- [ ] `bun run typecheck` passes
- [x] `bun run lint` passes: changed files pass Biome; repository lint has unrelated baseline warnings only.
- [ ] Tested against running daemon
- [x] N/A

Additional verification:

- `bun run build:cli`
- Mutation run with the old helper ordering: 1 pass, 3 failures on the prompt-ownership assertions.

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The first draft branch was superseded by this origin/main-based PR so the diff is limited to the four intended CLI files. Do not merge until the independent exact-head adversarial review is complete.
