### PR TITLE
refactor(setup): make source cloning explicit

### DIFF
--- a/platform/core/src/workspace-source-repo.test.ts
+++ b/platform/core/src/workspace-source-repo.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	type WorkspaceSourceRepoSyncResult,
 	resolveWorkspaceSourceRepoPath,
 	syncWorkspaceSourceRepo,
+	syncWorkspaceSourceRepoAsync,
 } from "./workspace-source-repo";
 
 const tmpDirs: string[] = [];
@@ -71,10 +72,40 @@ function pushRemoteChange(workDir: string, content: string, message: string): vo
 }
 
 function syncWorkspace(workspaceDir: string, remoteUrl: string): WorkspaceSourceRepoSyncResult {
-	return syncWorkspaceSourceRepo(workspaceDir, { remoteUrl });
+	return syncWorkspaceSourceRepo(workspaceDir, { remoteUrl, cloneIfMissing: true });
 }
 
 describe("syncWorkspaceSourceRepo", () => {
+	it("skips absent checkouts without cloning or creating sync state", async () => {
+		const { remoteUrl } = seedRemote();
+		const workspace = makeTempDir("signet-no-source-");
+		for (const sync of [syncWorkspaceSourceRepo, syncWorkspaceSourceRepoAsync]) {
+			expect(await sync(workspace, { remoteUrl })).toMatchObject({ status: "skipped" });
+			expect(existsSync(resolveWorkspaceSourceRepoPath(workspace))).toBe(false);
+			expect(existsSync(join(workspace, ".daemon"))).toBe(false);
+		}
+	});
+
+	it("does not treat an empty directory as authorization to clone", async () => {
+		const { remoteUrl } = seedRemote();
+		const workspace = makeTempDir("signet-empty-source-");
+		mkdirSync(resolveWorkspaceSourceRepoPath(workspace));
+		for (const sync of [syncWorkspaceSourceRepo, syncWorkspaceSourceRepoAsync])
+			expect(await sync(workspace, { remoteUrl })).toMatchObject({ status: "skipped" });
+		expect(existsSync(join(resolveWorkspaceSourceRepoPath(workspace), ".git"))).toBe(false);
+	});
+
+	it("explicit async creation preserves ordinary maintenance of an existing checkout", async () => {
+		const { remoteUrl, workDir } = seedRemote();
+		const workspace = makeTempDir("signet-explicit-source-");
+		expect(await syncWorkspaceSourceRepoAsync(workspace, { remoteUrl, cloneIfMissing: true })).toMatchObject({
+			status: "cloned",
+		});
+		pushRemoteChange(workDir, "Updated source\n", "update");
+		expect(await syncWorkspaceSourceRepoAsync(workspace, { remoteUrl })).toMatchObject({ status: "pulled" });
+		expect(syncWorkspaceSourceRepo(workspace, { remoteUrl })).toMatchObject({ status: "current" });
+	});
+
 	it("clones the Signet source checkout when the workspace does not have one", () => {
 		const { remoteUrl } = seedRemote();
 		const workspaceDir = makeTempDir("signet-source-workspace-");
@@ -157,7 +188,10 @@ describe("syncWorkspaceSourceRepo", () => {
 	it("rejects unsafe remote URLs before invoking git clone", () => {
 		const workspaceDir = makeTempDir("signet-source-workspace-");
 
-		const result = syncWorkspaceSourceRepo(workspaceDir, { remoteUrl: "--upload-pack=touch /tmp/pwned" });
+		const result = syncWorkspaceSourceRepo(workspaceDir, {
+			cloneIfMissing: true,
+			remoteUrl: "--upload-pack=touch /tmp/pwned",
+		});
 
 		expect(result.status).toBe("error");
 		expect(result.message).toContain("safe git source");
@@ -170,7 +204,7 @@ describe("syncWorkspaceSourceRepo", () => {
 		chmodSync(daemonDir, 0o500);
 
 		try {
-			const result = syncWorkspaceSourceRepo(workspaceDir);
+			const result = syncWorkspaceSourceRepo(workspaceDir, { cloneIfMissing: true });
 
 			expect(result.status).toBe("error");
 			expect(result.message).toContain("failed to acquire source checkout sync lock");
@@ -185,7 +219,7 @@ describe("syncWorkspaceSourceRepo", () => {
 		const workspaceFile = join(root, "workspace-file");
 		writeFileSync(workspaceFile, "not a directory\n");
 
-		const result = syncWorkspaceSourceRepo(workspaceFile);
+		const result = syncWorkspaceSourceRepo(workspaceFile, { cloneIfMissing: true });
 
 		expect(result.status).toBe("error");
 		expect(result.message).toContain("failed to prepare source checkout sync lock directory");

--- a/platform/core/src/workspace-source-repo.ts
+++ b/platform/core/src/workspace-source-repo.ts
@@ -13,6 +13,8 @@ const SOURCE_REPO_SYNC_LOCK_WAIT_MS = 15_000;
 export type WorkspaceSourceRepoStatus = "cloned" | "pulled" | "fetched" | "current" | "skipped" | "error";
 
 export interface WorkspaceSourceRepoSyncOptions {
+	/** Only explicit source builds may create a checkout; routine sync updates existing repositories. */
+	readonly cloneIfMissing?: boolean;
 	readonly gitTimeoutMs?: number;
 	readonly remoteUrl?: string;
 	readonly repoDirName?: string;
@@ -74,12 +76,14 @@ export function syncWorkspaceSourceRepo(
 	workspaceDir: string,
 	options: WorkspaceSourceRepoSyncOptions = {},
 ): WorkspaceSourceRepoSyncResult {
+	const clone = options.cloneIfMissing === true;
 	const timeoutMs = options.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
 	const remoteUrl = options.remoteUrl ?? SIGNET_SOURCE_REMOTE_URL;
 	const repoPath = resolveWorkspaceSourceRepoPath(workspaceDir, options.repoDirName);
 	if (!isSafeCloneSource(remoteUrl)) {
 		return unsafeRemoteResult(repoPath);
 	}
+	if (!clone && !existsSync(repoPath)) return missingCheckoutResult(repoPath);
 	if (!isGitAvailable(timeoutMs)) {
 		return gitUnavailableResult(repoPath);
 	}
@@ -93,7 +97,7 @@ export function syncWorkspaceSourceRepo(
 	}
 
 	try {
-		return syncWorkspaceSourceRepoLocked(runGit, workspaceDir, repoPath, remoteUrl, timeoutMs);
+		return syncWorkspaceSourceRepoLocked(runGit, workspaceDir, repoPath, remoteUrl, timeoutMs, clone);
 	} finally {
 		releaseSourceRepoSyncLock(lock.lock);
 	}
@@ -103,12 +107,14 @@ export async function syncWorkspaceSourceRepoAsync(
 	workspaceDir: string,
 	options: WorkspaceSourceRepoSyncOptions = {},
 ): Promise<WorkspaceSourceRepoSyncResult> {
+	const clone = options.cloneIfMissing === true;
 	const timeoutMs = options.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
 	const remoteUrl = options.remoteUrl ?? SIGNET_SOURCE_REMOTE_URL;
 	const repoPath = resolveWorkspaceSourceRepoPath(workspaceDir, options.repoDirName);
 	if (!isSafeCloneSource(remoteUrl)) {
 		return unsafeRemoteResult(repoPath);
 	}
+	if (!clone && !existsSync(repoPath)) return missingCheckoutResult(repoPath);
 	if (!(await isGitAvailableAsync(timeoutMs))) {
 		return gitUnavailableResult(repoPath);
 	}
@@ -122,7 +128,7 @@ export async function syncWorkspaceSourceRepoAsync(
 	}
 
 	try {
-		return await syncWorkspaceSourceRepoLocked(runGitAsync, workspaceDir, repoPath, remoteUrl, timeoutMs);
+		return await syncWorkspaceSourceRepoLocked(runGitAsync, workspaceDir, repoPath, remoteUrl, timeoutMs, clone);
 	} finally {
 		releaseSourceRepoSyncLock(lock.lock);
 	}
@@ -134,6 +140,7 @@ function syncWorkspaceSourceRepoLocked(
 	repoPath: string,
 	remoteUrl: string,
 	timeoutMs: number,
+	cloneIfMissing: boolean,
 ): WorkspaceSourceRepoSyncResult;
 function syncWorkspaceSourceRepoLocked(
 	run: typeof runGitAsync,
@@ -141,6 +148,7 @@ function syncWorkspaceSourceRepoLocked(
 	repoPath: string,
 	remoteUrl: string,
 	timeoutMs: number,
+	cloneIfMissing: boolean,
 ): Promise<WorkspaceSourceRepoSyncResult>;
 function syncWorkspaceSourceRepoLocked(
 	run: GitRunner,
@@ -148,8 +156,10 @@ function syncWorkspaceSourceRepoLocked(
 	repoPath: string,
 	remoteUrl: string,
 	timeoutMs: number,
+	cloneIfMissing: boolean,
 ): MaybePromise<WorkspaceSourceRepoSyncResult> {
 	if (!existsSync(repoPath) || isEmptyDirectory(repoPath)) {
+		if (!cloneIfMissing) return missingCheckoutResult(repoPath);
 		const workspaceReady = ensureWorkspaceDir(workspaceDir);
 		if (workspaceReady.ok === false) {
 			return errorResult(repoPath, workspaceReady.message);
@@ -580,6 +590,16 @@ async function sleep(ms: number): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function missingCheckoutResult(repoPath: string): WorkspaceSourceRepoSyncResult {
+	return {
+		status: "skipped",
+		path: repoPath,
+		message: "No Signet source checkout; source builds can create one explicitly",
+		branch: null,
+		defaultBranch: null,
+	};
+}
+
 function unsafeRemoteResult(repoPath: string): WorkspaceSourceRepoSyncResult {
 	return {
 		status: "error",
@@ -826,7 +846,7 @@ function parsePorcelainStatusPath(line: string): string | null {
 	const path = rawPath.includes(renameSeparator)
 		? rawPath.slice(rawPath.lastIndexOf(renameSeparator) + renameSeparator.length)
 		: rawPath;
-	return path.replace(/^\"|\"$/g, "");
+	return path.replace(/^"|"$/g, "");
 }
 
 function readUpstreamBranchWith(run: typeof runGit, repoPath: string, timeoutMs: number): string | null;

--- a/scripts/native-first-use-smoke.test.ts
+++ b/scripts/native-first-use-smoke.test.ts
@@ -1,7 +1,7 @@
 /** Release regression guard for the compiled binary's first-install contract. */
 import { afterEach, describe, expect, test } from "bun:test";
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -108,11 +108,8 @@ describe("compiled native first use", () => {
 			smokeHome = mkdtempSync(join(tmpdir(), "signet-native-first-use-"));
 			const workspace = join(smokeHome, ".agents");
 			const sourceCheckout = join(workspace, "signetai");
-			mkdirSync(sourceCheckout, { recursive: true });
-			// Setup always syncs this optional managed checkout. A non-git marker
-			// keeps the release acceptance hermetic and focused on first use.
-			writeFileSync(join(sourceCheckout, ".release-smoke"), "native first-use smoke\n");
-			const env = smokeEnv(smokeHome, workspace);
+			const gitLog = join(smokeHome, "git-trace.log");
+			const env = { ...smokeEnv(smokeHome, workspace), GIT_TRACE: gitLog, GIT_ALLOW_PROTOCOL: "" };
 			const port = await freePort();
 			const origin = `http://127.0.0.1:${port}`;
 
@@ -145,6 +142,8 @@ describe("compiled native first use", () => {
 				120_000,
 			);
 
+			expect(existsSync(sourceCheckout)).toBe(false);
+			expect(existsSync(gitLog) ? readFileSync(gitLog, "utf8") : "").not.toMatch(/\bgit (clone|fetch|pull)\b/);
 			const agentYaml = readFileSync(join(workspace, "agent.yaml"), "utf8");
 			expect(agentYaml).toContain("embedding:\n  provider: none");
 			let daemonOutput = "";
@@ -169,6 +168,9 @@ describe("compiled native first use", () => {
 			await waitForHealth(origin, daemonChild, () => daemonOutput);
 			const cliEnv = { ...env, SIGNET_DAEMON_URL: origin };
 
+			run(binary, ["sync"], cliEnv, 30000);
+			expect(existsSync(sourceCheckout)).toBe(false);
+			expect(existsSync(gitLog) ? readFileSync(gitLog, "utf8") : "").not.toMatch(/\bgit (clone|fetch|pull)\b/);
 			const doctor = run(binary, ["doctor"], cliEnv, 30_000);
 			expect(doctor).not.toContain("Missing required identity files");
 			const status = parseJsonOutput(run(binary, ["status", "--json"], cliEnv, 30_000));

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -1028,7 +1028,6 @@ registerAppCommands(program, {
 			startDaemon,
 			syncBuiltinSkills,
 			syncNativeEmbeddingModel,
-			syncWorkspaceSourceRepo: syncWorkspaceSourceRepoAsync,
 			loadConfiguredHarnesses,
 		}),
 	showDoctor: (options) => showDoctor(options, healthDeps),

--- a/surfaces/cli/src/features/desktop.test.ts
+++ b/surfaces/cli/src/features/desktop.test.ts
@@ -163,7 +163,8 @@ describe("desktop source build", () => {
 				{
 					cwd: home,
 					env: { SIGNET_PATH: workspace },
-					syncWorkspaceSourceRepo: (workspaceDir) => {
+					syncWorkspaceSourceRepo: (workspaceDir, options) => {
+						expect(options).toEqual({ cloneIfMissing: true });
 						calls.push(`sync ${workspaceDir}`);
 						return {
 							status: "pulled",
@@ -240,7 +241,7 @@ describe("linux desktop install", () => {
 			expect(launcher).toContain(`export SIGNET_PATH='${workspace}'`);
 			expect(launcher).toContain(`exec '${result.appImage}' "$@"`);
 			expect(readFileSync(result.desktopEntry, "utf8")).toContain("Name=Signet");
-			expect(readFileSync(result.desktopEntry, "utf8")).toContain(`Exec=\"${result.binary}\" %U`);
+			expect(readFileSync(result.desktopEntry, "utf8")).toContain(`Exec="${result.binary}" %U`);
 			expect(existsSync(result.icon)).toBe(true);
 			expect(result.workspace).toBe(workspace);
 		} finally {
@@ -338,7 +339,8 @@ describe("linux desktop install", () => {
 					home,
 					env: { SIGNET_PATH: workspace },
 					platform: "linux",
-					syncWorkspaceSourceRepo: (workspaceDir) => {
+					syncWorkspaceSourceRepo: (workspaceDir, options) => {
+						expect(options).toEqual({ cloneIfMissing: true });
 						calls.push(`sync ${workspaceDir}`);
 						return {
 							status: "pulled",

--- a/surfaces/cli/src/features/desktop.ts
+++ b/surfaces/cli/src/features/desktop.ts
@@ -111,7 +111,7 @@ function prepareDesktopSourceCheckout(options: DesktopCommandOptions, ctx: Deskt
 	if (explicit || options.skipSourceSync) return resolveDesktopSourceCheckout(options.repo, ctx);
 
 	const workspace = resolveAgentsDir(env).path;
-	const sync = (ctx.syncWorkspaceSourceRepo ?? syncWorkspaceSourceRepo)(workspace);
+	const sync = (ctx.syncWorkspaceSourceRepo ?? syncWorkspaceSourceRepo)(workspace, { cloneIfMissing: true });
 	if (!["cloned", "pulled", "current"].includes(sync.status)) {
 		throw new Error(`Could not update Signet source checkout before desktop build: ${sync.message}`);
 	}

--- a/surfaces/cli/src/features/setup-embedding-validation.test.ts
+++ b/surfaces/cli/src/features/setup-embedding-validation.test.ts
@@ -67,13 +67,6 @@ function stubDeps(overrides: Partial<SetupDeps> = {}): SetupDeps {
 			status: "current" as const,
 			message: "nomic-ai/nomic-embed-text-v1.5",
 		})),
-		syncWorkspaceSourceRepo: mock(async () => ({
-			status: "current" as const,
-			path: "/tmp/agents/signetai",
-			message: "current",
-			branch: "main",
-			defaultBranch: "main",
-		})),
 		...overrides,
 	};
 }

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -27,7 +27,7 @@ import {
 import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary, refreshSnapshotProtection } from "./setup-protection.js";
-import { formatWorkspaceSourceRepoSync, readErr, readRecord } from "./setup-shared.js";
+import { readErr, readRecord } from "./setup-shared.js";
 import { withSetupPrompt } from "./setup-terminal.js";
 import type { SetupDeps } from "./setup-types.js";
 
@@ -87,9 +87,6 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 
 		spinner.text = "Installing built-in skills...";
 		deps.syncBuiltinSkills(deps.getSkillsSourceDir(), context.basePath);
-
-		spinner.text = "Cloning Signet source checkout...";
-		const sourceRepoSync = await deps.syncWorkspaceSourceRepo(context.basePath);
 
 		if (plan.identityMode === "managed") {
 			spinner.text = "Creating agent identity...";
@@ -386,7 +383,6 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			const special = plan.specialIdentityFiles.some((entry) => entry.path === name) ? " (special session)" : "";
 			console.log(chalk.dim(`    ├── ${name.padEnd(12)}${special}`));
 		}
-		console.log(chalk.dim("    ├── signetai/     Signet source checkout"));
 		console.log(chalk.dim("    └── memory/       database & vectors"));
 
 		console.log();
@@ -406,12 +402,6 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			for (const harness of configuredHarnesses) {
 				console.log(chalk.dim(`    ✓ ${harness}`));
 			}
-		}
-
-		const sourceRepoLine = formatWorkspaceSourceRepoSync(sourceRepoSync);
-		if (sourceRepoLine) {
-			console.log();
-			console.log(chalk.dim(sourceRepoLine));
 		}
 
 		if (daemonStarted) {

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -35,7 +35,6 @@ import { enforceSetupProtection, printSetupProtectionSummary, refreshSnapshotPro
 import {
 	type EmbeddingProviderChoice,
 	type ExtractionProviderChoice,
-	formatWorkspaceSourceRepoSync,
 	getEmbeddingDimensions,
 	readErr,
 	readHarnesses,
@@ -129,9 +128,6 @@ export async function runExistingSetupWizard(
 
 		spinner.text = "Syncing built-in skills...";
 		deps.syncBuiltinSkills(deps.getSkillsSourceDir(), basePath);
-
-		spinner.text = "Cloning Signet source checkout...";
-		const sourceRepoSync = await deps.syncWorkspaceSourceRepo(basePath);
 
 		spinner.text = "Creating agent manifest...";
 		const now = new Date().toISOString();
@@ -429,12 +425,6 @@ export async function runExistingSetupWizard(
 			console.log(
 				chalk.dim(`  Skills unified: ${skillsResult.imported} imported, ${skillsResult.symlinked} symlinked`),
 			);
-		}
-
-		const sourceRepoLine = formatWorkspaceSourceRepoSync(sourceRepoSync);
-		if (sourceRepoLine) {
-			console.log();
-			console.log(chalk.dim(sourceRepoLine));
 		}
 
 		if (configuredHarnesses.length > 0) {

--- a/surfaces/cli/src/features/setup-shared.ts
+++ b/surfaces/cli/src/features/setup-shared.ts
@@ -1,5 +1,5 @@
 import { OpenClawConnector } from "@signet/connector-openclaw";
-import type { SetupDetection, WorkspaceSourceRepoSyncResult } from "@signet/core";
+import type { SetupDetection } from "@signet/core";
 import chalk from "chalk";
 
 export type HarnessChoice =
@@ -326,23 +326,6 @@ export function readRecord(value: unknown): Record<string, unknown> {
 
 export function readString(value: unknown): string | null {
 	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-export function formatWorkspaceSourceRepoSync(result: WorkspaceSourceRepoSyncResult): string | null {
-	switch (result.status) {
-		case "cloned":
-			return `  ✓ ${result.message}: ${result.path}`;
-		case "pulled":
-			return `  ✓ ${result.message}: ${result.path}`;
-		case "fetched":
-			return `  ↺ ${result.message}`;
-		case "error":
-			return `  ⚠ ${result.message}`;
-		case "skipped":
-			return `  ${result.message}`;
-		case "current":
-			return null;
-	}
 }
 
 export function readHarnesses(value: unknown): string[] {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -1,4 +1,4 @@
-import type { SetupDetection, WorkspaceSourceRepoSyncResult } from "@signet/core";
+import type { SetupDetection } from "@signet/core";
 import type { OpenClawRuntimeChoice } from "./setup-shared.js";
 
 export interface SetupWizardOptions {
@@ -73,7 +73,6 @@ export interface SetupDeps {
 		skillsSourceDir: string,
 		basePath: string,
 	) => { installed: string[]; updated: string[]; skipped: string[] };
-	readonly syncWorkspaceSourceRepo: (basePath: string) => Promise<WorkspaceSourceRepoSyncResult>;
 	readonly syncNativeEmbeddingModel: (
 		basePath: string,
 	) => Promise<{ readonly status: "updated" | "current" | "skipped" | "error"; readonly message: string }>;

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -77,13 +77,6 @@ function stubDeps(overrides: Partial<SetupDeps> = {}): SetupDeps {
 		getSkillsSourceDir: mock(() => "/tmp/skills"),
 		syncBuiltinSkills: mock(() => ({ installed: [], updated: [], skipped: [] })),
 		syncNativeEmbeddingModel: mock(async () => ({ status: "current" as const, message: "ready" })),
-		syncWorkspaceSourceRepo: mock(async () => ({
-			status: "current" as const,
-			path: "/tmp/agents/signetai",
-			message: "current",
-			branch: "main",
-			defaultBranch: "main",
-		})),
 		...overrides,
 	};
 }

--- a/web/docs/src/content/docs/getting-started/setup.md
+++ b/web/docs/src/content/docs/getting-started/setup.md
@@ -53,3 +53,16 @@ signet dashboard
 ```
 
 Use `signet setup` again to reconfigure an existing installation. Use [CLI environment and exit codes](/cli/environment/) before changing workspace variables or running the daemon under service tooling.
+
+## Source checkouts
+
+Setup and workspace migration do not clone the Signet repository. Saving and
+recalling memories use the installed application. `signet sync` and application
+updates maintain an existing workspace checkout but do not create one.
+
+`signet desktop build` or `signet desktop install` explicitly creates the managed
+checkout when needed for a source build. Contributors can also clone the repository
+and pass `--repo` to the desktop command. Existing checkouts, local edits, and
+branches are preserved; this change does not delete or relocate them. If a managed
+desktop checkout was removed, rerun `signet desktop install` to restore its source
+build path before the next automatic desktop update.


### PR DESCRIPTION
## Summary
Fresh setup and workspace migration cloned the Signet repository before memory was ready, and routine sync/update could recreate it. Remove those setup calls and make the existing core source-sync operation maintain existing checkouts only. Explicit `signet desktop build/install` opts into creation through `cloneIfMissing: true`; the existing shared Git executor remains the sole clone path.

This removes an automatic GitHub source dependency from first use. It adds no setup question, service, background job, or workspace setting. Existing repositories, local edits, branches, and desktop maintenance remain supported. No user files or durable database state are deleted or migrated.

## Compatibility
Core callers that intentionally create a checkout must pass `cloneIfMissing: true`. Setup and migration no longer clone or update source repositories. Routine sync and application update still maintain existing checkouts. If a managed desktop's checkout has been manually removed, rerun `signet desktop install` to restore it before its next automatic update. The owning setup documentation covers this behavior.

## Verification
- 133 scoped tests pass across source sync, setup, embedding validation, desktop, template sync, and update behavior. One Forge-detection assertion in the broader setup suite also fails on unchanged merged code; it is excluded from the passing scoped run.
- The regression test fails on the previous implementation because it clones an absent checkout. New coverage checks absent and empty checkout paths, explicit async creation, ordinary maintenance, and preservation of local edits.
- Compiled native first-use acceptance passes: clean setup, sync, doctor, status, remember, and recall with Git transports disabled; Git tracing confirms no clone/fetch/pull and no source checkout is created. The previous dummy source-directory workaround is removed.
- Workspace typecheck and lint pass (existing warnings). Core, connector, daemon, and native builds succeeded. The aggregate `bun run build` reaches an unrelated local SDK build failure because the optional better-sqlite3 11.10.0 package is missing; no source workaround was added. Full repository tests were not run.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Readiness refers to the scoped checks above. This changes no database query or admin endpoint; existing Git URL validation and checkout safety rules remain in place. Creation permission is checked again under the sync lock.

## AI disclosure
- [x] AI tools were used (see `Assisted-by` tags in commits)
