### PR TITLE
fix(inference): update pi-ai model registry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,8 +52,8 @@
         "signet-connector-claude-code": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -67,8 +67,8 @@
         "signet-connector-codex": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -93,8 +93,8 @@
         "signet-connector-forge": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -108,8 +108,8 @@
         "signet-connector-gemini": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -123,8 +123,8 @@
         "signet-connector-hermes-agent": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -138,8 +138,8 @@
         "signet-connector-kimi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -153,8 +153,8 @@
         "signet-connector-oh-my-pi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -181,8 +181,8 @@
         "signet-connector-openclaw": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -214,8 +214,8 @@
         "signet-connector-opencode": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
         "jsonc-parser": "3.3.1",
       },
       "devDependencies": {
@@ -246,8 +246,8 @@
         "signet-connector-pi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.204.4",
-        "@signet/core": "0.204.4",
+        "@signet/connector-base": "0.214.36",
+        "@signet/core": "0.214.36",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -284,7 +284,7 @@
       "name": "@signet/connector-base",
       "version": "0.214.42",
       "dependencies": {
-        "@signet/core": "0.204.4",
+        "@signet/core": "0.214.36",
         "json5": "^2.2.3",
         "jsonc-parser": "3.3.1",
       },
@@ -361,6 +361,12 @@
         "sqlite-vec-linux-x64": "^0.1.7-alpha.2",
         "sqlite-vec-windows-x64": "^0.1.7-alpha.2",
       },
+      "peerDependencies": {
+        "better-sqlite3": "*",
+      },
+      "optionalPeers": [
+        "better-sqlite3",
+      ],
     },
     "platform/daemon": {
       "name": "@signet/daemon",
@@ -371,8 +377,8 @@
       },
       "dependencies": {
         "@1password/sdk": "^0.3.0",
-        "@earendil-works/pi-ai": "0.83.0",
-        "@earendil-works/pi-coding-agent": "0.83.0",
+        "@earendil-works/pi-ai": "0.84.4",
+        "@earendil-works/pi-coding-agent": "0.84.4",
         "@firecrawl/anydoc": "0.1.7",
         "@hono/node-server": "^2.1.0",
         "@huggingface/transformers": "^4.2.0",
@@ -425,8 +431,8 @@
       "version": "0.214.42",
       "bin": "./dist/cli.js",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.83.0",
-        "@earendil-works/pi-tui": "0.83.0",
+        "@earendil-works/pi-ai": "0.84.4",
+        "@earendil-works/pi-tui": "0.84.4",
         "@inquirer/prompts": "^7.0.0",
         "@signet/connector-claude-code": "workspace:*",
         "@signet/connector-codex": "workspace:*",
@@ -831,13 +837,19 @@
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.83.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.83.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-telemetry": "^0.84.4", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.83.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.4", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.83.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.83.0", "@earendil-works/pi-ai": "^0.83.0", "@earendil-works/pi-tui": "^0.83.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw=="],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.4", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.4" } }, "sha512-q398WY/3ZQHTizk7IKxApzqFV0xt4yM9LkSkwyqeLK5Bj5RwRjOWxESt26z4LgNp4O+8hqhqFPf/8fj4H5rE4A=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.83.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.4", "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-client": "^0.84.4", "@earendil-works/pi-protocol": "^0.84.4", "@earendil-works/pi-tui": "^0.84.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w=="],
+
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.4", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-acyE9ozxkMiWiz/xyWpU0O9vwnYv0hyG889Vniv6Sg9c9zfsX+8MePnDNphBacY2Fvm1rxdsGmiVDSZl9yuDFA=="],
+
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.4", "", {}, "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 
@@ -1109,8 +1121,6 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
-
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.13", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-E3Sv4eCYAlKYUTx8S3ioQcDUscOif+8zZ5OnW1IzJ+Tt+EO+ke8mn+Y3FX6N1H79picwbdOavVOb1jPi2EOyrg=="],
@@ -1294,8 +1304,6 @@
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.13", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-JY9etiVcu1G/pZjaH2vjK/b8z54ujxaWCD1GziO4ADUhRM6m6zm2332bPGcxEfA6TwweiJfNlK6wVZQ0f/X4KQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
-
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -2465,7 +2473,7 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
-    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "global-agent": ["global-agent@4.1.3", "", { "dependencies": { "globalthis": "^1.0.2", "matcher": "^4.0.0", "semver": "^7.3.5", "serialize-error": "^8.1.0" } }, "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g=="],
 
