### PR TITLE
fix(daemon): exclude superseded context candidates

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,23 +4,23 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 846 sites
+- Exact ledger inventory: 842 sites
 - Synchronous `withWriteTx()` sites: 65
-- Synchronous `withReadDb()` sites: 99
+- Synchronous `withReadDb()` sites: 97
 - Async-named DB sites: 173
 - Async-named ON-PARENT DB sites: 171
 - Async-named OFF-PARENT DB sites: 2
-- Synchronous filesystem/process sites: 509
-- Compile-visible legacy DB sites remaining: 164
+- Synchronous filesystem/process sites: 507
+- Compile-visible legacy DB sites remaining: 162
   - `withWriteTx`: 65
-  - `withReadDb`: 99
+  - `withReadDb`: 97
 
-The 846-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites are the complete database-call inventory; 164 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 842-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 65 synchronous writes, 97 synchronous reads, and 173 async-named DB sites are the complete database-call inventory; 162 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
-- Database accessor sites classified: 337
-- ON-PARENT callback execution: 335
+- Database accessor sites classified: 335
+- ON-PARENT callback execution: 333
 - OFF-PARENT callback execution: 2
 - Ratchet: new ON-PARENT async-named sites fail the audit; the campaign target is ON-PARENT → 0
 
@@ -91,15 +91,13 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `github-source-provider.ts:460` (withReadDbAsync)
 - `github-source-provider.ts:482` (withWriteTxAsync)
 - `github-source-provider.ts:502` (withWriteTxAsync)
-- `hooks.ts:830` (withReadDbAsync)
+- `db:hooks.session-start.inheritance` (withReadDbAsync)
 - `imported-source-lifecycle.ts:36` (withWriteTx)
 - `imported-source-outcome.ts:16` (withWriteTx)
 - `imported-source-outcome.ts:62` (withReadDb)
 - `knowledge-graph-hygiene.ts:428` (withReadDb)
 - `db:knowledge.entity-knowledge-tree.read` (withReadDbAsync)
 - `db:knowledge.graph-constellation.read` (withReadDbAsync)
-- `memory-candidates.ts:470` (withReadDb)
-- `memory-candidates.ts:511` (withReadDb)
 - `memory-head-curation.ts:31` (withReadDbAsync)
 - `memory-head-curation.ts:64` (withWriteTxAsync)
 - `memory-head-curation.ts:101` (withWriteTxAsync)
@@ -119,12 +117,12 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `db:memory.noise.sessions` (withReadDbAsync)
 - `memory-search-telemetry.ts:245` (withWriteTxAsync)
 - `memory-search-telemetry.ts:321` (withReadDbAsync)
-- `memory-search.ts:2308` (withReadDbAsync)
-- `memory-search.ts:2386` (withReadDbAsync)
-- `memory-search.ts:2433` (withReadDbAsync)
-- `memory-search.ts:2512` (withReadDbAsync)
-- `memory-search.ts:2793` (withReadDbAsync)
-- `memory-search.ts:2820` (withReadDbAsync)
+- `db:recall.temporal-topic.content` (withReadDbAsync)
+- `db:recall.facet-coverage.content` (withReadDbAsync)
+- `db:recall.reranker.content` (withReadDbAsync)
+- `db:recall.dampening.metadata` (withReadDbAsync)
+- `db:recall.final-candidates.hydrate` (withReadDbAsync)
+- `db:recall.final-candidates.safety` (withReadDbAsync)
 - `obsidian-source-embeddings.ts:630` (withReadDb)
 - `obsidian-source-embeddings.ts:666` (withWriteTx)
 - `obsidian-source-embeddings.ts:682` (withReadDb)
