### PR TITLE
test(daemon): prove saturated read lease release

### DIFF
--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -575,26 +575,63 @@ describe("getKnowledgeEntityDetail (issue #515)", () => {
 		expect(detail?.dependencyCount).toBe(3);
 	});
 
-	test("releases the detail lease before nested structural reads", async () => {
+	test("releases every saturated detail lease before nested structural reads (#1758)", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 		seedEntity("e-hub", "Hub");
 
-		const requests = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
-			getKnowledgeEntityDetail(getDbAccessor(), "e-hub", "default"),
-		);
-		const completed = await Promise.race([
-			Promise.all(requests).then(
-				() => true,
-				() => false,
+		const accessor = getDbAccessor();
+		// The live base routes getKnowledgeEntityDetail through the DB owner.
+		// Keep this synchronization proof at the accessor boundary where the
+		// lease contract is implemented, rather than wrapping an unused seam.
+		let entered = 0;
+		let releaseCallbacks = (): void => {};
+		let resolveAllEntered = (): void => {};
+		const callbackGate = new Promise<void>((resolve) => {
+			releaseCallbacks = resolve;
+		});
+		const allEntered = new Promise<void>((resolve) => {
+			resolveAllEntered = resolve;
+		});
+		const requests = Array.from({ length: MAX_READ_CONNECTIONS }, (_, index) =>
+			accessor.withReadDbAsync(
+				async (db) => {
+					// This is the synchronous detail query in the saturated request.
+					db.prepare("SELECT ? AS entity_id").get(index);
+					entered += 1;
+					if (entered === MAX_READ_CONNECTIONS) resolveAllEntered();
+					await callbackGate;
+					// The structural-density query must be able to acquire a new
+					// lease while the outer callback continuation is still pending.
+					return await accessor.withReadDbAsync((innerDb) => innerDb.prepare("SELECT 1 AS structural_density").get(), {
+						operation: "db:knowledge.structural-density.read",
+					});
+				},
+				{ operation: "db:knowledge.entity-detail.read" },
 			),
-			new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 500)),
-		]);
-		if (!completed) {
-			closeDbAccessor();
+		);
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let pressureVerified = false;
+		try {
+			await Promise.race([
+				allEntered,
+				new Promise<never>((_, reject) => {
+					timer = setTimeout(() => reject(new Error("detail callbacks did not saturate the read pool")), 2_000);
+				}),
+			]);
+			expect(accessor.getReadPressure()).toMatchObject({
+				activeLeases: 0,
+				queued: 0,
+				maxConnections: MAX_READ_CONNECTIONS,
+			});
+			pressureVerified = true;
+		} finally {
+			if (timer !== undefined) clearTimeout(timer);
+			releaseCallbacks();
+			if (!pressureVerified) accessor.close();
 			await Promise.allSettled(requests);
 		}
-		expect(completed).toBe(true);
+		await expect(Promise.all(requests)).resolves.toHaveLength(MAX_READ_CONNECTIONS);
 	});
 
 	test("returns null for unknown entity id", async () => {


### PR DESCRIPTION
## Summary

- replace the 500 ms knowledge-detail lease race with a deterministic saturated read-pool proof
- exercise the current owning `withReadDbAsync` boundary instead of the retired accessor injection seam
- prove every saturated callback releases its lease before its async continuation performs a nested structural read

Closes the stranded test recovery for [#1758](https://github.com/Signet-AI/signetai/issues/1758) and recovers the focused boundary from [#1830](https://github.com/Signet-AI/signetai/pull/1830) onto current `main`.

## Verification

- `bun test ./platform/daemon/src/knowledge-graph-list.test.ts -t 'releases every saturated detail lease before nested structural reads'` — pass
- `bunx biome check platform/daemon/src/knowledge-graph-list.test.ts` — pass
- `bun run --filter '@signet/daemon' typecheck` — pass
- `git diff --check` — pass
- mutation proof: delaying `releaseRead` until the async callback completed made the regression fail with `activeLeases: 16`; restoring the implementation returned it to green

The full knowledge graph file rerun was attempted with `--rerun-each=3`, but concurrent DB owner processes caused unrelated owner deadline and cleanup failures in existing tests. The new regression passed during that run and in the focused invocation above.
