### PR TITLE
fix(config): enable dreaming defaults

### DIFF
--- a/dist/signetai/templates/agent.yaml.template
+++ b/dist/signetai/templates/agent.yaml.template
@@ -82,22 +82,7 @@ memory:
   # Importance decay rate per day (0.95 = 5% decay/day)
   decay_rate: 0.95
   
-  # MEMORY.md synthesis configuration
-  synthesis:
-    # Which harness performs the synthesis (openclaw, claude-code, codex, opencode)
-    harness: openclaw
-    
-    # Model to use for synthesis (harness-specific format)
-    # Examples: "sonnet", "claude-sonnet-4", "gpt-4o", "gemini-pro"
-    model: sonnet
-    
-    # How often to regenerate MEMORY.md (daily, weekly, on-demand)
-    schedule: daily
-    
-    # Maximum tokens for synthesis output
-    max_tokens: 4000
-
-  # Pipeline V2 — automatic memory extraction from conversations
+  # Pipeline V2 — retrieval, indexing, maintenance, and Dreaming support
   pipelineV2:
     # Master switch (true = run pipeline workers)
     # When false, shadowMode is ignored and the pipeline is fully disabled.
@@ -108,23 +93,6 @@ memory:
 
     # Freeze all mutations (reads only, no writes/updates/deletes)
     # mutationsFrozen: false
-
-    # Extraction provider and model
-    # Safety: on a VPS, set provider: none unless you explicitly want
-    # background extraction.
-    # Intended usage: Claude Code on haiku, Codex on gpt-5.4-mini with a
-    # Pro/Max subscription, or local Ollama at qwen3:4b or larger.
-    # Remote API extraction can rack up extreme fees fast.
-    extraction:
-      # "none", "claude-code" (Claude CLI), "codex" (Codex CLI),
-      # "opencode" (OpenCode), or "ollama" (local)
-      provider: claude-code
-      model: haiku
-      # endpoint/base_url override (ollama base URL, or OpenCode server URL when provider=opencode)
-      # endpoint: http://127.0.0.1:11434  # ollama
-      # endpoint: http://127.0.0.1:4096   # opencode
-      # timeout: 120000
-      # minConfidence: 0.7
 
     # Knowledge graph — boosts related memories in search results
     graph:
@@ -147,6 +115,10 @@ memory:
     semanticContradictionEnabled: true
 
     # Memory relevance configuration removed (hard-deprecated in 0.112.0)
+
+  # Background semantic consolidation is opt-in during setup.
+  # dreaming:
+  #   enabled: true
 
 # ============================================================================
 # Hooks Configuration

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -533,6 +533,8 @@ export interface DreamingSurprisalConfig {
 }
 
 export interface DreamingConfig {
+	/** Enable the background Dreaming worker. Semantic writes stay off when false. */
+	readonly enabled: boolean;
 	readonly tokenThreshold: number;
 	/** Maximum time that non-empty episodic evidence may wait below the token threshold. */
 	readonly maxInterval: number;

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1944,7 +1944,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		});
 	}
 
