### PR TITLE
fix: build connector dependencies for desktop release

### DIFF
--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -9,13 +9,14 @@
 	"scripts": {
 		"build:core": "cd ../../platform/core && bun run build",
 		"build:tray": "cd ../tray && bun run build",
+		"build:connectors": "cd ../.. && bun run build:connector-base && bun run build:opencode-plugin && bun run build:oh-my-pi-extension && bun run build:pi-extension && bun run --filter '@signet/connector-claude-code' --filter '@signet/connector-codex' --filter '@signet/connector-forge' --filter '@signet/connector-gemini' --filter '@signet/connector-hermes-agent' --filter '@signet/connector-kimi' --filter '@signet/connector-oh-my-pi' --filter '@signet/connector-openclaw' --filter '@signet/connector-opencode' --filter '@signet/connector-pi' build",
 		"build:dashboard": "cd ../../platform/daemon && bun run build:dashboard",
 		"build:daemon": "cd ../../platform/daemon && bun run build",
 		"build:main": "tsc -p tsconfig.json",
 		"stage:runtime": "node scripts/stage-runtime.mjs",
 		"verify:macos": "node scripts/verify-macos-release.mjs release",
 		"build": "bun run build:main",
-		"build:desktop": "bun run build:core && bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder --publish never",
+		"build:desktop": "bun run build:core && bun run build:tray && bun run build:connectors && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder --publish never",
 		"dev": "bun run build:tray && bun run build:dashboard && bun run build:main && electron .",
 		"typecheck": "bun run build:tray && tsc -p tsconfig.json --noEmit",
 		"test": "bun test"

--- a/surfaces/desktop/src/build-contract.test.ts
+++ b/surfaces/desktop/src/build-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+
+test("desktop release builds connector artifacts before bundling the daemon", () => {
+	const manifest = JSON.parse(readFileSync(join(import.meta.dir, "..", "package.json"), "utf8")) as {
+		scripts: Record<string, string>;
+	};
+	const desktopBuild = manifest.scripts["build:desktop"] ?? "";
+	const connectorBuild = manifest.scripts["build:connectors"] ?? "";
+
+	expect(desktopBuild.indexOf("build:connectors")).toBeGreaterThanOrEqual(0);
+	expect(desktopBuild.indexOf("build:connectors")).toBeLessThan(desktopBuild.indexOf("build:daemon"));
+	for (const prerequisite of [
+		"build:connector-base",
+		"build:opencode-plugin",
+		"build:oh-my-pi-extension",
+		"build:pi-extension",
+	])
+		expect(connectorBuild).toContain(prerequisite);
+});


### PR DESCRIPTION
The merged onboarding work made the packaged daemon bundle its harness installers. Clean desktop release runners do not have connector `dist` outputs yet, so all four desktop matrix builds fail while bundling `harness-install-worker.ts`.

This adds one canonical `build:connectors` step to the desktop build graph. It builds connector-base, the plugin/extension prerequisites, and the ten connector packages before the daemon is bundled.

Validation:

- Full `surfaces/desktop` `build:desktop -- --x64` passed locally through Electron packaging.
- All ten connector packages built successfully.
- Daemon and desktop TypeScript builds passed.
- Generated bundles were restored; no generated artifacts are included.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no public spec or dependency contract changed; the desktop script follows the existing workspace build contracts.
- [x] Agent scoping verified on all new/changed data queries — no data queries changed.
- [x] Input/config validation and bounds checks added — no runtime input or configuration path changed.
- [x] Error handling and fallback paths tested (no silent swallow) — the build remains fail-fast; the regression test covers the required ordering.
- [x] Security checks applied to admin/mutation endpoints — no endpoint or authorization path changed.
- [x] Docs updated for API/spec/status changes — no API, spec, or status behavior changed.
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — scoped Biome, regression, connector, daemon, desktop, and full Linux packaging checks pass.

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)
