### PR TITLE
fix: unblock dreaming startup

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -3104,11 +3104,12 @@ async function main() {
 					}
 					return;
 				}
+				if (shuttingDown) return;
 				integritySlicePending = true;
 				if (globalVerifyInFlight || integritySliceTimer !== null) return;
 				integritySliceTimer = setTimeout(() => {
 					integritySliceTimer = null;
-					if (globalVerifyInFlight) return;
+					if (shuttingDown || globalVerifyInFlight) return;
 					integritySlicePending = false;
 					void runIntegritySlice().catch((error) => {
 						logger.error("startup-recovery", "Incremental database integrity continuation rejected", error);

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -54,6 +54,7 @@ import { clearAllPresence, reconcileAcpDeliveries } from "./cross-agent";
 import {
 	MIGRATION_VERIFY_FAILED_STATUS,
 	MIGRATION_VERIFY_PARKED_STATUS,
+	nextIncrementalIntegrityRetryDelay,
 	readMigrationVerifyCheckpoint,
 	runIncrementalDatabaseIntegrityCheck,
 } from "./incremental-database-integrity";
@@ -94,7 +95,11 @@ import {
 	ownerTransaction,
 	registerDbOwnerMaintenance,
 } from "./db-owner-maintenance";
-import { createDeferredRuntimeGate, createDeferredRuntimeScheduler } from "./deferred-runtime-gate";
+import {
+	createDeferredRuntimeGate,
+	createDeferredRuntimeScheduler,
+	releaseDeferredRuntimeGateIfSafe,
+} from "./deferred-runtime-gate";
 import { dbOwnerBatch, dbOwnerQuery, ownerStatement } from "./db-owner-runtime";
 import { ownerReadOne } from "./db-owner-sql";
 import type { QueuePressureSnapshot } from "./diagnostics-queue";
@@ -964,7 +969,7 @@ async function resolveActiveEmbeddingConfigThroughOwner(
 		[],
 		{ operation, deadlineMs: 5_000 },
 	);
-	return resolveActiveEmbeddingConfigFromState(configured, parseEmbeddingIndexStateRow(row ?? null));
+	return resolveActiveEmbeddingConfigFromState(configured, parseEmbeddingIndexStateRow(row));
 }
 
 async function legacyMarkdownFileState(filePath: string): Promise<LegacyMarkdownFileState | null> {
@@ -1977,6 +1982,34 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		} catch (err) {
 			logger.warn("dreaming", "Failed to start dreaming worker (non-fatal)", {
 				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	// Embedding migration is bounded background work. Start Dreaming before its
+	// owner maintenance so a slow provider or staging rebuild cannot prevent the
+	// worker from existing at all during startup.
+	if (!pipelinePaused) {
+		try {
+			embeddingIndexMigrationHandle = await startEmbeddingIndexMigration({
+				accessor: getDbAccessor(),
+				configured: memoryCfg.embedding,
+				// Re-read agent.yaml each tick so a mid-build config edit restarts
+				// the build against the new profile instead of spinning on the
+				// stale persisted one (#1160).
+				readConfigured: () => loadMemoryConfig(AGENTS_DIR).embedding,
+				fetchEmbedding,
+				checkProvider: checkEmbeddingProvider,
+				owner: dbOwnerClient ?? undefined,
+				pollMs: memoryCfg.pipelineV2.embeddingTracker.pollMs,
+				batchSize: memoryCfg.pipelineV2.embeddingTracker.batchSize,
+				onPromoted: () => {
+					restartAfterEmbeddingPromotion(telemetry);
+				},
+			});
+		} catch (error) {
+			logger.warn("embedding", "Embedding index migration deferred after startup admission failure", {
+				error: error instanceof Error ? error.message : String(error),
 			});
 		}
 	}
@@ -3007,6 +3040,18 @@ async function main() {
 			port: info.port,
 		});
 		logger.info("daemon", "Daemon ready");
+		const migrationBackupPendingAtReady = pendingMigrationBackupPath(MEMORY_DB) !== null;
+		if (
+			releaseDeferredRuntimeGateIfSafe(deferredRuntimeGate, {
+				migrationBackupPending: migrationBackupPendingAtReady,
+				writesBlocked: migrationIntegrityWritesBlocked,
+			})
+		) {
+			logger.info(
+				"startup-recovery",
+				"Starting post-ready runtime without waiting for background integrity maintenance",
+			);
+		}
 		if (!migrationIntegrityWritesBlocked) {
 			deferredRuntimeScheduler.scheduleMaintenance(async (): Promise<void> => {
 				const maintenance = dbOwnerMaintenanceHandle;
@@ -3062,6 +3107,7 @@ async function main() {
 			// verification of this generation.
 			let integritySliceTimer: ReturnType<typeof setTimeout> | null = null;
 			let integritySlicePending = false;
+			let integrityRetryDelayMs = 0;
 			let migrationIntegrityGateActive = false;
 			let integrityGateCompleted = false;
 			let migrationWritersAllowed = Promise.resolve(true);
@@ -3085,6 +3131,12 @@ async function main() {
 					integritySlicePending = false;
 					void runIntegritySlice().catch((error) => {
 						logger.error("startup-recovery", "Incremental database integrity continuation rejected", error);
+						integrityRetryDelayMs = nextIncrementalIntegrityRetryDelay("unavailable", integrityRetryDelayMs);
+						if (!migrationIntegrityGateActive && !integrityGateCompleted) {
+							integrityGateCompleted = true;
+							deferredRuntimeGate.completeIntegrity();
+						}
+						scheduleIntegritySlice(integrityRetryDelayMs);
 					});
 				}, delayMs);
 				integritySliceTimer.unref?.();
@@ -3116,9 +3168,11 @@ async function main() {
 						5_000,
 					);
 				} catch (error) {
+					deferMigrationWriters();
+					migrationWritersAllowed = Promise.resolve(false);
 					logger.error(
 						"startup-recovery",
-						"Migration verification checkpoint read failed; retrying verification",
+						"Migration verification checkpoint read failed; retrying verification with writes blocked",
 						error instanceof Error ? error : undefined,
 					);
 					publishMigrationVerifyStatus("degraded", ["degraded:integrity-unverified"]);
@@ -3266,7 +3320,21 @@ async function main() {
 					});
 				}
 				if (result.phase === "running" || result.phase === "timed_out" || result.phase === "unavailable") {
-					scheduleIntegritySlice(result.phase === "running" ? 0 : 1000);
+					integrityRetryDelayMs = nextIncrementalIntegrityRetryDelay(result.phase, integrityRetryDelayMs);
+					if (result.phase !== "running") {
+						const ownerHealth = owner.health();
+						logger.warn("startup-recovery", "Backing off incremental integrity after an unsuccessful owner slice", {
+							phase: result.phase,
+							retryDelayMs: integrityRetryDelayMs,
+							ownerState: ownerHealth.state,
+							activeJobId: ownerHealth.activeJobId,
+							activeWorkloadClass: ownerHealth.activeWorkloadClass,
+							maintenanceQueuedJobs: ownerHealth.lanes?.maintenance.queuedJobs ?? ownerHealth.maintenanceQueuedJobs,
+							foregroundQueuedJobs:
+								ownerHealth.lanes?.maintenance.foregroundQueuedJobs ?? ownerHealth.foregroundQueuedJobs,
+						});
+					}
+					scheduleIntegritySlice(integrityRetryDelayMs);
 				}
 				if (!migrationIntegrityGateActive && !integrityGateCompleted) {
 					integrityGateCompleted = true;

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1931,25 +1931,6 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		setEmbeddingTrackerHandle(embeddingTrackerHandle);
 	}
 
-	if (!pipelinePaused) {
-		embeddingIndexMigrationHandle = await startEmbeddingIndexMigration({
-			accessor: getDbAccessor(),
-			configured: memoryCfg.embedding,
-			// Re-read agent.yaml each tick so a mid-build config edit restarts
-			// the build against the new profile instead of spinning on the
-			// stale persisted one (#1160).
-			readConfigured: () => loadMemoryConfig(AGENTS_DIR).embedding,
-			fetchEmbedding,
-			checkProvider: checkEmbeddingProvider,
-			owner: dbOwnerClient ?? undefined,
-			pollMs: memoryCfg.pipelineV2.embeddingTracker.pollMs,
-			batchSize: memoryCfg.pipelineV2.embeddingTracker.batchSize,
-			onPromoted: () => {
-				restartAfterEmbeddingPromotion(telemetry);
-			},
-		});
-	}
-
 	if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
 		try {
 			dreamingWorkerHandle = startDreamingWorker(
@@ -3242,12 +3223,10 @@ async function main() {
 							},
 						});
 						if (result.phase === "pass") {
-							/* if (result.phase === "pass") {
-							startVacuumConversion(); */
-							if (deferredMigrationVerification) {
+							if (deferredMigrationVerification || migrationWritesDeferred) {
 								logger.info(
 									"startup-recovery",
-									"Prior-generation verification passed; scheduling graceful restart before admitting migration",
+									"Migration verification passed; scheduling graceful restart before admitting migration",
 								);
 								setTimeout(() => {
 									requestShutdown("migration-verify-complete-restart", 0, undefined, false);
@@ -3330,8 +3309,7 @@ async function main() {
 							activeJobId: ownerHealth.activeJobId,
 							activeWorkloadClass: ownerHealth.activeWorkloadClass,
 							maintenanceQueuedJobs: ownerHealth.lanes?.maintenance.queuedJobs ?? ownerHealth.maintenanceQueuedJobs,
-							foregroundQueuedJobs:
-								ownerHealth.lanes?.maintenance.foregroundQueuedJobs ?? ownerHealth.foregroundQueuedJobs,
+							foregroundQueuedJobs: ownerHealth.foregroundQueuedJobs,
 						});
 					}
 					scheduleIntegritySlice(integrityRetryDelayMs);

--- a/platform/daemon/src/deferred-runtime-gate.test.ts
+++ b/platform/daemon/src/deferred-runtime-gate.test.ts
@@ -2,10 +2,56 @@ import { describe, expect, it } from "bun:test";
 import {
 	createDeferredRuntimeGate,
 	createDeferredRuntimeScheduler,
+	releaseDeferredRuntimeGateIfSafe,
 	scheduleDeferredRuntimeWork,
 } from "./deferred-runtime-gate";
 
 describe("deferred runtime startup contention (#1609)", () => {
+	it("releases ordinary startup without waiting for background integrity", async () => {
+		const gate = createDeferredRuntimeGate();
+		let pipelineStarted = false;
+		const pipeline = gate.waitForIntegrity().then(() => {
+			pipelineStarted = true;
+		});
+
+		expect(
+			releaseDeferredRuntimeGateIfSafe(gate, {
+				migrationBackupPending: false,
+				writesBlocked: false,
+			}),
+		).toBe(true);
+		await pipeline;
+
+		expect(pipelineStarted).toBe(true);
+	});
+
+	it("keeps startup gated while migration verification is required", async () => {
+		const gate = createDeferredRuntimeGate();
+		let pipelineStarted = false;
+		const pipeline = gate.waitForIntegrity().then(() => {
+			pipelineStarted = true;
+		});
+
+		expect(
+			releaseDeferredRuntimeGateIfSafe(gate, {
+				migrationBackupPending: true,
+				writesBlocked: false,
+			}),
+		).toBe(false);
+		expect(
+			releaseDeferredRuntimeGateIfSafe(gate, {
+				migrationBackupPending: false,
+				writesBlocked: true,
+			}),
+		).toBe(false);
+		await Bun.sleep(0);
+		expect(pipelineStarted).toBe(false);
+
+		gate.completeIntegrity();
+		await pipeline;
+		expect(pipelineStarted).toBe(true);
+	});
+
 	it("serializes both 30-second callbacks before pipeline startup", async () => {
 		const gate = createDeferredRuntimeGate();
 		const callbacks: Array<{ readonly callback: () => void; readonly delayMs: number }> = [];

--- a/platform/daemon/src/deferred-runtime-gate.ts
+++ b/platform/daemon/src/deferred-runtime-gate.ts
@@ -32,6 +32,19 @@ export interface DeferredRuntimeScheduler {
 }
 
 /**
+ * Release ordinary startup from the background integrity gate. A retained
+ * migration backup still needs verification before any mutating runtime work.
+ */
+export function releaseDeferredRuntimeGateIfSafe(
+	gate: DeferredRuntimeGate,
+	options: { readonly migrationBackupPending: boolean; readonly writesBlocked: boolean },
+): boolean {
+	if (options.migrationBackupPending || options.writesBlocked) return false;
+	gate.completeIntegrity();
+	return true;
+}
+
+/**
  * Keep post-ready pipeline startup behind the deferred integrity work. Both
  * timers can mature together, but the DB owner must only see one maintenance
  * workload at a time.

--- a/platform/daemon/src/incremental-database-integrity.test.ts
+++ b/platform/daemon/src/incremental-database-integrity.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDbOwnerClient, DbOwnerDeadlineError, type DbOwnerClient } from "./db-owner-client";
 import {
+	nextIncrementalIntegrityRetryDelay,
 	runIncrementalDatabaseIntegrityCheck,
 	readMigrationVerifyCheckpoint,
 	type IncrementalIntegrityProgress,
@@ -40,6 +41,15 @@ function makeDatabase(): {
 }
 
 describe("incremental database integrity maintenance (#1683)", () => {
+	it("backs off abandoned slices and resets after progress", () => {
+		expect(nextIncrementalIntegrityRetryDelay("timed_out", 0)).toBe(1_000);
+		expect(nextIncrementalIntegrityRetryDelay("timed_out", 1_000)).toBe(2_000);
+		expect(nextIncrementalIntegrityRetryDelay("unavailable", 16_000)).toBe(30_000);
+		expect(nextIncrementalIntegrityRetryDelay("timed_out", 30_000)).toBe(30_000);
+		expect(nextIncrementalIntegrityRetryDelay("running", 8_000)).toBe(0);
+		expect(nextIncrementalIntegrityRetryDelay("complete", 8_000)).toBe(0);
+	});
+
 	it("tolerates concurrent legacy checkpoint upgrades", async () => {
 		const database = makeDatabase();
 		const legacy = new Database(database.path);

--- a/platform/daemon/src/incremental-database-integrity.ts
+++ b/platform/daemon/src/incremental-database-integrity.ts
@@ -38,6 +38,22 @@ export const MIGRATION_VERIFY_FAILED_STATUS = "failed:integrity-unverified" as c
 
 export type IncrementalIntegrityPhase = "running" | "complete" | "cancelled" | "timed_out" | "unavailable" | "degraded";
 
+const INCREMENTAL_INTEGRITY_RETRY_BASE_DELAY_MS = 1_000;
+const INCREMENTAL_INTEGRITY_RETRY_MAX_DELAY_MS = 30_000;
+
+/** Back off abandoned integrity slices so a blocked owner queue cannot self-fill. */
+export function nextIncrementalIntegrityRetryDelay(phase: IncrementalIntegrityPhase, previousDelayMs: number): number {
+	if (phase !== "timed_out" && phase !== "unavailable") return 0;
+	const previous =
+		Number.isFinite(previousDelayMs) && previousDelayMs >= INCREMENTAL_INTEGRITY_RETRY_BASE_DELAY_MS
+			? previousDelayMs
+			: 0;
+	return Math.min(
+		INCREMENTAL_INTEGRITY_RETRY_MAX_DELAY_MS,
+		previous === 0 ? INCREMENTAL_INTEGRITY_RETRY_BASE_DELAY_MS : previous * 2,
+	);
+}
+
 export interface IncrementalIntegrityProgress extends DatabaseIntegrityProgress {
 	readonly checkpointKey: string;
 	readonly phase: IncrementalIntegrityPhase;

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -480,21 +480,21 @@
     },
     {
       "path": "daemon.ts",
-      "line": 3332,
+      "line": 3333,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3333,
+      "line": 3334,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3336,
+      "line": 3337,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -333,168 +333,168 @@
     },
     {
       "path": "daemon.ts",
-      "line": 615,
+      "line": 620,
       "api": "existsSync",
       "source": "if (!existsSync(agentsMdPath)) return;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 632,
+      "line": 637,
       "api": "existsSync",
       "source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 660,
+      "line": 665,
       "api": "existsSync",
       "source": "if (!existsSync(identityPath)) return \"\";",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 690,
+      "line": 695,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 722,
+      "line": 727,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 729,
-      "api": "existsSync",
-      "source": "if (existsSync(geminiDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
       "line": 734,
       "api": "existsSync",
+      "source": "if (existsSync(geminiDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 739,
+      "api": "existsSync",
       "source": "if (existsSync(settingsPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 735,
+      "line": 740,
       "api": "readFileSync",
       "source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 755,
+      "line": 760,
       "api": "existsSync",
       "source": "if (!existsSync(targetPath)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1320,
+      "line": 1325,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1688,
+      "line": 1693,
       "api": "existsSync",
       "source": "if (!existsSync(p)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1690,
+      "line": 1695,
       "api": "readFileSync",
       "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1734,
+      "line": 1739,
       "api": "existsSync",
       "source": "if (!existsSync(path)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1736,
+      "line": 1741,
       "api": "readFileSync",
       "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2138,
+      "line": 2152,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2140,
+      "line": 2154,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2298,
+      "line": 2312,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2299,
+      "line": 2313,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2300,
+      "line": 2314,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2471,
+      "line": 2485,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2546,
+      "line": 2560,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3286,
+      "line": 3332,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3287,
+      "line": 3333,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3290,
+      "line": 3336,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

Fix daemon startup starvation on large workspaces so ordinary startup can create the Dreaming worker without waiting for observational integrity maintenance or embedding-index migration to finish.

Fixes #1859

## Changes

- Release the ordinary deferred-runtime gate at readiness when no migration backup is pending and database writes are not blocked.
- Start Dreaming before the long-running embedding-index migration, and keep migration startup failure non-fatal to worker creation.
- Route the active embedding configuration lookup through the DB-owner read lane instead of maintenance.
- Exponentially back off timed-out, unavailable, and unexpectedly rejected integrity slices up to 30 seconds, with owner queue-health logging.
- Preserve the migration-verification gate and fail-closed write behavior when a rollback backup or write block requires it.
- Add regression coverage for gate safety and integrity retry backoff.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A: daemon startup/runtime behavior only.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no schema or data migration changes.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted verification:

- `bun test platform/daemon/src/deferred-runtime-gate.test.ts platform/daemon/src/incremental-database-integrity.test.ts platform/daemon/src/migration-integrity-verify.test.ts`: 34 passed, 0 failed.
- `bun test platform/daemon/src/db-owner-client.test.ts --test-name-pattern 'keeps transport readiness distinct from database initialization'`: 1 passed, 0 failed when run alone.
- `bun run --filter '@signet/daemon' typecheck`: passed.
- `bun run --filter '@signet/daemon' build`: passed.
- `bun run typecheck`: passed.
- `bun run lint`: passed with existing repository warnings only.
- `bun run format:check`: passed.
- `git diff --check`: passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full root `bun test` sweep was not completed: it exceeded the execution limit while running unrelated third-party/reference tests and was stopped after spawning DB-owner workers from `/home/nicholai/signet/signetai/_old-head-mutation`; it produced no aggregate test result. No large-workspace live daemon reproduction was available in this environment.
