### PR TITLE
fix(ci): harden native embedding health gate repairs

### DIFF
--- a/.github/workflows/embedding-health-isolation.yml
+++ b/.github/workflows/embedding-health-isolation.yml
@@ -77,6 +77,10 @@ jobs:
         working-directory: platform/daemon
         run: bun test src/embedding-worker-handle.test.ts src/native-embedding.test.ts
 
+      - name: Native embedding /health isolation (source daemon)
+        working-directory: platform/daemon
+        run: bun test src/native-embedding-eventloop-isolation.test.ts
+
       # Compiled-binary guard: this is deliberately a separate gate from the
       # embedding smoke. It constructs DbOwnerClient inside the Bun-compiled
       # binary and executes a real owner query, so a missing embedded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,11 @@ jobs:
         if: steps.changes.outputs.skip != 'true'
         run: bun surfaces/cli/src/cli.ts --help > /dev/null
 
+      - name: Native embedding /health isolation (source daemon)
+        if: steps.changes.outputs.skip != 'true'
+        working-directory: platform/daemon
+        run: bun test src/native-embedding-eventloop-isolation.test.ts
+
       - name: Configure Git
         if: steps.changes.outputs.skip != 'true'
         run: |
@@ -278,10 +283,6 @@ jobs:
 
       - name: Build workspace dependencies
         run: bun run build
-
-      - name: Native embedding /health isolation (source daemon)
-        working-directory: platform/daemon
-        run: bun test src/native-embedding-eventloop-isolation.test.ts
 
       - name: Build dashboard assets
         run: bun run build:dashboard

--- a/platform/daemon/src/native-embedding-eventloop-isolation.test.ts
+++ b/platform/daemon/src/native-embedding-eventloop-isolation.test.ts
@@ -17,6 +17,7 @@
  * event loop can't be starved because the grinding now happens in a worker.
  */
 
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
 import { type ChildProcessByStdio, spawn } from "node:child_process";
 import type { Readable } from "node:stream";
@@ -151,11 +152,18 @@ async function freePort(): Promise<number> {
 	});
 }
 
+type BlackholeEndpoint = {
+	readonly origin: string;
+	readonly connectionCount: () => number;
+};
+
 /** A TCP server that accepts connections but never responds — makes an HTTP
  *  fetch hang indefinitely on response headers (a stalled CDN), hermetically. */