@@ -2492,6 +2500,8 @@
     "graphology-types": ["graphology-types@0.24.8", "", {}, "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q=="],
 
     "graphology-utils": ["graphology-utils@2.5.2", "", { "peerDependencies": { "graphology-types": ">=0.23.0" } }, "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ=="],
+
+    "grok-mermaid": ["grok-mermaid@0.2.2", "", {}, "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA=="],
 
     "gsap": ["gsap@3.15.0", "", {}, "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A=="],
 
@@ -3037,7 +3047,7 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+    "openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
@@ -3081,7 +3091,7 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -3831,8 +3841,6 @@
 
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
-    "@electron/asar/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
     "@electron/asar/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@electron/fuses/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -4085,6 +4093,8 @@
 
     "get-intrinsic/hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "global-agent/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "happy-dom/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -4183,6 +4193,8 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
     "pkijs/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
@@ -4204,8 +4216,6 @@
     "remark-rehype/@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
@@ -4451,8 +4461,6 @@
 
     "cacache/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
-    "cacache/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
     "cli-truncate/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "cli-truncate/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -4503,6 +4511,8 @@
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
     "happy-dom/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "jest-util/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
@@ -4540,8 +4550,6 @@
     "pg/pg-types/postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -4723,6 +4731,8 @@
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "mem0ai/openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "natural/pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
@@ -4732,8 +4742,6 @@
     "natural/pg/pg-types/postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
 
     "natural/pg/pg-types/postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
-
-    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -4842,8 +4850,6 @@
     "electron-builder-squirrel-windows/app-builder-lib/@electron/rebuild/ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/get/global-agent/serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 