@@ -384,4 +382,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 164 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 65 write and 99 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 162 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 65 write and 97 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -739,6 +739,25 @@ describe("inferType", () => {
 // ============================================================================
 
 describe("handleSessionStart", () => {
+	test.serial("does not inject a pinned superseded memory", async () => {
+		createMemoryDb();
+		const db = openTestDb();
+		const oldId = "hook-superseded-tuesday";
+		const currentId = "hook-current-thursday";
+		db.prepare(
+			"INSERT INTO memories (id, content, who, created_at, updated_at, importance, pinned, agent_id) VALUES (?, ?, 'test', ?, ?, 0.9, 1, 'default')",
+		).run(oldId, "Project Marigold deploys on Tuesdays.", "2026-09-04T10:00:00.000Z", "2026-09-04T10:00:00.000Z");
+		db.prepare(
+			"INSERT INTO memories (id, content, who, created_at, updated_at, importance, agent_id) VALUES (?, ?, 'test', ?, ?, 0.9, 'default')",
+		).run(currentId, "Project Marigold deploys on Thursdays.", "2026-09-04T11:00:00.000Z", "2026-09-04T11:00:00.000Z");
+		db.prepare("UPDATE memories SET superseded_by = ? WHERE id = ?").run(currentId, oldId);
+		db.close();
+
+		const result = await handleSessionStart({ harness: "codex", prompt: "When does Marigold deploy?" });
+		expect(result.inject).toContain("Project Marigold deploys on Thursdays.");
+		expect(result.inject).not.toContain("Project Marigold deploys on Tuesdays.");
+	});
+
 	test.serial("returns default identity when no config files exist", async () => {
 		const result = await handleSessionStart({ harness: "claude-code" });
 

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -666,22 +666,6 @@ async function getRecentMemories(
 	}
 }
 
-/**
- * Get memories created after a given timestamp, ordered by recency.
- */
-function _getMemoriesSince(
-	sinceMs: number,
-	limit: number,
-): Array<{
-	id: string;
-	content: string;
-	type: string;
-	importance: number;
-	created_at: string;
-}> {
-	return memoryCandidates.getMemoriesSince(getMemoryDbPath(), sinceMs, limit);
-}
-
 // ============================================================================
 // Hook Handlers
 // ============================================================================

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -826,7 +826,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 					});
 					return parent ? assembleInheritedContextBlock(db, parent, subagentCfg) : null;
 				},
-				{ siteToken: "hooks.ts:830" },
+				{ siteToken: "db:hooks.session-start.inheritance" },
 			);
 			inheritedSection = block ?? "";
 		} catch (error) {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -63,7 +63,7 @@ import { type ScoredMemory, buildActiveConstraintsSection } from "./memory-candi
 import { effectiveScore, inferType, isDuplicate } from "./memory-classification";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
 
-import { type RecallResponse, type RecallResult, hybridRecall } from "./memory-search";
+import { type RecallResponse, type RecallResult, currentMemorySql, hybridRecall } from "./memory-search";
 import { recordMemorySearchTelemetry } from "./memory-search-telemetry";
 import {
 	type SynthesisRequest,
@@ -626,7 +626,7 @@ async function getRecentMemories(
           (julianday('now') - julianday(m.created_at)) as age_days${safetyProjection}
         FROM memories m
         ${safetyJoin}
-        WHERE m.is_deleted = 0${scope.sql}
+        WHERE 1 = 1${currentMemorySql("m")}${scope.sql}
         ORDER BY
           (m.importance * ${1 - recencyBias}) +
           (1.0 / (1.0 + (julianday('now') - julianday(m.created_at)))) * ${recencyBias}

--- a/platform/daemon/src/memory-candidates.test.ts
+++ b/platform/daemon/src/memory-candidates.test.ts
@@ -84,7 +84,7 @@ describe("fetchTraversalCandidates (#1250)", () => {
 		insertMemory("memory-no-attribute", "agent-a", 0.4);
 		insertMemory("memory-superseded", "agent-a", 0.95);
 		getDbAccessor().withWriteTx((db) => {
-			db.prepare("UPDATE memories SET superseded_by = 'memory-active' WHERE id = 'memory-superseded'").run();
+			db.prepare("UPDATE memories SET pinned = 1, superseded_by = 'memory-active' WHERE id = 'memory-superseded'").run();
 		});
 		insertAttribute("attribute-a-1", "memory-active", "agent-a", 0.4);
 		insertAttribute("attribute-a-2", "memory-active", "agent-a", 0.9);

--- a/platform/daemon/src/memory-candidates.test.ts
+++ b/platform/daemon/src/memory-candidates.test.ts
@@ -82,6 +82,10 @@ describe("fetchTraversalCandidates (#1250)", () => {
 		insertMemory("memory-other-agent", "agent-a", 0.3);
 		insertMemory("memory-deleted", "agent-a", 0.9, 1);
 		insertMemory("memory-no-attribute", "agent-a", 0.4);
+		insertMemory("memory-superseded", "agent-a", 0.95);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET superseded_by = 'memory-active' WHERE id = 'memory-superseded'").run();
+		});
 		insertAttribute("attribute-a-1", "memory-active", "agent-a", 0.4);
 		insertAttribute("attribute-a-2", "memory-active", "agent-a", 0.9);
 		insertAttribute("attribute-b", "memory-active", "agent-b", 1.0);
@@ -89,7 +93,7 @@ describe("fetchTraversalCandidates (#1250)", () => {
 
 		const rows = await fetchTraversalCandidates(
 			dbPath,
-			["memory-active", "memory-other-agent", "memory-deleted", "memory-no-attribute"],
+			["memory-active", "memory-other-agent", "memory-deleted", "memory-no-attribute", "memory-superseded"],
 			"agent-a",
 		);
 		const byId = new Map(rows.map((row) => [row.id, row]));
@@ -99,6 +103,18 @@ describe("fetchTraversalCandidates (#1250)", () => {
 		expect(byId.get("memory-other-agent")?.effScore).toBe(0.3);
 		expect(byId.get("memory-no-attribute")?.effScore).toBe(0.4);
 		expect(byId.has("memory-deleted")).toBe(false);
+		expect(byId.has("memory-superseded")).toBe(false);
+	});
+
+	test("excludes superseded memories from the ordinary candidate pool", async () => {
+		insertMemory("memory-current", "agent-a", 0.5);
+		insertMemory("memory-old", "agent-a", 0.95);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET superseded_by = 'memory-current' WHERE id = 'memory-old'").run();
+		});
+
+		const rows = await getAllScoredCandidates(dbPath, undefined, 10, "agent-a");
+		expect(rows.map((row) => row.id)).toEqual(["memory-current"]);
 	});
 
 	test("caps the hydration IN list and yields between batches", async () => {

--- a/platform/daemon/src/memory-candidates.test.ts
+++ b/platform/daemon/src/memory-candidates.test.ts
@@ -84,7 +84,9 @@ describe("fetchTraversalCandidates (#1250)", () => {
 		insertMemory("memory-no-attribute", "agent-a", 0.4);
 		insertMemory("memory-superseded", "agent-a", 0.95);
 		getDbAccessor().withWriteTx((db) => {
-			db.prepare("UPDATE memories SET pinned = 1, superseded_by = 'memory-active' WHERE id = 'memory-superseded'").run();
+			db.prepare(
+				"UPDATE memories SET pinned = 1, superseded_by = 'memory-active' WHERE id = 'memory-superseded'",
+			).run();
 		});
 		insertAttribute("attribute-a-1", "memory-active", "agent-a", 0.4);
 		insertAttribute("attribute-a-2", "memory-active", "agent-a", 0.9);

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import { type AgentRosterReadPolicy, scanMemoryContent } from "@signet/core";
 import { yieldEvery } from "./async-yield";
-import { getDbAccessor } from "./db-accessor";
 import { getDbOwner } from "./db-owner-runtime";
 import { ownerReadAll, ownerReadOne } from "./db-owner-sql";
 import { logger } from "./logger";
@@ -19,14 +18,6 @@ export interface ScoredMemory {
 	created_at: string;
 	access_count: number;
 	effScore: number;
-}
-
-export interface SimpleMemory {
-	id: string;
-	content: string;
-	type: string;
-	importance: number;
-	created_at: string;
 }
 
 const PREDICTED_CONTEXT_TERM_LIMIT = 6;
@@ -457,78 +448,6 @@ export async function getPredictedContextMemories(
 		logger.warn("hooks", "Predicted context failed (non-fatal)", {
 			error: e instanceof Error ? e.message : String(e),
 		});
-		return [];
-	}
-}
-
-export function getRecentMemories(memoryDbPath: string, limit: number, recencyBias = 0.7): SimpleMemory[] {
-	if (!existsSync(memoryDbPath)) return [];
-
-	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const query = `
-        SELECT
-          id, content, type, importance, created_at,
-          (julianday('now') - julianday(created_at)) as age_days
-        FROM memories
-				WHERE is_deleted = 0 AND superseded_by IS NULL AND stale_at IS NULL
-        ORDER BY
-          (importance * ${1 - recencyBias}) +
-          (1.0 / (1.0 + (julianday('now') - julianday(created_at)))) * ${recencyBias}
-          DESC
-        LIMIT ?
-      `;
-
-			return (db.prepare(query).all(limit) as unknown as Array<SimpleMemory>).filter(
-				(row) => scanMemoryContent(row.content).contextEligible,
-			);
-		}, "memory-candidates.ts:470");
-
-		return rows.map((r) => ({
-			id: r.id,
-			content: r.content,
-			type: r.type || "general",
-			importance: r.importance || 0.5,
-			created_at: r.created_at,
-		}));
-	} catch (e) {
-		logger.error("hooks", "Failed to query memories", e as Error);
-		return [];
-	}
-}
-
-/**
- * Get memories created after a given timestamp, ordered by recency.
- */
-export function getMemoriesSince(memoryDbPath: string, sinceMs: number, limit: number): SimpleMemory[] {
-	if (!existsSync(memoryDbPath)) return [];
-
-	try {
-		const sinceIso = new Date(sinceMs).toISOString();
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const rows = db
-				.prepare(`
-				SELECT id, content, type, importance, created_at
-				FROM memories
-				WHERE is_deleted = 0 AND superseded_by IS NULL AND stale_at IS NULL AND created_at > ?
-				ORDER BY created_at DESC
-				LIMIT ?
-			`)
-				.all(sinceIso, limit) as unknown as Array<SimpleMemory>;
-			return rows.filter((row) => scanMemoryContent(row.content).contextEligible);
-		}, "memory-candidates.ts:511");
-
-		return rows.map((r) => ({
-			id: r.id,
-			content: r.content,
-			type: r.type || "general",
-			importance: r.importance || 0.5,
-			created_at: r.created_at,
-		}));
-	} catch (e) {
-		logger.error("hooks", "Failed to query memories since timestamp", e as Error);
 		return [];
 	}
 }

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -6,7 +6,7 @@ import { getDbOwner } from "./db-owner-runtime";
 import { ownerReadAll, ownerReadOne } from "./db-owner-sql";
 import { logger } from "./logger";
 import { effectiveScore } from "./memory-classification";
-import { buildAgentScopeClause } from "./memory-search";
+import { buildAgentScopeClause, currentMemorySql } from "./memory-search";
 
 export interface ScoredMemory {
 	id: string;
@@ -193,8 +193,7 @@ export async function fetchTraversalCandidates(
 						 0.5
 					 ) AS effScore${safetySelect}
 				 FROM memories m${safetyJoin}
-				 WHERE m.id IN (${placeholders})
-				   AND m.is_deleted = 0`,
+				 WHERE m.id IN (${placeholders})${currentMemorySql("m")}`,
 				hasSafetyTable ? [agentId, agentId, ...batch] : [agentId, ...batch],
 				{
 					operation: "session-start.traversal-candidate-hydration",
@@ -278,7 +277,7 @@ export async function getAllScoredCandidates(
 			`SELECT m.id, m.content, m.type, m.importance, m.tags, m.pinned, m.project, m.created_at,
 			        COALESCE(m.access_count, 0) AS access_count
 			 FROM memories m${safetyJoin}
-			 WHERE m.is_deleted = 0${scope.sql}${safetyPredicate}
+				 WHERE 1 = 1${currentMemorySql("m")}${scope.sql}${safetyPredicate}
 			 ORDER BY m.created_at DESC LIMIT ?`,
 			hasSafetyTable ? [agentId, ...scope.args, limit * 3] : [...scope.args, limit * 3],
 			readOptions,
@@ -422,7 +421,7 @@ export async function getPredictedContextMemories(
 			 JOIN memories m ON memories_fts.rowid = m.rowid
 			 ${hasSafetyTable ? "LEFT JOIN memory_content_safety safety ON safety.agent_id = ? AND safety.source_kind = 'memory' AND safety.source_id = m.id" : ""}
 			 WHERE memories_fts MATCH ?
-			   AND m.is_deleted = 0
+			   ${currentMemorySql("m")}
 			   AND m.project = ?
 			   ${scope.sql}
 			 ORDER BY bm25(memories_fts)
@@ -473,7 +472,7 @@ export function getRecentMemories(memoryDbPath: string, limit: number, recencyBi
           id, content, type, importance, created_at,
           (julianday('now') - julianday(created_at)) as age_days
         FROM memories
-        WHERE is_deleted = 0
+				WHERE is_deleted = 0 AND superseded_by IS NULL AND stale_at IS NULL
         ORDER BY
           (importance * ${1 - recencyBias}) +
           (1.0 / (1.0 + (julianday('now') - julianday(created_at)))) * ${recencyBias}
@@ -513,7 +512,7 @@ export function getMemoriesSince(memoryDbPath: string, sinceMs: number, limit: n
 				.prepare(`
 				SELECT id, content, type, importance, created_at
 				FROM memories
-				WHERE is_deleted = 0 AND created_at > ?
+				WHERE is_deleted = 0 AND superseded_by IS NULL AND stale_at IS NULL AND created_at > ?
 				ORDER BY created_at DESC
 				LIMIT ?
 			`)

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -697,29 +697,9 @@ function mergeCandidate(
 	}
 }
 
-function hasColumn(
-	db: { prepare: (sql: string) => { all: () => Array<{ name?: unknown }> } },
-	table: string,
-	column: string,
-): boolean {
-	try {
-		return db
-			.prepare(`PRAGMA table_info(${table})`)
-			.all()
-			.some((row) => row.name === column);
-	} catch {
-		return false;
-	}
-}
-
-function memorySupersessionSql(
-	db: { prepare: (sql: string) => { all: () => Array<{ name?: unknown }> } },
-	alias = "m",
-): string {
-	const currentness: string[] = [];
-	if (hasColumn(db, "memories", "superseded_by")) currentness.push(`${alias}.superseded_by IS NULL`);
-	if (hasColumn(db, "memories", "stale_at")) currentness.push(`${alias}.stale_at IS NULL`);
-	return currentness.length > 0 ? ` AND ${currentness.join(" AND ")}` : "";
+/** Eligibility for ordinary memory delivery. Lineage/history callers do not use this predicate. */
+export function currentMemorySql(alias = "m"): string {
+	return ` AND ${alias}.is_deleted = 0 AND ${alias}.superseded_by IS NULL AND ${alias}.stale_at IS NULL`;
 }
 
 function lexicalFallbackTerms(keywordQuery: string): string[] {
@@ -785,10 +765,10 @@ async function readLexicalFallbackThroughOwner(
  * has shipped since migration 002 and every accessor runs migrations.
  */
 export function memoryLifecycleSql(
-	db: { prepare: (sql: string) => { all: () => Array<{ name?: unknown }> } },
+	_db: { prepare: (sql: string) => { all: () => Array<{ name?: unknown }> } },
 	alias = "m",
 ): string {
-	return ` AND ${alias}.is_deleted = 0${memorySupersessionSql(db, alias)}`;
+	return currentMemorySql(alias);
 }
 
 async function authorizeScoredCandidates(
@@ -2796,7 +2776,7 @@ export async function hybridRecall(
 						.prepare(
 							`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at, m.visibility, m.scope, m.agent_id
         FROM memories m
-        WHERE m.id IN (${placeholders}) AND m.is_deleted = 0${memorySupersessionSql(db)}${filter.sql}`,
+        WHERE m.id IN (${placeholders})${currentMemorySql("m")}${filter.sql}`,
 						)
 						.all(...topIds, ...filter.args) as Array<{
 						id: string;

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -2270,7 +2270,7 @@ export async function hybridRecall(
 								 WHERE id IN (${placeholders})`,
 							)
 							.all(...candidateIds) as Array<{ id: string; content: string }>,
-					{ siteToken: "memory-search.ts:2308" },
+					{ siteToken: "db:recall.temporal-topic.content" },
 				);
 				for (const row of contentRows) {
 					const score = scoreTemporalTopicEvidence(query, row.content);
@@ -2348,7 +2348,7 @@ export async function hybridRecall(
 									 WHERE id IN (${placeholders})`,
 								)
 								.all(...coverageIds) as Array<{ id: string; content: string }>,
-						{ siteToken: "memory-search.ts:2386" },
+						{ siteToken: "db:recall.facet-coverage.content" },
 					);
 					contentMap = new Map(contentRows.map((row) => [row.id, row.content]));
 				}
@@ -2398,7 +2398,7 @@ export async function hybridRecall(
 						id: string;
 						content: string;
 					}>,
-				{ siteToken: "memory-search.ts:2433" },
+				{ siteToken: "db:recall.reranker.content" },
 			);
 			const contentMap = new Map(contentRows.map((r) => [r.id, r.content]));
 
@@ -2478,7 +2478,7 @@ export async function hybridRecall(
 						content: string;
 						type: string;
 					}>,
-				{ siteToken: "memory-search.ts:2512" },
+				{ siteToken: "db:recall.dampening.metadata" },
 			);
 			const meta = new Map(dampenRows.map((r) => [r.id, r]));
 
@@ -2770,7 +2770,7 @@ export async function hybridRecall(
 						scope: string | null;
 						agent_id: string | null;
 					}>,
-				{ siteToken: "memory-search.ts:2793" },
+				{ siteToken: "db:recall.final-candidates.hydrate" },
 			),
 	);
 
@@ -2784,7 +2784,7 @@ export async function hybridRecall(
 					content: row.content,
 				}),
 			),
-		{ siteToken: "memory-search.ts:2820" },
+		{ siteToken: "db:recall.final-candidates.safety" },
 	);
 	const rowMap = new Map(safeRows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -697,7 +697,11 @@ function mergeCandidate(
 	}
 }
 
-/** Eligibility for ordinary memory delivery. Lineage/history callers do not use this predicate. */
+/**
+ * Eligibility for ordinary memory delivery. All owner accessors run migrations
+ * before querying, so these lifecycle columns are required. Lineage/history
+ * callers do not use this predicate.
+ */
 export function currentMemorySql(alias = "m"): string {
 	return ` AND ${alias}.is_deleted = 0 AND ${alias}.superseded_by IS NULL AND ${alias}.stale_at IS NULL`;
 }
@@ -738,9 +742,7 @@ async function readLexicalFallbackThroughOwner(
 		 SELECT m.id, (${score.join(" + ")}) AS matches
 		 FROM fallback_scan m
 		 WHERE (${match})
-		   AND m.is_deleted = 0
-		   AND m.superseded_by IS NULL
-		   AND m.stale_at IS NULL
+		   ${currentMemorySql("m")}
 		   ${filter.sql}
 		 ORDER BY matches DESC
 		 LIMIT ?`,
@@ -752,23 +754,6 @@ async function readLexicalFallbackThroughOwner(
 			deadlineMs: 30_000,
 		},
 	);
-}
-
-/**
- * Lifecycle predicate for surfacing memories: deleted, superseded, and stale
- * rows must never reach a caller. Mirrors the gate `authorizeScoredCandidates`
- * applies to standard recall candidates so similarity-search routes (e.g.
- * GET /memory/similar) do not drift from recall semantics.
- *
- * Returns a SQL fragment starting with ` AND ...` (empty when the memories
- * table predates the lifecycle columns). `is_deleted` is unconditional — it
- * has shipped since migration 002 and every accessor runs migrations.
- */
-export function memoryLifecycleSql(
-	_db: { prepare: (sql: string) => { all: () => Array<{ name?: unknown }> } },
-	alias = "m",
-): string {
-	return currentMemorySql(alias);
 }
 
 async function authorizeScoredCandidates(
@@ -815,9 +800,7 @@ async function authorizeScoredCandidates(
 			 FROM memories m
 			 ${safetyJoin}
 			 WHERE m.id IN (${placeholders})
-			   AND m.is_deleted = 0
-			   AND m.superseded_by IS NULL
-			   AND m.stale_at IS NULL
+			   ${currentMemorySql("m")}
 			   ${filter.sql}
 			   ${hasSafetyLedger ? "AND (mcs.source_id IS NULL OR (mcs.status = 'clean' AND mcs.context_eligible = 1))" : ""}`,
 			[...batch, ...filter.args],
@@ -1740,9 +1723,7 @@ export async function hybridRecall(
 					 FROM memories_fts
 					 CROSS JOIN memories m ON memories_fts.rowid = m.rowid
 					 WHERE memories_fts MATCH ?
-					   AND m.is_deleted = 0
-					   AND m.superseded_by IS NULL
-					   AND m.stale_at IS NULL
+					   ${currentMemorySql("m")}
 					   ${filter.sql}
 					 ORDER BY raw_score
 					 LIMIT ?`,
@@ -1816,9 +1797,7 @@ export async function hybridRecall(
 				   CROSS JOIN memories m ON m.id = h.memory_id
 				   WHERE memory_hints_fts MATCH ?
 				     AND h.agent_id = m.agent_id
-				     AND m.is_deleted = 0
-				     AND m.superseded_by IS NULL
-				     AND m.stale_at IS NULL
+				     ${currentMemorySql("m")}
 				     ${filter.sql}
 				   ORDER BY raw_score LIMIT ?`;
 
@@ -2211,9 +2190,7 @@ export async function hybridRecall(
 										  AND ea.agent_id = ?
 										  AND ea.status = 'active'
 										 WHERE m.id IN (${placeholders})
-										   AND m.is_deleted = 0
-										   AND m.superseded_by IS NULL
-										   AND m.stale_at IS NULL
+										   ${currentMemorySql("m")}
 										   ${filter.sql}
 										 GROUP BY m.id, m.importance`,
 											[agentId, ...missingIds, ...filter.args],
@@ -3044,9 +3021,7 @@ export async function hybridRecall(
 						 ${safetyJoin}
 						 WHERE mem.entity_id IN (${ePlaceholders})
 						   AND m.type = 'rationale'
-						   AND m.is_deleted = 0
-						   AND m.superseded_by IS NULL
-						   AND m.stale_at IS NULL
+						   ${currentMemorySql("m")}
 						   ${filter.sql}
 						   ${safetyFilter}
 						 LIMIT 10`,
@@ -3112,9 +3087,7 @@ export async function hybridRecall(
 							 FROM memory_entity_mentions mem
 							 JOIN memories m ON m.id = mem.memory_id
 							 WHERE mem.entity_id IN (${ph})
-							   AND m.is_deleted = 0
-							   AND m.superseded_by IS NULL
-							   AND m.stale_at IS NULL
+							   ${currentMemorySql("m")}
 							   ${filter.sql}`,
 							[...eids, ...filter.args],
 							"memory-search.entity-context.scope",

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -38,8 +38,8 @@ import {
 	type RecallParams,
 	type RecallResponse,
 	buildAgentScopeClause,
+	currentMemorySql,
 	hybridRecall,
-	memoryLifecycleSql,
 } from "../memory-search";
 import { recordMemorySearchTelemetry } from "../memory-search-telemetry";
 import { resolveMemorySearchTelemetryProject } from "../memory-search-telemetry-project";
@@ -3647,7 +3647,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
         INNER JOIN memories m ON m.id = e.source_id
         WHERE e.source_type = 'memory' AND e.source_id = ?
         AND COALESCE(m.source_type, '') != 'aggregate-recall'
-        ${memoryLifecycleSql(db)}
+        ${currentMemorySql("m")}
         LIMIT 1
       `)
 						.get(id) as { vector: Buffer } | undefined,
@@ -3696,7 +3696,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						.prepare(`
 	        SELECT id, content, agent_id, type, tags, confidence, created_at
 	        FROM memories m
-	        WHERE id IN (${placeholders})${memoryLifecycleSql(db)}
+        WHERE id IN (${placeholders})${currentMemorySql("m")}
 	      `)
 						.all(...ids) as Array<{
 						id: string;

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -381,15 +381,15 @@ test("the generated report describes the type boundary and transitional counts",
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 169, withWriteTx: 65, withReadDb: 104 });
 	expect(report).toContain(`Exact ledger inventory: ${baseline.length} sites`);
-	expect(report).toContain("65 synchronous writes, 99 synchronous reads, and 173 async-named DB sites");
+	expect(report).toContain("65 synchronous writes, 97 synchronous reads, and 173 async-named DB sites");
 	expect(report).toContain("Async-named ON-PARENT DB sites: 171");
 	expect(report).toContain("Async-named OFF-PARENT DB sites: 2");
 	expect(report).not.toContain("async-named parent DB sites");
 	expect(report).toContain(
 		"The async-named DB counts above separate the 171 ON-PARENT callbacks from the 2 OFF-PARENT callbacks.",
 	);
-	expect(report).toContain("Database accessor sites classified: 337");
-	expect(report).toContain("ON-PARENT callback execution: 335");
+	expect(report).toContain("Database accessor sites classified: 335");
+	expect(report).toContain("ON-PARENT callback execution: 333");
 	expect(report).toContain("OFF-PARENT callback execution: 2");
 	expect(report).toContain("- `db:recall.embedding.config.read` (withReadDbAsync)");
 	expect(report).toContain("- `db:recall.vector.search.read` (withReadDbAsync)");

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1259,56 +1259,57 @@
     },
     {
       "path": "hooks.ts",
-      "line": 827,
+      "line": 811,
       "api": "existsSync",
       "source": "if (req.sessionKey && existsSync(getMemoryDbPath())) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 830,
+      "line": 814,
       "api": "withReadDbAsync",
       "source": "const block = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:hooks.session-start.inheritance"
     },
     {
       "path": "hooks.ts",
-      "line": 1683,
+      "line": 1667,
       "api": "existsSync",
       "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 1685,
+      "line": 1669,
       "api": "readFileSync",
       "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2093,
+      "line": 2077,
       "api": "existsSync",
       "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2095,
+      "line": 2079,
       "api": "readFileSync",
       "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2357,
+      "line": 2341,
       "api": "existsSync",
       "source": "} else if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2359,
+      "line": 2343,
       "api": "readFileSync",
       "source": "const raw = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
@@ -1639,51 +1640,23 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 133,
+      "line": 124,
       "api": "existsSync",
       "source": "if (memoryIds.length === 0 || !existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 240,
+      "line": 230,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 328,
+      "line": 318,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 466,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 470,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 506,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 511,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2096,45 +2069,51 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2308,
+      "line": 2265,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:recall.temporal-topic.content"
     },
     {
       "path": "memory-search.ts",
-      "line": 2386,
+      "line": 2343,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:recall.facet-coverage.content"
     },
     {
       "path": "memory-search.ts",
-      "line": 2433,
+      "line": 2390,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:recall.reranker.content"
     },
     {
       "path": "memory-search.ts",
-      "line": 2512,
+      "line": 2469,
       "api": "withReadDbAsync",
       "source": "const dampenRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:recall.dampening.metadata"
     },
     {
       "path": "memory-search.ts",
-      "line": 2793,
+      "line": 2750,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:recall.final-candidates.hydrate"
     },
     {
       "path": "memory-search.ts",
-      "line": 2820,
+      "line": 2777,
       "api": "withReadDbAsync",
       "source": "const safeRows = await getDbAccessor().withReadDbAsync(",
-      "category": "hot-path"
+      "category": "hot-path",
+      "siteToken": "db:recall.final-candidates.safety"
     },
     {
       "path": "migration-integrity-verify.ts",

--- a/scripts/legacy-sync-db-baseline.json
+++ b/scripts/legacy-sync-db-baseline.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"generatedFrom": "bun scripts/legacy-sync-db-baseline.ts",
 	"markedCallsites": {
-		"total": 164,
-		"withReadDb": 99,
+		"total": 162,
+		"withReadDb": 97,
 		"withWriteTx": 65
 	}
 }


### PR DESCRIPTION
A corrected memory could disappear from direct recall while still being injected by session-start hooks. Ordinary candidate selection now uses the same currentness predicate as recall, excluding deleted, superseded, and stale memories. Explicit lineage/history is retained.

## Changes

- Keep one `currentMemorySql` predicate in memory-search and use it in recall, traversal hydration, ordinary/predicted candidate selection, recent hook context, and similarity routes.
- Delete two unused synchronous candidate readers, their unused wrapper, and the obsolete schema-probing lifecycle helper. Preserve existing ranking, safety and authorization checks.
- Tighten the legacy synchronous-reader ratchet by two sites and regenerate its audit. Replace displaced line-number tokens with stable operation names.
- Add regression coverage for a superseded pinned traversal candidate, ordinary candidate selection, and actual session-start injection.

Current diff: 121 lines added, 252 removed (net -131), including tests and generated audit changes.

## Validation

- Independent hermetic candidate suite with pinned Bun 1.3.11: 6 passed, 13 expectations.
- The permanent pinned-supersession hook regression was run against both implementations with the same test source and pinned hermetic command. Base fails because its actual injected text contains Tuesday; candidate passes (1 test, 2 expectations). The baseline test file was restored byte-for-byte afterward.
- Daemon typecheck, repository-wide Biome check, exact event-loop audit and its 24 fixture tests pass.
- Real isolated daemon journey: remember Tuesday, supersede with Thursday, inspect retained lineage, direct recall and both Codex/Claude Code hook strings contain Thursday only. Both hooks also return Thursday-only after restart. Another agent sees no private memory. Fixture shutdown reports no forced cleanup or surviving processes.
- Broader suites were compared with identical commands in separate hermetic processes on base and candidate. Hooks: both 169 passed / 4 failed. Search: both 49 passed / 15 failed, with the same failing-test names; baseline has 12 unhandled errors and candidate 13, largely closed-owner/shared-state failures. Full suites are not claimed green.

## Explicit remaining work

This is a draft because the broader correction-everywhere task is not complete. A separate real curation reproduction shows generated MEMORY.md can publish a superseded Tuesday fact while live hook candidates return Thursday. That path has two active head writers, different persisted provenance representations, and static identity copies. This patch does not claim to invalidate generated heads or queued source-purge publications. Consolidating that authority requires a coherent follow-up; adding another hook-only filter would preserve the competing writers. Explicit user-authored identity files and historical evidence must remain untouched.

No database migration, ranking change, new memory engine, or historical evidence deletion is included.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`).
- [x] Agent scoping verified on all new/changed data queries.
- [x] Input/config validation and bounds checks added — no new external input boundary; existing filters retained.
- [x] Error handling and fallback paths tested (no silent swallow).
- [x] Security checks applied to admin/mutation endpoints — no mutation policy changed.
- [ ] Docs updated for API/spec/status changes.
- [x] Regression tests added for each bug fix.
- [ ] Lint/typecheck/tests pass locally — scoped checks pass; baseline suite failures and remaining runtime acceptance gaps are stated above.

## AI disclosure

- [x] AI tools were used.

GPT-5.6 Luna implemented the change and runtime reproductions. Codex independently reviewed the diff, reproduced candidate test results and baseline suite failures, and updated the deletion ratchet. Commits include Assisted-by trailers.