-async function blackholeOrigin(): Promise<string> {
+async function blackholeOrigin(): Promise<BlackholeEndpoint> {
 	return new Promise((resolve, reject) => {
+		let connectionCount = 0;
 		const server = createServer((socket) => {
+			connectionCount += 1;
 			// Hold the connection open without ever writing a response.
 			socket.on("error", () => {});
 		});
@@ -164,9 +172,27 @@ async function blackholeOrigin(): Promise<string> {
 			const address = server.address();
 			if (address === null || typeof address === "string") return reject(new Error("no port"));
 			servers.push(server);
-			resolve(`http://127.0.0.1:${address.port}`);
+			resolve({
+				origin: `http://127.0.0.1:${address.port}`,
+				connectionCount: () => connectionCount,
+			});
 		});
 	});
+}
+
+async function waitForBlackholeConnection(
+	endpoint: BlackholeEndpoint,
+	child: TestChild,
+	lifecycle: ChildLifecycle,
+	deadlineMs = 60_000,
+): Promise<void> {
+	const deadline = Date.now() + deadlineMs;
+	while (Date.now() < deadline) {
+		if (endpoint.connectionCount() > 0) return;
+		if (child.exitCode !== null || child.signalCode !== null) throw await childExitError(child, lifecycle);
+		await Bun.sleep(100);
+	}
+	throw new Error(`native embedding worker did not reach the blackhole within ${deadlineMs}ms`);
 }
 
 async function waitForHealth(
@@ -228,19 +254,22 @@ describe("native embedding event-loop isolation (e2e)", () => {
 		await expect(result).rejects.toThrow(/status unknown, signal SIGTERM/);
 	});
 
-	// Generous timeout: daemon startup + a 5s probe window.
+	// Generous timeout: daemon startup + deferred native startup + a 5s probe window.
 	it("/health stays within SLA while the embedding worker is stuck on a model download", async () => {
 		const agentsDir = tempDir();
+		mkdirSync(join(agentsDir, "memory"), { recursive: true });
+		const database = new Database(join(agentsDir, "memory", "memories.db"));
+		database.close();
 		writeFileSync(
 			join(agentsDir, "agent.yaml"),
 			[
 				"memory:",
 				"  pipelineV2:",
 				"    enabled: false",
-				"  embedding:",
-				"    provider: native",
-				"    model: nomic-ai/nomic-embed-text-v1.5",
-				"    dimensions: 768",
+				"embedding:",
+				"  provider: native",
+				"  model: nomic-ai/nomic-embed-text-v1.5",
+				"  dimensions: 768",
 				"",
 			].join("\n"),
 		);
@@ -256,7 +285,7 @@ describe("native embedding event-loop isolation (e2e)", () => {
 				SIGNET_BIND: "127.0.0.1",
 				// Redirect the transformers model fetch to the blackhole so the
 				// embedding worker's first-run download hangs for the whole probe.
-				SIGNET_EMBEDDING_REMOTE_HOST: blackhole,
+				SIGNET_EMBEDDING_REMOTE_HOST: blackhole.origin,
 				// Avoid crosstalk with the user's real daemon/services.
 				SIGNET_DAEMON_ENTRYPOINT: "1",
 			},
@@ -270,9 +299,13 @@ describe("native embedding event-loop isolation (e2e)", () => {
 
 		await waitForHealth(origin, child, lifecycle);
 
-		// The daemon's startup probe (daemon.ts) fires checkEmbeddingProvider
-		// at boot, so the embedding worker is now grinding against the
-		// blackhole. Poll /health through the window and assert the SLA.
+		// The daemon's deferred startup probe (daemon.ts) fires after the initial
+		// health handshake. Waiting for the blackhole connection proves the native worker
+		// entered its model fetch before this test evaluates the /health SLA.
+		await waitForBlackholeConnection(blackhole, child, lifecycle);
+		expect(blackhole.connectionCount()).toBeGreaterThan(0);
+
+		// Poll /health through the window and assert the SLA.
 		const samples: number[] = [];
 		const probeDeadline = Date.now() + 5_000;
 		while (Date.now() < probeDeadline) {
@@ -288,46 +321,5 @@ describe("native embedding event-loop isolation (e2e)", () => {
 		// while the embedding worker is hung. (Before the fix this timed out.)
 		const max = Math.max(...samples);
 		expect(max).toBeLessThan(1_000);
-
-		// Prove the embedding worker actually started its (stuck) init against
-		// the blackhole — otherwise this test could pass trivially with the
-		// provider idle. The handle forwards worker logs through the daemon
-		// logger, which writes to the agents-dir log.
-		const logDir = join(agentsDir, ".daemon", "logs");
-		let logText = "";
-		try {
-			for (const name of readdirSync(logDir)) {
-				if (name.endsWith(".log")) logText += readFileSync(join(logDir, name), "utf8");
-			}
-		} catch {
-			// logs may live elsewhere on some platforms; the SLA assertion above
-			// is the load-bearing guard.
-		}
-		expect(logText).toMatch(/nomic-embed|Initializing.*nomic|embedding/i);
-	}, 60_000);
-
-	it("starts the DB owner when the fresh workspace has no memory directory", async () => {
-		const agentsDir = tempDir();
-		const port = await freePort();
-		const origin = `http://127.0.0.1:${port}`;
-		expect(readdirSync(agentsDir)).not.toContain("memory");
-
-		const child = spawn(process.execPath, [daemonScript], {
-			env: {
-				...process.env,
-				SIGNET_PORT: String(port),
-				SIGNET_PATH: agentsDir,
-				SIGNET_BIND: "127.0.0.1",
-				SIGNET_DAEMON_ENTRYPOINT: "1",
-			},
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-		children.push(child);
-		const lifecycle = captureChildLifecycle(child, agentsDir);
-		child.stdout.on("data", () => {});
-
-		await waitForHealth(origin, child, lifecycle);
-		expect(readdirSync(agentsDir)).toContain("memory");
-		expect((await fetch(`${origin}/health`)).ok).toBe(true);
-	}, 60_000);
+	}, 120_000);
 });


### PR DESCRIPTION
## Summary

This replaces the prior five-commit implementation on #1839 with one coherent commit based directly on the latest `main` (`4d402bf24fcd05570999c6b9b070f27fe989aae0`).

The failure was a stale explicit-workspace fixture, not a native embedding runtime regression. The event-loop isolation E2E passed `SIGNET_PATH` to a temporary directory without `memory/memories.db`; `preflightWorkspace()` correctly classified that explicit workspace as incomplete and the daemon exited before `/health`. The fixture also nested `embedding` under `memory`, so it did not configure the native provider through the current loader.

Production workspace preflight and native embedding runtime behavior are unchanged.

## Changes

- `platform/daemon/src/native-embedding-eventloop-isolation.test.ts`: write `agent.yaml` with a top-level `embedding` key; create an empty valid `memory/memories.db` by opening and closing it with `bun:sqlite`; retain the local TCP blackhole; expose its accepted-connection counter; and wait for a worker connection before collecting `/health` latency samples.
- Removed the invalid embedding-suite test that treated an explicit empty `SIGNET_PATH` as a fresh workspace the daemon should bootstrap.
- `.github/workflows/embedding-health-isolation.yml`: run the platform-independent source isolation E2E in the dedicated workflow.
- `.github/workflows/release.yml`: run that source E2E exactly once in the `release` job after the build and CLI smoke, before Git/version/tag/release mutation; remove it from the `build-native` matrix. The matrix still owns compiled platform artifacts and compiled smoke coverage.

All model traffic in the source E2E remains redirected to the local blackhole; no external model registry or network dependency is added.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [x] Other: CI workflows and source E2E coverage

## Screenshots

Not applicable: no UI behavior changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable: no migrations or persisted schema changes.

## Testing

- `bun install --frozen-lockfile`: pass.
- `bun test platform/daemon/src/native-embedding-eventloop-isolation.test.ts`: 3 pass, 0 fail, 29 expectations.
- `bun test platform/daemon/src/workspace-startup.test.ts`: 1 pass, 0 fail, 5 expectations.
- Fixture mutation proof: removing the empty database initialization made the positive E2E fail closed with `incomplete workspace` and `workspace database is missing (memory/memories.db)`; restoring it made the E2E pass.
- Blackhole witness mutation proof: redirecting the worker to an unused local endpoint made the test fail at `native embedding worker did not reach the blackhole within 1000ms`, before accepting `/health` measurements; restoring it made the E2E pass.
- `bun run --filter '@signet/daemon' build`: pass.
- `bun run typecheck`: pass.
- `bun run lint`: pass with the repository's existing 535 warnings and 24 infos.
- `bunx biome check platform/daemon/src/native-embedding-eventloop-isolation.test.ts`: pass.
- `git diff --check`: pass.
- Workflow inspection: the source E2E occurs once in `release.yml`, after Build and CLI runtime smoke, before Configure Git, Bump version, tagging, Push version bump, and GitHub release creation; it is absent from `build-native`; `SIGNET_NATIVE_EMBEDDING_SMOKE` remains `"0"`.

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- `preflightWorkspace()` was not changed.
- `scripts/native-embedding-runtime-smoke.test.ts` was not changed.
- The final commit is `f339ffda5749f7eba79d897bc7c76a4532dc90dc`, with parent `4d402bf24fcd05570999c6b9b070f27fe989aae0`.
- Generated connector bundle files used to complete the repository-wide typecheck are ignored and are not part of this PR.