--- a/platform/core/src/llm-model-catalog.test.ts
+++ b/platform/core/src/llm-model-catalog.test.ts
@@ -4,6 +4,9 @@ import { modelPresetsForProvider } from "./llm-model-catalog";
 describe("modelPresetsForProvider", () => {
 	it("returns checked presets for catalog-owned providers", () => {
 		expect(modelPresetsForProvider("codex").map((preset) => preset.value)).toContain("gpt-5.4-mini");
+		expect(modelPresetsForProvider("codex").map((preset) => preset.value)).toContain("gpt-5.6-luna");
+		expect(modelPresetsForProvider("anthropic").map((preset) => preset.value)).toContain("claude-sonnet-4-6");
+		expect(modelPresetsForProvider("openrouter").map((preset) => preset.value)).toContain("deepseek/deepseek-v4-pro");
 	});
 
 	it("ignores inherited object keys instead of indexing prototype values", () => {

--- a/platform/core/src/llm-model-catalog.ts
+++ b/platform/core/src/llm-model-catalog.ts
@@ -18,13 +18,21 @@ export type ModelCatalogProvider =
 	| "openai-compatible"
 	| "command";
 
+// Provider-backed entries are curated against @earendil-works/pi-ai 0.84.4.
+// Pi's complete provider catalogs remain the authority for connect/setup flows;
+// these are the small checked presets used by the legacy pipeline endpoints.
 export const PIPELINE_MODEL_CATALOG = {
 	none: [],
 	command: [],
 	acpx: [
 		{ value: "haiku", label: "Claude Code · haiku", tier: "low", source: "harness" },
 		{ value: "gpt-5.4-mini", label: "Codex CLI · gpt-5.4-mini", tier: "low", source: "harness" },
-		{ value: "google/gemini-2.5-flash", label: "OpenCode · google/gemini-2.5-flash", tier: "low", source: "harness" },
+		{
+			value: "opencode/gemini-3-flash",
+			label: "OpenCode · opencode/gemini-3-flash",
+			tier: "low",
+			source: "harness",
+		},
 	],
 	"llama-cpp": [
 		{ value: "qwen3:4b", label: "qwen3:4b", tier: "low", source: "local" },
@@ -40,27 +48,35 @@ export const PIPELINE_MODEL_CATALOG = {
 		{ value: "opus", label: "Opus", tier: "high", source: "harness" },
 	],
 	codex: [
+		{ value: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark", tier: "low", source: "harness" },
 		{ value: "gpt-5.4-mini", label: "gpt-5.4-mini", tier: "low", source: "harness" },
 		{ value: "gpt-5.4", label: "gpt-5.4", tier: "mid", source: "harness" },
 		{ value: "gpt-5.5", label: "gpt-5.5", tier: "high", source: "harness" },
-		{ value: "gpt-5.3-codex", label: "gpt-5.3-codex", tier: "mid", source: "harness" },
-		{ value: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark", tier: "low", source: "harness" },
-		{ value: "gpt-5.2", label: "gpt-5.2", tier: "mid", source: "harness" },
+		{ value: "gpt-5.6-luna", label: "gpt-5.6-luna", tier: "high", source: "harness" },
+		{ value: "gpt-5.6-sol", label: "gpt-5.6-sol", tier: "high", source: "harness" },
+		{ value: "gpt-5.6-terra", label: "gpt-5.6-terra", tier: "high", source: "harness" },
 	],
 	opencode: [
-		{ value: "google/gemini-2.5-flash", label: "google/gemini-2.5-flash", tier: "low", source: "harness" },
-		{ value: "openai/gpt-5.4-mini", label: "openai/gpt-5.4-mini", tier: "low", source: "harness" },
-		{ value: "openai/gpt-5.4", label: "openai/gpt-5.4", tier: "mid", source: "harness" },
+		{ value: "opencode/gemini-3-flash", label: "opencode/gemini-3-flash", tier: "low", source: "harness" },
+		{ value: "opencode/gpt-5.4-mini", label: "opencode/gpt-5.4-mini", tier: "low", source: "harness" },
+		{ value: "opencode/gpt-5.5", label: "opencode/gpt-5.5", tier: "mid", source: "harness" },
 	],
 	anthropic: [
-		{ value: "claude-3-5-haiku-20241022", label: "Claude 3.5 Haiku", tier: "low", source: "provider" },
-		{ value: "claude-sonnet-4-20250514", label: "Claude Sonnet 4", tier: "mid", source: "provider" },
+		{ value: "claude-haiku-4-5", label: "Claude Haiku 4.5", tier: "low", source: "provider" },
+		{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", tier: "mid", source: "provider" },
+		{ value: "claude-opus-4-6", label: "Claude Opus 4.6", tier: "high", source: "provider" },
 	],
 	openrouter: [
-		{ value: "openai/gpt-4o-mini", label: "openai/gpt-4o-mini", tier: "low", source: "provider" },
 		{ value: "openai/gpt-5.4-mini", label: "openai/gpt-5.4-mini", tier: "low", source: "provider" },
-		{ value: "anthropic/claude-3.5-haiku", label: "anthropic/claude-3.5-haiku", tier: "low", source: "provider" },
-		{ value: "google/gemini-2.5-flash", label: "google/gemini-2.5-flash", tier: "low", source: "provider" },
+		{ value: "openai/gpt-5.4", label: "openai/gpt-5.4", tier: "mid", source: "provider" },
+		{ value: "anthropic/claude-sonnet-4.6", label: "anthropic/claude-sonnet-4.6", tier: "mid", source: "provider" },
+		{
+			value: "google/gemini-3.1-pro-preview",
+			label: "google/gemini-3.1-pro-preview",
+			tier: "high",
+			source: "provider",
+		},
+		{ value: "deepseek/deepseek-v4-pro", label: "deepseek/deepseek-v4-pro", tier: "high", source: "provider" },
 	],
 	"openai-compatible": [
 		{ value: "gpt-4o-mini", label: "gpt-4o-mini", tier: "low", source: "provider" },
@@ -76,15 +92,15 @@ export const MODEL_DEFAULTS = {
 	ollama: "qwen3:4b",
 	"claude-code": "haiku",
 	codex: "gpt-5.4-mini",
-	opencode: "google/gemini-2.5-flash",
-	anthropic: "claude-3-5-haiku-20241022",
-	openrouter: "openai/gpt-4o-mini",
+	opencode: "opencode/gemini-3-flash",
+	anthropic: "claude-haiku-4-5",
+	openrouter: "openai/gpt-5.4-mini",
 	"openai-compatible": "gpt-4o-mini",
 	command: "",
 } as const satisfies Record<ModelCatalogProvider, string>;
 
 export function modelPresetsForProvider(provider: string): readonly PipelineModelPreset[] {
-	return Object.prototype.hasOwnProperty.call(PIPELINE_MODEL_CATALOG, provider)
+	return Object.hasOwn(PIPELINE_MODEL_CATALOG, provider)
 		? PIPELINE_MODEL_CATALOG[provider as ModelCatalogProvider]
 		: [];
 }

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -37,8 +37,8 @@
 	},
 	"dependencies": {
 		"@1password/sdk": "^0.3.0",
-		"@earendil-works/pi-ai": "0.83.0",
-		"@earendil-works/pi-coding-agent": "0.83.0",
+		"@earendil-works/pi-ai": "0.84.4",
+		"@earendil-works/pi-coding-agent": "0.84.4",
 		"@firecrawl/anydoc": "0.1.7",
 		"@hono/node-server": "^2.1.0",
 		"@huggingface/transformers": "^4.2.0",

--- a/platform/daemon/src/inference-oauth.ts
+++ b/platform/daemon/src/inference-oauth.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type {
-	AuthInteraction,
 	OAuthAuth,
 	OAuthCredentials,
 	OAuthPrompt,
 	OAuthSelectPrompt,
+	ProviderAuthInteraction,
 } from "@earendil-works/pi-ai";
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 import { logger } from "./logger";
@@ -195,7 +195,10 @@ export async function resolveOAuthCredential(providerId: string): Promise<Resolv
 		let resolved = credentials;
 		try {
 			if (resolved.expires <= Date.now()) {
-				const refreshed = await provider.oauth.refresh({ ...resolved, type: "oauth" });
+				const refreshed = await provider.oauth.refresh(
+					{ ...resolved, type: "oauth" },
+					AbortSignal.timeout(OAUTH_SESSION_TTL_MS),
+				);
 				resolved = { refresh: refreshed.refresh, access: refreshed.access, expires: refreshed.expires };
 			}
 		} catch (error) {
@@ -288,7 +291,7 @@ export function startOAuthLogin(
 			const timeout = setTimeout(() => abortOAuthLogin(sessionId, "Login session expired"), OAUTH_SESSION_TTL_MS);
 			timeout.unref?.();
 
-			const callbacks: AuthInteraction = {
+			const callbacks: ProviderAuthInteraction = {
 				signal: abortController.signal,
 				notify: (event) => {
 					if (event.type === "auth_url")

--- a/platform/daemon/src/inference-provider-factory.test.ts
+++ b/platform/daemon/src/inference-provider-factory.test.ts
@@ -92,8 +92,10 @@ describe("inference provider factory", () => {
 				locality: "remote",
 			});
 			await expect(provider.generate("test")).resolves.toBe("done");
-			expect(requestBody?.thinking).toEqual({ type: "disabled" });
-			expect(requestBody?.reasoning_effort).toBeUndefined();
+			// pi-ai 0.84.4's OpenCode Go metadata supports low reasoning, so the
+			// explicit routing depth is now forwarded instead of being suppressed.
+			expect(requestBody?.thinking).toEqual({ type: "enabled" });
+			expect(requestBody?.reasoning_effort).toBe("low");
 		} finally {
 			globalThis.fetch = originalFetch;
 		}

--- a/platform/daemon/src/pipeline/model-registry.test.ts
+++ b/platform/daemon/src/pipeline/model-registry.test.ts
@@ -35,7 +35,7 @@ describe("static model registry", () => {
 		const acpx = getAvailableModels("acpx").map((model) => model.id);
 		expect(acpx).toContain("gpt-5.4-mini");
 		expect(acpx).toContain("haiku");
-		expect(acpx).toContain("google/gemini-2.5-flash");
+		expect(acpx).toContain("opencode/gemini-3-flash");
 		expect(acpx).not.toContain("gpt-5-codex");
 		expect(acpx).not.toContain("gpt-5-codex-mini");
 	});
@@ -43,12 +43,13 @@ describe("static model registry", () => {
 	it("groups checked catalog entries by provider", () => {
 		const byProvider = getModelsByProvider();
 		expect(byProvider.codex.map((model) => model.id)).toEqual([
+			"gpt-5.3-codex-spark",
 			"gpt-5.4-mini",
 			"gpt-5.4",
 			"gpt-5.5",
-			"gpt-5.3-codex",
-			"gpt-5.3-codex-spark",
-			"gpt-5.2",
+			"gpt-5.6-luna",
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
 		]);
 		expect(byProvider.acpx.map((model) => model.id)).toContain("gpt-5.4-mini");
 	});

--- a/platform/daemon/src/routes/pipeline-routes-models.test.ts
+++ b/platform/daemon/src/routes/pipeline-routes-models.test.ts
@@ -23,7 +23,7 @@ describe("pipeline model routes", () => {
 		const ids = body.models.map((model) => model.id);
 		expect(ids).toContain("gpt-5.4-mini");
 		expect(ids).toContain("haiku");
-		expect(ids).toContain("google/gemini-2.5-flash");
+		expect(ids).toContain("opencode/gemini-3-flash");
 		expect(ids).not.toContain("gpt-5-codex");
 		expect(ids).not.toContain("gpt-5-codex-mini");
 	});
@@ -34,12 +34,13 @@ describe("pipeline model routes", () => {
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as Record<string, Array<{ id: string }>>;
 		expect(body.codex.map((model) => model.id)).toEqual([
+			"gpt-5.3-codex-spark",
 			"gpt-5.4-mini",
 			"gpt-5.4",
 			"gpt-5.5",
-			"gpt-5.3-codex",
-			"gpt-5.3-codex-spark",
-			"gpt-5.2",
+			"gpt-5.6-luna",
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
 		]);
 		expect(body.acpx.map((model) => model.id)).toContain("gpt-5.4-mini");
 	});

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -43,8 +43,8 @@
 	"homepage": "https://signetai.sh",
 	"dependencies": {
 		"@signet/core": "workspace:*",
-		"@earendil-works/pi-ai": "0.83.0",
-		"@earendil-works/pi-tui": "0.83.0",
+		"@earendil-works/pi-ai": "0.84.4",
+		"@earendil-works/pi-tui": "0.84.4",
 		"@signet/connector-claude-code": "workspace:*",
 		"@signet/connector-codex": "workspace:*",
 		"@signet/connector-forge": "workspace:*",

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -68,7 +68,7 @@ describe("buildSetupPipeline", () => {
 describe("buildSetupInference", () => {
 	it("defaults ACPX models from the selected harness, not the ACPX provider bucket", () => {
 		expect(defaultAcpxModel(["codex"], ["acpx"])).toBe("gpt-5.4-mini");
-		expect(defaultAcpxModel(["opencode"], ["acpx"])).toBe("google/gemini-2.5-flash");
+		expect(defaultAcpxModel(["opencode"], ["acpx"])).toBe("opencode/gemini-3-flash");
 		expect(defaultAcpxModel(["claude-code"], ["acpx"])).toBe("haiku");
 		expect(defaultAcpxModel(["kimi"], ["acpx"])).toBe("haiku");
 
@@ -82,7 +82,7 @@ describe("buildSetupInference", () => {
 			buildSetupInference("acpx", undefined, ["opencode"], ["acpx"], "/usr/local/bin/bunx")?.targets["background-acpx"],
 		).toMatchObject({
 			acpx: { agent: "opencode" },
-			models: { default: { model: "google/gemini-2.5-flash" } },
+			models: { default: { model: "opencode/gemini-3-flash" } },
 		});
 		expect(
 			buildSetupInference("acpx", undefined, ["kimi"], ["acpx"], "/usr/local/bin/bunx")?.targets["background-acpx"],
@@ -95,7 +95,7 @@ describe("buildSetupInference", () => {
 	it("writes ACPX as explicit inference routing with the selected harness agent", () => {
 		const inference = buildSetupInference(
 			"acpx",
-			"google/gemini-2.5-flash",
+			"opencode/gemini-3-flash",
 			["opencode", "codex"],
 			[],
 			"/usr/local/bin/bunx",

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -85,7 +85,8 @@ function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string
 
 /**
  * Pick a model from a list of pi-ai model options. Plain select for short
- * lists, searchable `search` prompt for large ones (e.g. openrouter's 253) so
+ * lists, searchable `search` prompt for large ones (e.g. OpenRouter's full
+ * provider catalog) so
  * the user can type to find what they want — all results are shown, not capped.
  */
 async function pickModel(

--- a/surfaces/cli/src/lib/dream-attach.ts
+++ b/surfaces/cli/src/lib/dream-attach.ts
@@ -1,5 +1,12 @@
-import { Key, ProcessTerminal, TUI, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
-import type { Component } from "@earendil-works/pi-tui";
+import {
+	Key,
+	ProcessTerminal,
+	TuiMainScreen,
+	matchesKey,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import type { Component, TUI } from "@earendil-works/pi-tui";
 import type { DaemonStreamResult } from "./daemon.js";
 
 const MAX_VIEW_LINE_CHARS = 16_000;
@@ -483,7 +490,7 @@ export function createDreamingAttachTui(view: DreamingAttachView): {
 	readonly terminal: ProcessTerminal;
 } {
 	const terminal = new ProcessTerminal();
-	const tui = new TUI(terminal);
+	const tui = new TuiMainScreen(terminal);
 	tui.addChild(view);
 	tui.setFocus(view);
 	return { tui, terminal };


### PR DESCRIPTION
## Summary

Update Signet's pi-ai integration to 0.84.4 and refresh the static model registry against the current provider catalogs.

## Changes

- Bump `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` to 0.84.4.
- Adapt OAuth refresh and CLI TUI integration to the pi package APIs shipped in 0.84.4.
- Refresh Codex, OpenCode, Anthropic, and OpenRouter model presets and defaults.
- Add/update registry, provider factory, OAuth, setup, and TUI regression coverage.
- Keep the static list limited to legacy pipeline presets; pi-ai's provider catalogs remain authoritative for current setup/connect model discovery.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `refactor` — code change with no behavior change
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `test` — tests only

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/extension`
- [ ] `@signet/integrations`
- [ ] `@signet/memorybench`
- [ ] Other: N/A

## Screenshots

N/A: no dashboard, web, or extension UI changed.

## PR Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes

- [ ] Migration required — describe below
- [x] No migration required

The change updates package compatibility and static provider presets only. Existing configuration remains valid.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] `bun test` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted tests: 76 passed, 0 failed across core, daemon, and CLI registry/provider/TUI coverage.

The full lint command exits successfully; it reports pre-existing warnings in unrelated areas.

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)
- [ ] No AI tools were used

## Notes

The live pi-ai 0.84.4 catalogs and current `opencode models opencode` output were checked locally. No live provider API request was made.