-	if (!pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
+	if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
 		try {
 			dreamingWorkerHandle = startDreamingWorker(
 				getDbAccessor(),

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -26,6 +26,11 @@ afterEach(() => {
 });
 
 describe("loadDreamingConfig", () => {
+	it("defaults dreaming off and preserves an explicit enable", () => {
+		expect(loadDreamingConfig({}).enabled).toBe(false);
+		expect(loadDreamingConfig({ memory: { dreaming: { enabled: true } } }).enabled).toBe(true);
+	});
+
 	it("defaults and bounds the low-volume backlog maximum wait", () => {
 		expect(loadDreamingConfig({}).maxInterval).toBe(6 * 60 * 60 * 1_000);
 		expect(loadDreamingConfig({ memory: { dreaming: { maxInterval: 1 } } }).maxInterval).toBe(5 * 60 * 1_000);
@@ -457,6 +462,18 @@ network:
 		);
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.embedding.provider).toBe("openai");
+	});
+
+	it("includes install-on retrieval and maintenance defaults when no config exists", () => {
+		const agentsDir = makeTempAgentsDir();
+		const cfg = loadMemoryConfig(agentsDir);
+
+		expect(cfg.search.rehearsal_enabled).toBe(true);
+		expect(cfg.pipelineV2.reranker.enabled).toBe(true);
+		expect(cfg.pipelineV2.graph.enabled).toBe(true);
+		expect(cfg.pipelineV2.autonomous.enabled).toBe(true);
+		expect(cfg.pipelineV2.autonomous.allowUpdateDelete).toBe(true);
+		expect(cfg.pipelineV2.autonomous.maintenanceMode).toBe("execute");
 	});
 
 	it("includes pipelineV2 defaults when no config exists", () => {

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -91,6 +91,7 @@ const DEFAULT_DREAMING_SURPRISAL = {
 } as const;
 
 export const DEFAULT_DREAMING: DreamingConfig = {
+	enabled: false,
 	tokenThreshold: 100_000,
 	maxInterval: 6 * 60 * 60 * 1_000,
 	timeout: 20 * 60 * 1_000, // 20 minutes
@@ -165,7 +166,7 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 	autonomous: {
 		enabled: true,
 		frozen: false,
-		allowUpdateDelete: false,
+		allowUpdateDelete: true,
 		maintenanceIntervalMs: 30 * 60 * 1000, // 30 min
 		maintenanceMode: "execute",
 	},
@@ -992,6 +993,7 @@ export function loadDreamingConfig(yaml: Record<string, unknown>): DreamingConfi
 	const defaultSurprisal = dd.surprisal ?? DEFAULT_DREAMING_SURPRISAL;
 	const surprisal = raw.surprisal as Record<string, unknown> | undefined;
 	return {
+		enabled: typeof raw.enabled === "boolean" ? raw.enabled : dd.enabled,
 		tokenThreshold: clampWarn("tokenThreshold", raw.tokenThreshold, 10_000, 1_000_000, dd.tokenThreshold),
 		maxInterval: clampWarn("maxInterval", raw.maxInterval, 5 * 60 * 1_000, 7 * 24 * 60 * 60 * 1_000, dd.maxInterval),
 		timeout: clampWarn("timeout", raw.timeout, 30_000, 1_800_000, dd.timeout),

--- a/platform/daemon/src/pipeline/dreaming-surprisal.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-surprisal.test.ts
@@ -22,6 +22,7 @@ const CONFIG = {
 } as const;
 
 const DREAMING_CONFIG: DreamingConfig = {
+	enabled: true,
 	tokenThreshold: 100_000,
 	maxInterval: 6 * 60 * 60 * 1_000,
 	timeout: 300_000,

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -57,6 +57,7 @@ const AGENT = "default";
 
 function defaultCfg(overrides?: Partial<DreamingConfig>): DreamingConfig {
 	return {
+		enabled: true,
 		tokenThreshold: 100_000,
 		maxInterval: 6 * 60 * 60 * 1_000,
 		maxInputTokens: 32_000,

--- a/platform/daemon/src/pipeline/memorybench-dreaming-gate.test.ts
+++ b/platform/daemon/src/pipeline/memorybench-dreaming-gate.test.ts
@@ -44,6 +44,7 @@ function readCorpus(): GateCorpus {
 
 function defaultCfg(): DreamingConfig {
 	return {
+		enabled: true,
 		tokenThreshold: 1,
 		maxInterval: 6 * 60 * 60 * 1_000,
 		maxInputTokens: 32_000,

--- a/platform/daemon/src/source-artifact-graph.test.ts
+++ b/platform/daemon/src/source-artifact-graph.test.ts
@@ -29,6 +29,7 @@ it("routes transcript source purge through the DB owner boundary", () => {
 });
 
 const DREAMING_CONFIG: DreamingConfig = {
+	enabled: true,
 	tokenThreshold: 1,
 	maxInterval: 6 * 60 * 60 * 1_000,
 	maxInputTokens: 32_000,

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1245,7 +1245,7 @@
     },
     {
       "path": "harness-install-worker.ts",
-      "line": 46,
+      "line": 38,
       "api": "existsSync",
       "source": "if (!pluginPath || !existsSync(join(pluginPath, \"dist\", \"index.js\")))",
       "category": "hot-path"
@@ -1668,14 +1668,14 @@
     },
     {
       "path": "memory-config.ts",
-      "line": 367,
+      "line": 368,
       "api": "existsSync",
       "source": ".find((path) => existsSync(path));",
       "category": "hot-path"
     },
     {
       "path": "memory-config.ts",
-      "line": 369,
+      "line": 370,
       "api": "readFileSync",
       "source": "const yaml = path ? parseRuntimeYaml(readFileSync(path, \"utf8\")) : {};",
       "category": "hot-path"
@@ -3191,35 +3191,35 @@
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 393,
+      "line": 397,
       "api": "existsSync",
-      "source": "{ id: \"pi\", name: \"Pi\", path: join(homedir(), \".pi\", \"agent\", \"settings.json\"), exists: existsSync(join(homedir(), \".pi\", \"agent\", \"settings.json\")) },",
+      "source": "exists: existsSync(join(homedir(), \".pi\", \"agent\", \"settings.json\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 394,
+      "line": 403,
       "api": "existsSync",
-      "source": "{ id: \"oh-my-pi\", name: \"Oh My Pi\", path: join(homedir(), \".omp\", \"agent\", \"settings.json\"), exists: existsSync(join(homedir(), \".omp\", \"agent\", \"settings.json\")) },",
+      "source": "exists: existsSync(join(homedir(), \".omp\", \"agent\", \"settings.json\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 395,
+      "line": 409,
       "api": "existsSync",
-      "source": "{ id: \"kimi\", name: \"Kimi\", path: join(homedir(), \".kimi\", \"config.toml\"), exists: existsSync(join(homedir(), \".kimi\", \"config.toml\")) },",
+      "source": "exists: existsSync(join(homedir(), \".kimi\", \"config.toml\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 396,
+      "line": 415,
       "api": "existsSync",
-      "source": "{ id: \"forge\", name: \"ForgeCode\", path: join(homedir(), \".forge\", \"config.yaml\"), exists: existsSync(join(homedir(), \".forge\", \"config.yaml\")) },",
+      "source": "exists: existsSync(join(homedir(), \".forge\", \"config.yaml\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 414,
+      "line": 434,
       "api": "existsSync",
       "source": "if (!existsSync(script)) {",
       "category": "hot-path"

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -134,6 +134,7 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 				alpha: plan.searchBalance,
 				top_k: plan.searchTopK,
 				min_score: plan.searchMinScore,
+				rehearsal_enabled: true,
 			},
 		};
 
@@ -157,9 +158,9 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 					};
 
 		const memory = readRecord(config.memory);
-		memory.pipelineV2 = buildSetupPipeline(plan.extractionProvider);
+		memory.pipelineV2 = buildSetupPipeline(plan.extractionProvider, plan.dreamingEnabled === true);
 		if (plan.dreamingEnabled) {
-			memory.dreaming = {};
+			memory.dreaming = { enabled: true };
 		}
 		config.memory = memory;
 		const inference = buildSetupInference(

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -44,6 +44,80 @@ import {
 import { withSetupPrompt } from "./setup-terminal.js";
 import type { SetupDeps } from "./setup-types.js";
 
+const RETIRED_PIPELINE_KEYS = [
+	"synthesis",
+	"writeGate",
+	"durability",
+	"writeGateEnabled",
+	"writeGateThreshold",
+	"writeGateContinuityDiscount",
+] as const;
+
+const RETIRED_ROUTING_KEYS = [
+	"extractionProvider",
+	"extractionModel",
+	"extractionEndpoint",
+	"extractionBaseUrl",
+	"extractionFallbackProvider",
+	"extractionCommand",
+	"allowRemoteProviders",
+] as const;
+
+const RETIRED_EXTRACTION_KEYS = [
+	"provider",
+	"model",
+	"endpoint",
+	"baseUrl",
+	"base_url",
+	"fallbackProvider",
+	"command",
+	"allowRemoteProviders",
+] as const;
+
+const MIGRATABLE_LEGACY_PROVIDERS = new Set([
+	"acpx",
+	"anthropic",
+	"claude-code",
+	"codex",
+	"llama-cpp",
+	"ollama",
+	"openai-compatible",
+	"openrouter",
+	"opencode",
+	"kimi",
+]);
+
+function canRemoveLegacyRouting(provider: unknown): boolean {
+	const value = typeof provider === "string" ? provider.trim() : "";
+	return value === "" || value === "none" || MIGRATABLE_LEGACY_PROVIDERS.has(value);
+}
+
+function removeRetiredPipelineSettings(pipeline: Record<string, unknown>): Record<string, unknown> {
+	const cleaned = { ...pipeline };
+	const flatProvider = cleaned.extractionProvider;
+	const preserveFlatRouting = !canRemoveLegacyRouting(flatProvider);
+	for (const key of RETIRED_PIPELINE_KEYS) {
+		Reflect.deleteProperty(cleaned, key);
+	}
+	for (const key of RETIRED_ROUTING_KEYS) {
+		if (preserveFlatRouting && key !== "allowRemoteProviders") continue;
+		Reflect.deleteProperty(cleaned, key);
+	}
+
+	const extraction = readRecord(cleaned.extraction);
+	const preserveNestedRouting = !canRemoveLegacyRouting(extraction.provider);
+	for (const key of RETIRED_EXTRACTION_KEYS) {
+		if (preserveNestedRouting && key !== "allowRemoteProviders") continue;
+		Reflect.deleteProperty(extraction, key);
+	}
+	if (Object.keys(extraction).length > 0) {
+		cleaned.extraction = extraction;
+	} else {
+		Reflect.deleteProperty(cleaned, "extraction");
+	}
+	return cleaned;
+}
+
 export function detectedHarnessesForExistingSetup(
 	detection: SetupDetection,
 	configuredHarnessList: readonly string[],
@@ -79,6 +153,7 @@ export async function runExistingSetupWizard(
 		extractionEndpoint?: string;
 		availableExtractionProviders?: readonly ExtractionProviderChoice[];
 		acpxBin?: string;
+		dreamingEnabled?: boolean;
 		signetSecretsEnabled?: boolean;
 		graphiqEnabled?: boolean;
 		identityMode?: IdentityMode;
@@ -88,6 +163,8 @@ export async function runExistingSetupWizard(
 	const signetSecretsEnabled = options?.signetSecretsEnabled ?? true;
 	const graphiqEnabled = options?.graphiqEnabled ?? false;
 	const identityMode = options?.identityMode ?? "managed";
+	const existingDreamingEnabled = readRecord(readRecord(existingConfig.memory).dreaming).enabled === true;
+	const dreamingEnabled = options?.dreamingEnabled === true || existingDreamingEnabled;
 	let graphiqInstalled = false;
 
 	try {
@@ -182,6 +259,7 @@ export async function runExistingSetupWizard(
 				alpha: 0.7,
 				top_k: 20,
 				min_score: 0.3,
+				rehearsal_enabled: true,
 			},
 		};
 
@@ -216,15 +294,14 @@ export async function runExistingSetupWizard(
 			};
 		}
 
+		const memory = readRecord(config.memory);
 		if (options?.extractionProvider) {
 			const model =
 				options.extractionModel ||
 				(options.extractionProvider === "acpx"
 					? defaultAcpxModel(detectedHarnesses, options.availableExtractionProviders)
 					: defaultExtractionModel(options.extractionProvider));
-			const memory = readRecord(config.memory);
-			memory.pipelineV2 = buildSetupPipeline(options.extractionProvider);
-			config.memory = memory;
+			memory.pipelineV2 = buildSetupPipeline(options.extractionProvider, options.dreamingEnabled === true);
 			const inference = buildSetupInference(
 				options.extractionProvider,
 				model,
@@ -235,22 +312,51 @@ export async function runExistingSetupWizard(
 			);
 			applySetupInferenceRoute(config, inference);
 		}
+		if (dreamingEnabled) {
+			memory.dreaming = { enabled: true };
+			memory.pipelineV2 = buildSetupPipeline(options?.extractionProvider ?? "none", true);
+		}
+		config.memory = memory;
 
 		const agentYamlPath = join(basePath, "agent.yaml");
 		if (existsSync(agentYamlPath)) {
 			const existingCapabilities = readRecord(existingConfig.capabilities);
-			writeFileSync(
-				agentYamlPath,
-				formatYaml({
-					...existingConfig,
-					capabilities: {
-						...existingCapabilities,
-						memory: { ...readRecord(existingCapabilities.memory), enabled: true, autoInject: true, memoryHead: true },
-						secrets: { ...readRecord(existingCapabilities.secrets), enabled: signetSecretsEnabled },
-						identity: { ...readRecord(existingCapabilities.identity), mode: identityMode },
+			const existingSearch = readRecord(existingConfig.search);
+			const updatedConfig: Record<string, unknown> = {
+				...existingConfig,
+				search: {
+					...existingSearch,
+					rehearsal_enabled:
+						typeof existingSearch.rehearsal_enabled === "boolean" ? existingSearch.rehearsal_enabled : true,
+				},
+				capabilities: {
+					...existingCapabilities,
+					memory: { ...readRecord(existingCapabilities.memory), enabled: true, autoInject: true, memoryHead: true },
+					secrets: { ...readRecord(existingCapabilities.secrets), enabled: signetSecretsEnabled },
+					identity: { ...readRecord(existingCapabilities.identity), mode: identityMode },
+				},
+			};
+			if (dreamingEnabled) {
+				const existingMemory = { ...readRecord(existingConfig.memory) };
+				Reflect.deleteProperty(existingMemory, "synthesis");
+				const existingPipeline = removeRetiredPipelineSettings(readRecord(existingMemory.pipelineV2));
+				const pipelineDefaults = buildSetupPipeline(options?.extractionProvider ?? "none", true);
+				updatedConfig.memory = {
+					...existingMemory,
+					dreaming: { ...readRecord(existingMemory.dreaming), enabled: true },
+					pipelineV2: {
+						...existingPipeline,
+						...pipelineDefaults,
+						graph: { ...readRecord(existingPipeline.graph), ...readRecord(pipelineDefaults.graph) },
+						reranker: { ...readRecord(existingPipeline.reranker), ...readRecord(pipelineDefaults.reranker) },
+						autonomous: {
+							...readRecord(existingPipeline.autonomous),
+							...readRecord(pipelineDefaults.autonomous),
+						},
 					},
-				}),
-			);
+				};
+			}
+			writeFileSync(agentYamlPath, formatYaml(updatedConfig));
 		} else {
 			writeFileSync(agentYamlPath, formatYaml(config));
 		}

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -336,6 +336,15 @@ export async function runExistingSetupWizard(
 					identity: { ...readRecord(existingCapabilities.identity), mode: identityMode },
 				},
 			};
+			if (options?.extractionProvider) {
+				if (Object.hasOwn(config, "inference")) {
+					updatedConfig.inference = config.inference;
+				} else {
+					// Remove only a generated setup route when extraction is disabled;
+					// preserve any user-owned inference configuration.
+					applySetupInferenceRoute(updatedConfig, undefined);
+				}
+			}
 			if (dreamingEnabled) {
 				const existingMemory = { ...readRecord(existingConfig.memory) };
 				Reflect.deleteProperty(existingMemory, "synthesis");

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -355,6 +355,18 @@ export async function runExistingSetupWizard(
 						},
 					},
 				};
+			} else {
+				const existingMemory = { ...readRecord(existingConfig.memory) };
+				Reflect.deleteProperty(existingMemory, "synthesis");
+				if (Object.hasOwn(existingMemory, "pipelineV2")) {
+					const existingPipeline = removeRetiredPipelineSettings(readRecord(existingMemory.pipelineV2));
+					if (Object.keys(existingPipeline).length > 0) {
+						existingMemory.pipelineV2 = existingPipeline;
+					} else {
+						Reflect.deleteProperty(existingMemory, "pipelineV2");
+					}
+				}
+				updatedConfig.memory = existingMemory;
 			}
 			writeFileSync(agentYamlPath, formatYaml(updatedConfig));
 		} else {

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -20,9 +20,23 @@ describe("defaultExtractionModel", () => {
 });
 
 describe("buildSetupPipeline", () => {
-	it("writes tuning-only config when extraction is turned off", () => {
+	it("keeps the reranker enabled even when extraction is turned off", () => {
 		expect(buildSetupPipeline("none")).toEqual({
 			enabled: false,
+			reranker: { enabled: true },
+		});
+	});
+
+	it("enables the full pipeline defaults when dreaming is enabled without extraction", () => {
+		expect(buildSetupPipeline("none", true)).toMatchObject({
+			enabled: true,
+			graph: { enabled: true },
+			reranker: { enabled: true },
+			autonomous: {
+				enabled: true,
+				allowUpdateDelete: true,
+				maintenanceMode: "execute",
+			},
 		});
 	});
 

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -33,10 +33,12 @@ export function defaultExtractionModel(provider: DirectExtractionProviderChoice)
 	return defaultPipelineModel(provider);
 }
 
-export function buildSetupPipeline(provider: ExtractionProviderChoice): SetupPipelineConfig {
-	if (provider === "none") {
+export function buildSetupPipeline(provider: string, dreamingEnabled = false): SetupPipelineConfig {
+	const pipelineEnabled = provider !== "none" || dreamingEnabled;
+	if (!pipelineEnabled) {
 		return {
 			enabled: false,
+			reranker: { enabled: true },
 		};
 	}
 

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -437,6 +437,43 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(agentYaml).not.toContain("legacy-model");
 	});
 
+	it("does not carry retired fields into a new manifest when existing setup lacks agent.yaml", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-migrate-new-manifest-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		mkdirSync(basePath, { recursive: true });
+		mkdirSync(join(basePath, "memory"), { recursive: true });
+		writeIdentityTemplates(templatesPath);
+
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+		});
+		await runExistingSetupWizard(
+			basePath,
+			fakeDetection(basePath),
+			{
+				memory: {
+					synthesis: { harness: "openclaw" },
+					pipelineV2: { extractionProvider: "claude-code", writeGate: { threshold: 0.4 } },
+				},
+			},
+			deps,
+			{
+				nonInteractive: true,
+				skipGit: true,
+				allowUnprotectedWorkspace: true,
+				signetSecretsEnabled: true,
+			},
+		);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).not.toContain("synthesis:");
+		expect(agentYaml).not.toContain("pipelineV2:");
+		expect(agentYaml).not.toContain("claude-code");
+	});
+
 	it("includes Hermes in migration harnesses when detected in ~/.hermes", () => {
 		root = mkdtempSync(join(tmpdir(), "setup-migrate-hermes-default-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -474,6 +474,34 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(agentYaml).not.toContain("claude-code");
 	});
 
+	it("applies an explicit extraction provider to an existing manifest", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-migrate-extraction-provider-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		mkdirSync(basePath, { recursive: true });
+		mkdirSync(join(basePath, "memory"), { recursive: true });
+		writeIdentityTemplates(templatesPath);
+		writeFileSync(join(basePath, "agent.yaml"), "version: 1\n");
+
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+		});
+		await runExistingSetupWizard(basePath, fakeDetection(basePath), {}, deps, {
+			nonInteractive: true,
+			skipGit: true,
+			allowUnprotectedWorkspace: true,
+			extractionProvider: "ollama",
+			extractionModel: "qwen3:4b",
+			signetSecretsEnabled: true,
+		});
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("executor: ollama");
+		expect(agentYaml).toContain("model: qwen3:4b");
+	});
+
 	it("includes Hermes in migration harnesses when detected in ~/.hermes", () => {
 		root = mkdtempSync(join(tmpdir(), "setup-migrate-hermes-default-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -341,6 +341,59 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(state.activeProject).toBe(projectPath);
 	});
 
+	it("enables Dreaming defaults and removes retired routing during existing setup", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-migrate-dreaming-defaults-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		mkdirSync(basePath, { recursive: true });
+		mkdirSync(join(basePath, "memory"), { recursive: true });
+		writeIdentityTemplates(templatesPath);
+		writeFileSync(join(basePath, "agent.yaml"), "version: 1\n");
+
+		const existingConfig = {
+			memory: {
+				dreaming: { enabled: true },
+				synthesis: { harness: "openclaw" },
+				pipelineV2: {
+					enabled: false,
+					writeGate: { threshold: 0.4 },
+					durability: "transient",
+					extraction: { provider: "claude-code", model: "haiku" },
+					graph: { enabled: false },
+					reranker: { enabled: false },
+					autonomous: { enabled: false, allowUpdateDelete: false, maintenanceMode: "observe" },
+				},
+			},
+		};
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+		});
+
+		await runExistingSetupWizard(basePath, fakeDetection(basePath), existingConfig, deps, {
+			nonInteractive: true,
+			skipGit: true,
+			allowUnprotectedWorkspace: true,
+			extractionProvider: "none",
+			signetSecretsEnabled: true,
+		});
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("dreaming:\n    enabled: true");
+		expect(agentYaml).toContain("pipelineV2:\n    enabled: true");
+		expect(agentYaml).toContain("graph:\n      enabled: true");
+		expect(agentYaml).toContain("reranker:\n      enabled: true");
+		expect(agentYaml).toContain("allowUpdateDelete: true");
+		expect(agentYaml).toContain("maintenanceMode: execute");
+		expect(agentYaml).toContain("rehearsal_enabled: true");
+		expect(agentYaml).not.toContain("synthesis:");
+		expect(agentYaml).not.toContain("writeGate:");
+		expect(agentYaml).not.toContain("durability:");
+		expect(agentYaml).not.toContain("provider: claude-code");
+		expect(agentYaml).not.toContain("model: haiku");
+	});
+
 	it("includes Hermes in migration harnesses when detected in ~/.hermes", () => {
 		root = mkdtempSync(join(tmpdir(), "setup-migrate-hermes-default-"));
 		const basePath = join(root, "agents");
@@ -913,6 +966,14 @@ describe("setupWizard headless plan path", () => {
 		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
 		expect(agentYaml).toContain("dreaming:");
 		expect(agentYaml).toContain("enabled: true");
+		expect(agentYaml).toContain("rehearsal_enabled: true");
+		expect(agentYaml).toContain("pipelineV2:\n    enabled: true");
+		expect(agentYaml).toContain("graph:\n      enabled: true");
+		expect(agentYaml).toContain("reranker:\n      enabled: true");
+		expect(agentYaml).toContain("allowUpdateDelete: true");
+		expect(agentYaml).toContain("maintenanceMode: execute");
+		expect(agentYaml).not.toContain("synthesis:");
+		expect(agentYaml).not.toContain("provider: claude-code");
 	});
 
 	it("rejects a connected cloud extraction target from a headless plan", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -394,6 +394,49 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(agentYaml).not.toContain("model: haiku");
 	});
 
+	it("removes retired pipeline settings from existing setup even when Dreaming is off", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-migrate-retired-settings-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		mkdirSync(basePath, { recursive: true });
+		mkdirSync(join(basePath, "memory"), { recursive: true });
+		writeIdentityTemplates(templatesPath);
+		writeFileSync(join(basePath, "agent.yaml"), "version: 1\n");
+
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+		});
+		await runExistingSetupWizard(
+			basePath,
+			fakeDetection(basePath),
+			{
+				memory: {
+					synthesis: { harness: "openclaw" },
+					pipelineV2: {
+						extractionProvider: "claude-code",
+						extraction: { provider: "claude-code", model: "legacy-model" },
+						writeGate: { threshold: 0.4 },
+					},
+				},
+			},
+			deps,
+			{
+				nonInteractive: true,
+				skipGit: true,
+				allowUnprotectedWorkspace: true,
+				signetSecretsEnabled: true,
+			},
+		);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).not.toContain("synthesis:");
+		expect(agentYaml).not.toContain("pipelineV2:");
+		expect(agentYaml).not.toContain("claude-code");
+		expect(agentYaml).not.toContain("legacy-model");
+	});
+
 	it("includes Hermes in migration harnesses when detected in ~/.hermes", () => {
 		root = mkdtempSync(join(tmpdir(), "setup-migrate-hermes-default-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -648,6 +648,7 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 			extractionEndpoint: migrationExtractionEndpoint,
 			availableExtractionProviders: availableToolExtractionProviders,
 			acpxBin,
+			dreamingEnabled: options.enableDreaming === true,
 			signetSecretsEnabled,
 			graphiqEnabled,
 		});

--- a/surfaces/cli/templates/agent.yaml.template
+++ b/surfaces/cli/templates/agent.yaml.template
@@ -82,7 +82,7 @@ memory:
   # Importance decay rate per day (0.95 = 5% decay/day)
   decay_rate: 0.95
   
-  # Pipeline V2 — automatic memory extraction from conversations
+  # Pipeline V2 — retrieval, indexing, maintenance, and Dreaming support
   pipelineV2:
     # Master switch (true = run pipeline workers)
     # When false, shadowMode is ignored and the pipeline is fully disabled.
@@ -97,23 +97,6 @@ memory:
 
     # Freeze all mutations (reads only, no writes/updates/deletes)
     # mutationsFrozen: false
-
-    # Extraction provider and model
-    # Safety: on a VPS, set provider: none unless you explicitly want
-    # background extraction.
-    # Intended usage: Claude Code on haiku, Codex on gpt-5.4-mini with a
-    # Pro/Max subscription, or local Ollama at qwen3:4b or larger.
-    # Remote API extraction can rack up extreme fees fast.
-    extraction:
-      # "none", "claude-code" (Claude CLI), "codex" (Codex CLI),
-      # "opencode" (OpenCode), or "ollama" (local)
-      provider: claude-code
-      model: haiku
-      # endpoint/base_url override (ollama base URL, or OpenCode server URL when provider=opencode)
-      # endpoint: http://127.0.0.1:11434  # ollama
-      # endpoint: http://127.0.0.1:4096   # opencode
-      # timeout: 120000
-      # minConfidence: 0.7
 
     # Knowledge graph — boosts related memories in search results
     graph:
@@ -136,6 +119,10 @@ memory:
     semanticContradictionEnabled: true
 
     # Memory relevance configuration removed (hard-deprecated in 0.112.0)
+
+  # Background semantic consolidation is opt-in during setup.
+  # dreaming:
+  #   enabled: true
 
 # ============================================================================
 # Hooks Configuration

--- a/web/docs/src/content/docs/pipeline/extraction-decisions.md
+++ b/web/docs/src/content/docs/pipeline/extraction-decisions.md
@@ -151,6 +151,13 @@ The daemon reports a Pipeline V2 mode derived from these controls:
 | `autonomous.frozen` | Prevents the scheduled maintenance interval while leaving on-demand inspection available. |
 | `autonomous.maintenanceMode` | Selects whether maintenance recommendations are observed or executed. |
 
+Fresh installs enable rehearsal boosting and reranking by default. Running
+`signet setup --enable-dreaming` also enables the Pipeline V2 runtime, knowledge
+graph, autonomous maintenance, update/delete operations, and executable
+maintenance mode. Retired provider-routing and synthesis settings are not
+written to new configs; migrations remove retired fields from older configs
+when they can be migrated safely before strict loading.
+
 `autonomous.allowUpdateDelete` is not the old extraction decision gate. The
 retired extraction, write-gate, and legacy provider-routing configuration keys
 are rejected as retired; inference provider selection belongs to the canonical


### PR DESCRIPTION
## Summary

Make install-generated Signet configs useful by enabling rehearsal boosting and reranking by default. When Dreaming is explicitly enabled, setup now enables the supporting pipeline, graph, autonomous maintenance, update/delete operations, and executable maintenance mode while honoring the Dreaming off switch at daemon startup.

## Changes

- Enable `search.rehearsal_enabled` and reranking in fresh and existing-workspace setup defaults.
- Enable the full Dreaming support configuration when `--enable-dreaming` is selected.
- Remove retired synthesis, extraction-routing, and extraction-writer settings from new or safely migratable configs without deleting unmappable routes.
- Restore `memory.dreaming.enabled` to the runtime type/parser and gate Dreaming worker startup on it.
- Align source and packaged templates and document the install behavior.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: packaged templates and pipeline documentation

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description.

Existing explicit `memory.dreaming.enabled: false` remains respected. Retired settings are removed from fresh templates and known migratable legacy routes; provider routes that cannot be safely mapped remain for explicit operator repair rather than being silently discarded.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted configuration, migration, setup, and pipeline tests passed: 62 tests, 0 failures. Full typecheck and core/daemon builds passed. Full lint passed with pre-existing repository warnings. The full setup file still has two pre-existing offline onboarding failures (`Signet is not ready: offline`); they are unrelated to this change.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The runtime default for Dreaming remains opt-in (`false`). The install defaults requested here apply when Dreaming is enabled; rehearsal boosting and reranking are enabled for installs regardless of Dreaming.
