### PR TITLE
fix(daemon): bound recall context query work

### DIFF
--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1254,6 +1254,7 @@ export type {
 	PluginSurfaceBase,
 	PluginSurfaceSummary,
 	PluginToolSummary,
+	RecallContextMeta,
 	RecallResponse,
 	RecallResult,
 	RecoverResult,

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -49,10 +49,27 @@ export interface RecallResult {
 	readonly already_recalled?: boolean;
 }
 
+export interface RecallContextMeta {
+	readonly partial: boolean;
+	readonly focalEntityCount: number;
+	readonly selectedEntityCount: number;
+	readonly entityCount: number;
+	readonly entityLimit: number;
+	readonly omittedEntityCount: number;
+	readonly statementCount: number;
+	readonly estimatedWorkUnits: number;
+	readonly safetyLedger: "available" | "missing" | "unavailable";
+	readonly constructedLimit: number;
+	readonly constructedBlocks: number;
+	readonly truncatedBlocks: number;
+	readonly reason?: "entity_budget" | "safety_ledger_unavailable" | "owner_failure";
+}
+
 export interface RecallMeta {
 	readonly totalReturned: number;
 	readonly hasSupplementary: boolean;
 	readonly noHits: boolean;
+	readonly context?: RecallContextMeta;
 	readonly timings?: {
 		readonly totalMs: number;
 		readonly stages: readonly { readonly name: string; readonly durationMs: number }[];

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -249,6 +249,7 @@ export {
 } from "./recall";
 export type {
 	AggregateRecallMeta,
+	RecallContextMeta,
 	AggregateRecallUsage,
 	AggregateRecallUsageStage,
 	RecallMeta,

--- a/platform/core/src/recall.test.ts
+++ b/platform/core/src/recall.test.ts
@@ -34,6 +34,48 @@ describe("recall surface helpers", () => {
 		}
 	});
 
+	it("preserves bounded graph-context work metadata", () => {
+		const parsed = parseRecallPayload({
+			results: [],
+			meta: {
+				totalReturned: 0,
+				hasSupplementary: false,
+				noHits: true,
+				context: {
+					partial: true,
+					focalEntityCount: 200,
+					selectedEntityCount: 3,
+					entityCount: 3,
+					entityLimit: 3,
+					omittedEntityCount: 197,
+					statementCount: 7,
+					estimatedWorkUnits: 418,
+					safetyLedger: "available",
+					constructedLimit: 3,
+					constructedBlocks: 3,
+					truncatedBlocks: 0,
+					reason: "entity_budget",
+				},
+			},
+		});
+
+		expect(parsed.meta.context).toEqual({
+			partial: true,
+			focalEntityCount: 200,
+			selectedEntityCount: 3,
+			entityCount: 3,
+			entityLimit: 3,
+			omittedEntityCount: 197,
+			statementCount: 7,
+			estimatedWorkUnits: 418,
+			safetyLedger: "available",
+			constructedLimit: 3,
+			constructedBlocks: 3,
+			truncatedBlocks: 0,
+			reason: "entity_budget",
+		});
+	});
+
 	it("formats daemon recall payloads with primary and supporting context", () => {
 		const text = formatRecallText({
 			method: "hybrid",

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -31,6 +31,22 @@ export interface RecallRow extends RecallPartitionableRow {
 	readonly subject_id?: string;
 }
 
+export interface RecallContextMeta {
+	readonly partial: boolean;
+	readonly focalEntityCount: number;
+	readonly selectedEntityCount: number;
+	readonly entityCount: number;
+	readonly entityLimit: number;
+	readonly omittedEntityCount: number;
+	readonly statementCount: number;
+	readonly estimatedWorkUnits: number;
+	readonly safetyLedger: "available" | "missing" | "unavailable";
+	readonly constructedLimit: number;
+	readonly constructedBlocks: number;
+	readonly truncatedBlocks: number;
+	readonly reason?: "entity_budget" | "safety_ledger_unavailable" | "owner_failure";
+}
+
 export interface RecallMeta {
 	readonly totalReturned: number;
 	readonly hasSupplementary: boolean;
@@ -42,6 +58,7 @@ export interface RecallMeta {
 		readonly suppressed: number;
 		readonly repeatedReturned: number;
 	};
+	readonly context?: RecallContextMeta;
 }
 
 export type AggregateRecallBudget = "small" | "medium" | "large";
@@ -241,6 +258,58 @@ export function partitionRecallRows<T extends RecallPartitionableRow>(
 	};
 }
 
+function parseRecallContextMeta(raw: unknown): RecallContextMeta | undefined {
+	if (!isRecord(raw) || typeof raw.partial !== "boolean") return undefined;
+	const numberValue = (key: string): number | null => {
+		const value = raw[key];
+		return typeof value === "number" && Number.isFinite(value) ? value : null;
+	};
+	const focalEntityCount = numberValue("focalEntityCount");
+	const selectedEntityCount = numberValue("selectedEntityCount");
+	const entityCount = numberValue("entityCount");
+	const entityLimit = numberValue("entityLimit");
+	const omittedEntityCount = numberValue("omittedEntityCount");
+	const statementCount = numberValue("statementCount");
+	const estimatedWorkUnits = numberValue("estimatedWorkUnits");
+	const constructedLimit = numberValue("constructedLimit");
+	const constructedBlocks = numberValue("constructedBlocks");
+	const truncatedBlocks = numberValue("truncatedBlocks");
+	if (
+		focalEntityCount === null ||
+		selectedEntityCount === null ||
+		entityCount === null ||
+		entityLimit === null ||
+		omittedEntityCount === null ||
+		statementCount === null ||
+		estimatedWorkUnits === null ||
+		constructedLimit === null ||
+		constructedBlocks === null ||
+		truncatedBlocks === null
+	)
+		return undefined;
+	if (raw.safetyLedger !== "available" && raw.safetyLedger !== "missing" && raw.safetyLedger !== "unavailable")
+		return undefined;
+	const reason =
+		raw.reason === "entity_budget" || raw.reason === "safety_ledger_unavailable" || raw.reason === "owner_failure"
+			? raw.reason
+			: undefined;
+	return {
+		partial: raw.partial,
+		focalEntityCount,
+		selectedEntityCount,
+		entityCount,
+		entityLimit,
+		omittedEntityCount,
+		statementCount,
+		estimatedWorkUnits,
+		safetyLedger: raw.safetyLedger,
+		constructedLimit,
+		constructedBlocks,
+		truncatedBlocks,
+		...(reason === undefined ? {} : { reason }),
+	};
+}
+
 export function parseRecallMeta(raw: unknown, fallbackCount: number): RecallMeta {
 	if (!isRecord(raw)) {
 		return {
@@ -262,7 +331,15 @@ export function parseRecallMeta(raw: unknown, fallbackCount: number): RecallMeta
 			}
 		: undefined;
 	const temporal = isRecord(raw.temporal) ? (raw.temporal as unknown as RecallTemporalMeta) : undefined;
-	return { totalReturned, hasSupplementary, noHits, ...(dedupe ? { dedupe } : {}), ...(temporal ? { temporal } : {}) };
+	const context = parseRecallContextMeta(raw.context);
+	return {
+		totalReturned,
+		hasSupplementary,
+		noHits,
+		...(dedupe ? { dedupe } : {}),
+		...(temporal ? { temporal } : {}),
+		...(context ? { context } : {}),
+	};
 }
 
 export function parseRecallPayload(raw: unknown): {

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -341,6 +341,63 @@ describe("hybridRecall", () => {
 		expect(result.entities).toBeUndefined();
 	});
 
+	it("reports bounded graph-context omissions in recall metadata", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (id, content, type, agent_id, created_at, updated_at, updated_by)
+				 VALUES ('bounded-context-memory', 'Signet bounded context result', 'fact', 'default', ?, ?, 'test')`,
+			).run(now, now);
+			const entity = db.prepare(
+				`INSERT INTO entities (
+					id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at
+				) VALUES (?, ?, ?, 'project', 'default', 1, ?, ?)`,
+			);
+			const aspect = db.prepare(
+				`INSERT INTO entity_aspects (
+					id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at
+				) VALUES (?, ?, 'default', 'context', 'context', 0.9, ?, ?)`,
+			);
+			const attribute = db.prepare(
+				`INSERT INTO entity_attributes (
+					id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+					confidence, importance, status, created_at, updated_at
+				) VALUES (?, ?, 'default', NULL, 'attribute', ?, ?, 1, 0.9, 'active', ?, ?)`,
+			);
+			for (let index = 0; index < 4; index++) {
+				const entityId = `bounded-context-entity-${index}`;
+				const aspectId = `bounded-context-aspect-${index}`;
+				const content = `bounded graph context value ${index}`;
+				entity.run(entityId, `Signet context ${index}`, `signet-context-${index}`, now, now);
+				aspect.run(aspectId, entityId, now, now);
+				attribute.run(`bounded-context-attribute-${index}`, aspectId, content, content, now, now);
+			}
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "Signet",
+				keywordQuery: "Signet",
+				limit: 1,
+				agentId: "default",
+				readPolicy: "isolated",
+				trackRecallAccess: false,
+			},
+			testCfg({ graph: true, traversal: true }),
+			async () => null,
+		);
+
+		expect(result.meta.context).toMatchObject({
+			partial: true,
+			focalEntityCount: 4,
+			selectedEntityCount: 1,
+			entityLimit: 1,
+			constructedLimit: 1,
+			omittedEntityCount: 3,
+			reason: "entity_budget",
+		});
+	});
+
 	function seedUnbackedOntologyClaim(opts: {
 		readonly id: string;
 		readonly agentId?: string;

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -19,6 +19,7 @@ import {
 	type AgentRosterReadPolicy,
 	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
 	type LlmUsage,
+	type RecallContextMeta,
 	type RecallSurface,
 	type RecallTemporalMeta,
 	SOURCE_CHUNK_SOURCE_TYPE,
@@ -40,7 +41,13 @@ import { buildAgentScopeClause } from "./memory-access-scope";
 import type { EmbeddingConfig, MemorySearchConfig, ResolvedMemoryConfig } from "./memory-config";
 import { isMemoryContentContextEligible } from "./memory-content-safety";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
-import { constructContextBlocksViaOwner } from "./pipeline/context-construction";
+import {
+	buildEntityContextFromSnapshot,
+	constructContextBlocksFromSnapshot,
+	prepareContextRows,
+	type ConstructedContext,
+} from "./pipeline/context-construction";
+import { loadContextSnapshotViaOwner } from "./pipeline/context-snapshot";
 import { DEFAULT_DAMPENING, type ScoredRow, applyDampening } from "./pipeline/dampening";
 import { getGraphBoostIdsViaOwner, tokenizeGraphQuery } from "./pipeline/graph-search";
 import {
@@ -162,6 +169,8 @@ export interface RecallResponse {
 			code: string | number | null;
 			message: string;
 		};
+		/** Bounded knowledge-graph context work and any omitted/truncated context. */
+		context?: RecallContextMeta;
 		/** Most specific known degradation reason for partial recall. */
 		degradation?: "fts_incomplete" | "graph_traversal_timeout" | "graph_traversal_failed";
 		/**
@@ -1493,6 +1502,7 @@ export async function hybridRecall(
 	let graphPartial = false;
 	let graphError: RecallResponse["meta"]["graphError"];
 	let graphDegradation: RecallResponse["meta"]["degradation"];
+	let contextMeta: RecallContextMeta | undefined;
 	const selectionSuppressedIds = new Set<string>();
 	const lifecycleSourceResults = new Map<string, { readonly source?: string; readonly source_id?: string }>();
 	const selectionDedupeEnabled = !!params.sessionKey?.trim() && params.includeRecalled !== true;
@@ -1582,6 +1592,7 @@ export async function hybridRecall(
 					? { degradation: "fts_incomplete" as const }
 					: {}),
 			...(dedupeMeta.enabled ? { dedupe: dedupeMeta } : {}),
+			...(contextMeta ? { context: contextMeta } : {}),
 		};
 		try {
 			const trackedIds = response.results.map((row) => row.id).filter((id) => !id.includes(":"));
@@ -3065,8 +3076,14 @@ export async function hybridRecall(
 	}
 
 	// --- Entity context + constructed memories (DP-7) ---
+	// Both views consume one bounded raw snapshot. The constructed budget is
+	// also the entity budget, so a small requested card count cannot trigger
+	// work over the full focal set.
 	let entityContext: RecallResponse["entities"];
 	let focalEids: string[] = [];
+	let constructedBlocks: ReadonlyArray<ConstructedContext> = [];
+	const constructedLimit = Math.min(limit, Math.max(3, Math.ceil(limit * 0.3)));
+	let contextFocalEntityCount = 0;
 
 	if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.traversal?.enabled) {
 		const entityContextStart = performance.now();
@@ -3076,100 +3093,63 @@ export async function hybridRecall(
 				const agentId = params.agentId ?? "default";
 				const owner = await getGraphOwner();
 				const focal = await getFocalEntities(owner, agentId);
+				contextFocalEntityCount = focal.entityIds.length;
 				if (focal.error) recordGraphResult({ timedOut: false, error: focal.error });
-				const ctx = await (async () => {
-					if (focal.entityIds.length === 0) return null;
-					let eids = focal.entityIds;
-					if (params.scope !== undefined || params.project) {
-						const ph = eids.map(() => "?").join(", ");
-						const scoped = await graphOwnerReadAll<{ entity_id: string }>(
-							`SELECT DISTINCT mem.entity_id
-							 FROM memory_entity_mentions mem
-							 JOIN memories m ON m.id = mem.memory_id
-							 WHERE mem.entity_id IN (${ph})
-							   ${currentMemorySql("m")}
-							   ${filter.sql}`,
-							[...eids, ...filter.args],
-							"memory-search.entity-context.scope",
-							eids.length,
-						);
-						eids = scoped.map((row) => row.entity_id);
-						if (eids.length === 0) return null;
-					}
-
-					const placeholders = eids.map(() => "?").join(", ");
-					const entities = await graphOwnerReadAll<{ id: string; name: string; entity_type: string }>(
-						`SELECT id, name, entity_type FROM entities WHERE id IN (${placeholders})`,
-						eids,
-						"memory-search.entity-context.entities",
+				let eids = focal.entityIds;
+				if (eids.length > 0 && (params.scope !== undefined || params.project)) {
+					const ph = eids.map(() => "?").join(", ");
+					const scoped = await graphOwnerReadAll<{ entity_id: string }>(
+						`SELECT DISTINCT mem.entity_id
+						 FROM memory_entity_mentions mem
+						 JOIN memories m ON m.id = mem.memory_id
+						 WHERE mem.entity_id IN (${ph})
+						   ${currentMemorySql("m")}
+						   ${filter.sql}`,
+						[...eids, ...filter.args],
+						"memory-search.entity-context.scope",
 						eids.length,
 					);
-					const safetyTable = await graphOwnerReadAll<{ name: string }>(
-						"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_content_safety'",
-						[],
-						"memory-search.entity-context.safety-table",
-						1,
-					);
-					const safetyJoin =
-						safetyTable.length > 0
-							? "LEFT JOIN memory_content_safety safety ON safety.agent_id = ea.agent_id AND safety.source_kind = 'memory' AND safety.source_id = ea.memory_id"
-							: "";
-					const safetySelect =
-						safetyTable.length > 0
-							? ", safety.status AS safety_status, safety.context_eligible AS safety_context_eligible"
-							: "";
-					const structured = [];
-					for (const entity of entities) {
-						const aspects = await graphOwnerReadAll<{ id: string; name: string }>(
-							`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
-							 WHERE entity_id = ? AND agent_id = ?
-							 ORDER BY weight DESC LIMIT 10`,
-							[entity.id, agentId],
-							"memory-search.entity-context.aspects",
-							10,
-						);
-						const contextAspects = [];
-						for (const aspect of aspects) {
-							const attrs = await graphOwnerReadAll<{
-								content: string;
-								status: string;
-								importance: number;
-								memory_id: string | null;
-								safety_status?: string | null;
-								safety_context_eligible?: number | null;
-							}>(
-								`SELECT ea.content, ea.status, ea.importance, ea.memory_id${safetySelect}
-								 FROM entity_attributes ea ${safetyJoin}
-								 WHERE ea.aspect_id = ? AND ea.agent_id = ? AND ea.status = 'active'
-								 ORDER BY ea.importance DESC LIMIT 5`,
-								[aspect.id, agentId],
-								"memory-search.entity-context.attributes",
-								5,
-							);
-							const attributes = attrs
-								.filter(
-									(attr) =>
-										scanMemoryContent(attr.content).contextEligible &&
-										(!attr.memory_id ||
-											attr.safety_status == null ||
-											(attr.safety_status === "clean" && attr.safety_context_eligible === 1)),
-								)
-								.map((attr) => ({ content: attr.content, status: attr.status, importance: attr.importance }));
-							if (attributes.length > 0) contextAspects.push({ name: aspect.name, attributes });
-						}
-						if (contextAspects.length > 0) {
-							structured.push({ name: entity.name, type: entity.entity_type, aspects: contextAspects });
-						}
-					}
-					return { eids, structured };
-				})();
+					eids = scoped.map((row) => row.entity_id);
+				}
 
-				if (ctx) {
-					entityContext = ctx.structured;
-					focalEids = ctx.eids;
+				if (eids.length > 0) {
+					const snapshot = await loadContextSnapshotViaOwner(owner, agentId, eids, constructedLimit);
+					const prepared = await prepareContextRows(snapshot);
+					entityContext = await buildEntityContextFromSnapshot(snapshot, prepared);
+					constructedBlocks = await constructContextBlocksFromSnapshot(snapshot, constructedLimit, prepared);
+					focalEids = [...snapshot.entityIds];
+					contextMeta = {
+						...snapshot.work,
+						constructedLimit,
+						constructedBlocks: constructedBlocks.length,
+						truncatedBlocks: constructedBlocks.filter((block) => block.truncated).length,
+						...(snapshot.work.partial
+							? {
+									reason:
+										snapshot.work.safetyLedger === "unavailable"
+											? ("safety_ledger_unavailable" as const)
+											: ("entity_budget" as const),
+								}
+							: {}),
+					};
 				}
 			}
 		} catch (e) {
+			contextMeta = {
+				focalEntityCount: contextFocalEntityCount,
+				selectedEntityCount: 0,
+				entityCount: 0,
+				entityLimit: constructedLimit,
+				omittedEntityCount: contextFocalEntityCount,
+				statementCount: 0,
+				estimatedWorkUnits: 0,
+				partial: true,
+				safetyLedger: "unavailable",
+				constructedLimit,
+				constructedBlocks: 0,
+				truncatedBlocks: 0,
+				reason: "owner_failure",
+			};
 			logger.warn("memory", "Entity context fetch failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
@@ -3183,18 +3163,15 @@ export async function hybridRecall(
 	// query-independent. To prevent large entity cards from outranking
 	// actual memories that answer the query, cap their scores below the
 	// lowest real result score.
-	if (focalEids.length > 0) {
+	if (focalEids.length > 0 && constructedBlocks.length > 0) {
 		const constructedStart = performance.now();
 		try {
-			const agentId = params.agentId ?? "default";
-			const cap = Math.max(3, Math.ceil(limit * 0.3));
-			const blocks = await constructContextBlocksViaOwner(await getGraphOwner(), agentId, focalEids, cap);
 			const now = new Date().toISOString();
 			const minReal = results.length > 0 ? Math.min(...results.map((r) => r.score)) : 0.5;
 			const maxConstructed = Math.max(0.01, minReal - 0.01);
 			let added = 0;
-			for (const block of blocks) {
-				if (added >= cap || results.length >= limit) break;
+			for (const block of constructedBlocks) {
+				if (added >= constructedLimit || results.length >= limit) break;
 				if (!scanMemoryContent(block.content).contextEligible) continue;
 				const syntheticId = `constructed:${block.provenance.entityName}`;
 				if (existingIds.has(syntheticId)) continue;

--- a/platform/daemon/src/pipeline/context-construction.test.ts
+++ b/platform/daemon/src/pipeline/context-construction.test.ts
@@ -1,0 +1,242 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { DbOwnerClient, DbOwnerJobHandle, DbOwnerRequest, DbOwnerSubmitOptions } from "../db-owner-client";
+import {
+	CONTEXT_MAX_ASPECTS_PER_ENTITY,
+	CONTEXT_MAX_ATTRIBUTES_PER_ASPECT,
+	CONTEXT_MAX_ENTITIES,
+	CONTEXT_MAX_DEPENDENCIES_PER_ENTITY,
+	CONTEXT_SNAPSHOT_MAX_STATEMENTS,
+	CONTEXT_SNAPSHOT_WORK_UNIT_CEILING,
+} from "./context-snapshot";
+import { constructContextBlocksFromSnapshot, prepareContextRows } from "./context-construction";
+import { loadContextSnapshotViaOwner } from "./context-snapshot";
+
+interface OwnerCall {
+	readonly operation: string;
+	readonly estimatedWorkUnits: number | undefined;
+	readonly sql: string;
+	readonly params: readonly unknown[];
+}
+
+function createOwner(db: Database, calls: OwnerCall[]): DbOwnerClient {
+	return {
+		submit<Result>(request: DbOwnerRequest, options: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> {
+			if (request.kind !== "query") throw new Error(`unexpected owner request: ${request.kind}`);
+			const params = request.statement.params ?? [];
+			if (params.some((param) => typeof param === "object" && param !== null))
+				throw new Error("unexpected byte parameter in context query");
+			calls.push({
+				operation: options.operation,
+				estimatedWorkUnits: options.estimatedWorkUnits,
+				sql: request.statement.sql,
+				params,
+			});
+			const statement = db.prepare(request.statement.sql);
+			const result =
+				request.statement.result === "all"
+					? statement.all(...params)
+					: request.statement.result === "get"
+						? statement.get(...params)
+						: statement.run(...params);
+			return { result: Promise.resolve(result as Result) } as DbOwnerJobHandle<Result>;
+		},
+	} as DbOwnerClient;
+}
+
+function seedSchema(db: Database): void {
+	db.exec(`
+		CREATE TABLE entities (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			entity_type TEXT NOT NULL,
+			agent_id TEXT NOT NULL
+		);
+		CREATE TABLE entity_aspects (
+			id TEXT PRIMARY KEY,
+			entity_id TEXT NOT NULL,
+			agent_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			weight REAL NOT NULL
+		);
+		CREATE TABLE entity_attributes (
+			id TEXT PRIMARY KEY,
+			aspect_id TEXT NOT NULL,
+			agent_id TEXT NOT NULL,
+			memory_id TEXT,
+			kind TEXT NOT NULL,
+			content TEXT NOT NULL,
+			status TEXT NOT NULL,
+			importance REAL NOT NULL
+		);
+		CREATE TABLE entity_dependencies (
+			id TEXT PRIMARY KEY,
+			source_entity_id TEXT NOT NULL,
+			target_entity_id TEXT NOT NULL,
+			agent_id TEXT NOT NULL,
+			strength REAL NOT NULL
+		);
+		CREATE TABLE memory_content_safety (
+			agent_id TEXT NOT NULL,
+			source_kind TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			context_eligible INTEGER NOT NULL,
+			PRIMARY KEY (agent_id, source_kind, source_id)
+		);
+		CREATE INDEX idx_entity_aspects_entity ON entity_aspects(entity_id);
+		CREATE INDEX idx_entity_attributes_aspect ON entity_attributes(aspect_id);
+		CREATE INDEX idx_entity_dependencies_source ON entity_dependencies(source_entity_id);
+	`);
+}
+
+function seedWorstCaseGraph(db: Database, entityCount: number): string[] {
+	const entity = db.prepare(
+		"INSERT INTO entities (id, name, entity_type, agent_id) VALUES (?, ?, 'project', 'default')",
+	);
+	const aspect = db.prepare(
+		"INSERT INTO entity_aspects (id, entity_id, agent_id, name, weight) VALUES (?, ?, 'default', ?, ?)",
+	);
+	const attribute = db.prepare(
+		"INSERT INTO entity_attributes (id, aspect_id, agent_id, memory_id, kind, content, status, importance) VALUES (?, ?, 'default', ?, 'attribute', ?, 'active', ?)",
+	);
+	const dependency = db.prepare(
+		"INSERT INTO entity_dependencies (id, source_entity_id, target_entity_id, agent_id, strength) VALUES (?, ?, ?, 'default', ?)",
+	);
+	const focalIds: string[] = [];
+	for (let entityIndex = 0; entityIndex < entityCount; entityIndex++) {
+		const entityId = `entity-${entityIndex}`;
+		focalIds.push(entityId);
+		entity.run(entityId, `Entity ${entityIndex}`);
+		for (let aspectIndex = 0; aspectIndex < CONTEXT_MAX_ASPECTS_PER_ENTITY; aspectIndex++) {
+			const aspectId = `${entityId}-aspect-${aspectIndex}`;
+			aspect.run(aspectId, entityId, `Aspect ${aspectIndex}`, 1 - aspectIndex / 100);
+			for (let attributeIndex = 0; attributeIndex < CONTEXT_MAX_ATTRIBUTES_PER_ASPECT; attributeIndex++) {
+				attribute.run(
+					`${aspectId}-attribute-${attributeIndex}`,
+					aspectId,
+					`${aspectId}-memory-${attributeIndex}`,
+					`${entityId} value ${aspectIndex}-${attributeIndex}`,
+					1 - attributeIndex / 100,
+				);
+			}
+		}
+		for (let dependencyIndex = 0; dependencyIndex < CONTEXT_MAX_DEPENDENCIES_PER_ENTITY; dependencyIndex++) {
+			const targetIndex = (entityIndex + dependencyIndex + 1) % entityCount;
+			dependency.run(
+				`${entityId}-dependency-${dependencyIndex}`,
+				entityId,
+				`entity-${targetIndex}`,
+				1 - dependencyIndex / 100,
+			);
+		}
+	}
+	return focalIds;
+}
+
+function seedSafetyRows(db: Database): void {
+	const aspectId = "entity-0-aspect-0";
+	db.prepare(
+		`INSERT INTO entity_attributes
+			(id, aspect_id, agent_id, memory_id, kind, content, status, importance)
+			VALUES (?, ?, 'default', ?, 'attribute', ?, 'active', ?)`,
+	).run("safety-clean", aspectId, "memory-clean", "clean persisted context", 2);
+	db.prepare(
+		`INSERT INTO entity_attributes
+			(id, aspect_id, agent_id, memory_id, kind, content, status, importance)
+			VALUES (?, ?, 'default', ?, 'attribute', ?, 'active', ?)`,
+	).run("safety-tainted", aspectId, "memory-tainted", "tainted persisted context", 1.9);
+	db.prepare(
+		`INSERT INTO entity_attributes
+			(id, aspect_id, agent_id, memory_id, kind, content, status, importance)
+			VALUES (?, ?, 'default', ?, 'attribute', ?, 'active', ?)`,
+	).run("safety-missing", aspectId, "memory-missing", "missing ledger context", 1.8);
+	db.prepare(
+		`INSERT INTO entity_attributes
+			(id, aspect_id, agent_id, memory_id, kind, content, status, importance)
+			VALUES (?, ?, 'default', NULL, 'constraint', ?, 'active', ?)`,
+	).run("safety-constraint", aspectId, "preserve the bounded context contract", 1.7);
+	db.prepare(
+		`INSERT INTO memory_content_safety
+			(agent_id, source_kind, source_id, status, context_eligible)
+			VALUES ('default', 'memory', ?, ?, ?)`,
+	).run("memory-clean", "clean", 1);
+	db.prepare(
+		`INSERT INTO memory_content_safety
+			(agent_id, source_kind, source_id, status, context_eligible)
+			VALUES ('default', 'memory', ?, ?, ?)`,
+	).run("memory-tainted", "tainted", 0);
+}
+
+describe("bounded context snapshots", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		seedSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("bounds statements and parent-side work before assembling constructed cards", async () => {
+		const focalIds = seedWorstCaseGraph(db, 200);
+		seedSafetyRows(db);
+		const calls: OwnerCall[] = [];
+		const owner = createOwner(db, calls);
+		let eventLoopBreaths = 0;
+		let done = false;
+		const breathe = (): void => {
+			if (done) return;
+			eventLoopBreaths++;
+			setImmediate(breathe);
+		};
+		setImmediate(breathe);
+
+		const snapshot = await loadContextSnapshotViaOwner(owner, "default", focalIds, CONTEXT_MAX_ENTITIES);
+		const prepared = await prepareContextRows(snapshot);
+		const blocks = await constructContextBlocksFromSnapshot(snapshot, 3, prepared);
+		done = true;
+
+		expect(blocks).toHaveLength(3);
+		expect(snapshot.work).toMatchObject({
+			focalEntityCount: 200,
+			selectedEntityCount: CONTEXT_MAX_ENTITIES,
+			entityCount: CONTEXT_MAX_ENTITIES,
+			entityLimit: CONTEXT_MAX_ENTITIES,
+			omittedEntityCount: 200 - CONTEXT_MAX_ENTITIES,
+			partial: true,
+			safetyLedger: "available",
+		});
+		expect(snapshot.work.statementCount).toBeGreaterThan(7);
+		expect(snapshot.work.estimatedWorkUnits).toBeLessThanOrEqual(CONTEXT_SNAPSHOT_WORK_UNIT_CEILING);
+		expect(calls.length).toBe(snapshot.work.statementCount);
+		expect(calls.length).toBeLessThanOrEqual(CONTEXT_SNAPSHOT_MAX_STATEMENTS);
+		expect(calls.every((call) => call.operation === "memory-search.context.snapshot")).toBe(true);
+		expect(calls.reduce((total, call) => total + (call.estimatedWorkUnits ?? 0), 0)).toBeLessThanOrEqual(
+			CONTEXT_SNAPSHOT_WORK_UNIT_CEILING,
+		);
+		expect(eventLoopBreaths).toBeGreaterThan(0);
+	});
+
+	it("keeps persisted safety fail-closed while allowing a missing ledger row", async () => {
+		const focalIds = seedWorstCaseGraph(db, 1);
+		seedSafetyRows(db);
+		const owner = createOwner(db, []);
+		const snapshot = await loadContextSnapshotViaOwner(owner, "default", focalIds, 1);
+		const prepared = await prepareContextRows(snapshot);
+		const blocks = await constructContextBlocksFromSnapshot(snapshot, 1, prepared);
+		const content = blocks[0]?.content ?? "";
+		const safeAttributes = prepared.attributesByAspect.get("entity-0-aspect-0") ?? [];
+		const safeConstraints = prepared.constraintsByEntity.get("entity-0") ?? [];
+
+		expect(snapshot.safetyLedger).toBe("available");
+		expect(safeAttributes.map((attribute) => attribute.content)).toContain("clean persisted context");
+		expect(safeAttributes.map((attribute) => attribute.content)).toContain("missing ledger context");
+		expect(safeAttributes.map((attribute) => attribute.content)).not.toContain("tainted persisted context");
+		expect(safeConstraints.map((constraint) => constraint.content)).toContain("preserve the bounded context contract");
+		// The card remains bounded even when the fixture has the full per-entity shape.
+		expect(content.length).toBeLessThanOrEqual(900);
+	});
+});

--- a/platform/daemon/src/pipeline/context-construction.ts
+++ b/platform/daemon/src/pipeline/context-construction.ts
@@ -1,23 +1,23 @@
 /**
  * DP-7: Constructed memories with path provenance.
  *
- * Synthesizes purpose-built context blocks from knowledge graph
- * traversal paths. Each block combines entity attributes, constraints,
- * and dependency relationships into a coherent text representation
- * with provenance metadata for future path feedback (DP-9).
- *
- * No LLM calls — pure template synthesis.
+ * This module assembles prompt-facing entity and constructed context from a
+ * bounded raw snapshot. SQLite access and snapshot accounting live in
+ * context-snapshot.ts; no content scanning occurs in an owner callback.
  */
 
 import { scanMemoryContent } from "@signet/core";
+import { yieldEvery } from "../async-yield";
 import type { DbOwnerClient } from "../db-owner-client";
-import { ownerReadAll } from "../db-owner-sql";
-import type { ReadDb } from "../db-accessor";
-import { isMemoryContentContextEligible } from "../memory-content-safety";
-
-// ---------------------------------------------------------------------------
-// Public interfaces
-// ---------------------------------------------------------------------------
+import {
+	loadContextSnapshotViaOwner,
+	CONTEXT_MAX_ATTRIBUTES_PER_ASPECT,
+	type AspectRow,
+	type AttributeRow,
+	type ConstraintRow,
+	type DependencyRow,
+	type ContextSnapshot,
+} from "./context-snapshot";
 
 export interface ConstructedProvenance {
 	readonly entityId: string;
@@ -38,36 +38,12 @@ export interface ConstructedContext {
 	readonly provenance: ConstructedProvenance;
 }
 
-// ---------------------------------------------------------------------------
-// Internal row types
-// ---------------------------------------------------------------------------
-
-interface EntityRow {
-	readonly id: string;
-	readonly name: string;
-	readonly entity_type: string;
-}
-
-interface AspectRow {
-	readonly id: string;
-	readonly name: string;
-}
-
-interface AttributeRow {
-	readonly content: string;
-	readonly importance: number;
-	readonly memory_id: string | null;
-}
-
-interface ConstraintRow {
-	readonly content: string;
-	readonly importance: number;
-	readonly memory_id: string | null;
-}
-
-interface DependencyRow {
-	readonly target_entity_id: string;
-	readonly name: string;
+export interface PreparedContextRows {
+	/** All safe active attributes, used by the entity-context view. */
+	readonly attributesByAspect: ReadonlyMap<string, ReadonlyArray<AttributeRow>>;
+	/** Safe non-constraint attributes, used by constructed cards. */
+	readonly constructibleAttributesByAspect: ReadonlyMap<string, ReadonlyArray<AttributeRow>>;
+	readonly constraintsByEntity: ReadonlyMap<string, ReadonlyArray<ConstraintRow>>;
 }
 
 const MAX_BLOCK_CHARS = 900;
@@ -90,18 +66,12 @@ function isNoise(value: string): boolean {
 }
 
 function trimBlock(text: string): { text: string; truncated: boolean } {
-	if (text.length <= MAX_BLOCK_CHARS) {
-		return { text, truncated: false };
-	}
+	if (text.length <= MAX_BLOCK_CHARS) return { text, truncated: false };
 	return {
 		text: `${text.slice(0, Math.max(1, MAX_BLOCK_CHARS - 3)).trimEnd()}...`,
 		truncated: true,
 	};
 }
-
-// ---------------------------------------------------------------------------
-// Score normalization
-// ---------------------------------------------------------------------------
 
 /** Structural density score: more structure = higher score, clamped to [0, 1]. */
 function densityScore(aspects: number, attrs: number, constraints: number): number {
@@ -111,150 +81,188 @@ function densityScore(aspects: number, attrs: number, constraints: number): numb
 	return Math.min(1, Math.max(0, raw));
 }
 
+function normalizeBlockLimit(limit: number): number {
+	if (!Number.isFinite(limit) || limit <= 0) return 0;
+	return Math.max(1, Math.trunc(limit));
+}
+
 // ---------------------------------------------------------------------------
-// Main construction function
+// Parent-side safety filtering and view assembly
 // ---------------------------------------------------------------------------
 
-export function constructContextBlocks(
-	db: ReadDb,
-	agentId: string,
-	focalEntityIds: ReadonlyArray<string>,
+function contextEligible(snapshot: ContextSnapshot, content: string, memoryId: string | null): boolean {
+	if (!scanMemoryContent(content).contextEligible) return false;
+	if (!memoryId) return true;
+	if (snapshot.safetyLedger === "unavailable") return false;
+	const persisted = snapshot.safety.get(memoryId);
+	return !persisted || (persisted.status === "clean" && persisted.context_eligible === 1);
+}
+
+export async function prepareContextRows(snapshot: ContextSnapshot): Promise<PreparedContextRows> {
+	const attributesByAspect = new Map<string, AttributeRow[]>();
+	const constructibleAttributesByAspect = new Map<string, AttributeRow[]>();
+	const constraintsByEntity = new Map<string, ConstraintRow[]>();
+	const yieldRows = yieldEvery(100);
+	for (const attribute of snapshot.attributes) {
+		if (contextEligible(snapshot, attribute.content, attribute.memory_id)) {
+			if (attribute.all_row_number <= CONTEXT_MAX_ATTRIBUTES_PER_ASPECT) {
+				const rows = attributesByAspect.get(attribute.aspect_id) ?? [];
+				rows.push(attribute);
+				attributesByAspect.set(attribute.aspect_id, rows);
+			}
+			if (attribute.kind !== "constraint" && attribute.kind_row_number <= CONTEXT_MAX_ATTRIBUTES_PER_ASPECT) {
+				const constructibleRows = constructibleAttributesByAspect.get(attribute.aspect_id) ?? [];
+				constructibleRows.push(attribute);
+				constructibleAttributesByAspect.set(attribute.aspect_id, constructibleRows);
+			}
+		}
+		await yieldRows();
+	}
+	for (const constraint of snapshot.constraints) {
+		if (contextEligible(snapshot, constraint.content, constraint.memory_id)) {
+			const rows = constraintsByEntity.get(constraint.entity_id) ?? [];
+			rows.push(constraint);
+			constraintsByEntity.set(constraint.entity_id, rows);
+		}
+		await yieldRows();
+	}
+	return { attributesByAspect, constructibleAttributesByAspect, constraintsByEntity };
+}
+
+function buildEntityContextFromRows(
+	snapshot: ContextSnapshot,
+	prepared: PreparedContextRows,
+): Array<{
+	name: string;
+	type: string;
+	aspects: Array<{ name: string; attributes: Array<{ content: string; status: string; importance: number }> }>;
+}> {
+	const aspectsByEntity = new Map<string, AspectRow[]>();
+	for (const aspect of snapshot.aspects) {
+		const rows = aspectsByEntity.get(aspect.entity_id) ?? [];
+		rows.push(aspect);
+		aspectsByEntity.set(aspect.entity_id, rows);
+	}
+	const result: Array<{
+		name: string;
+		type: string;
+		aspects: Array<{ name: string; attributes: Array<{ content: string; status: string; importance: number }> }>;
+	}> = [];
+	for (const entity of snapshot.entities) {
+		const contextAspects: Array<{
+			name: string;
+			attributes: Array<{ content: string; status: string; importance: number }>;
+		}> = [];
+		for (const aspect of aspectsByEntity.get(entity.id) ?? []) {
+			const attributes = (prepared.attributesByAspect.get(aspect.id) ?? []).map((attribute) => ({
+				content: attribute.content,
+				status: attribute.status,
+				importance: attribute.importance,
+			}));
+			if (attributes.length > 0) contextAspects.push({ name: aspect.name, attributes });
+		}
+		if (contextAspects.length > 0)
+			result.push({ name: entity.name, type: entity.entity_type, aspects: contextAspects });
+	}
+	return result;
+}
+
+/** Build prompt-facing entity context after the owner has released SQLite. */
+export async function buildEntityContextFromSnapshot(
+	snapshot: ContextSnapshot,
+	prepared?: PreparedContextRows,
+): Promise<
+	Array<{
+		name: string;
+		type: string;
+		aspects: Array<{
+			name: string;
+			attributes: Array<{ content: string; status: string; importance: number }>;
+		}>;
+	}>
+> {
+	const rows = prepared ?? (await prepareContextRows(snapshot));
+	return buildEntityContextFromRows(snapshot, rows);
+}
+
+function buildConstructedContextFromRows(
+	snapshot: ContextSnapshot,
+	prepared: PreparedContextRows,
 	limit: number,
 ): ReadonlyArray<ConstructedContext> {
-	if (focalEntityIds.length === 0) return [];
-
-	const ph = focalEntityIds.map(() => "?").join(", ");
-	const entities = db
-		.prepare(
-			`SELECT id, name, entity_type FROM entities
-			 WHERE id IN (${ph})`,
-		)
-		.all(...focalEntityIds) as EntityRow[];
-
-	if (entities.length === 0) return [];
-
+	const aspectsByEntity = new Map<string, AspectRow[]>();
+	for (const aspect of snapshot.aspects) {
+		const rows = aspectsByEntity.get(aspect.entity_id) ?? [];
+		rows.push(aspect);
+		aspectsByEntity.set(aspect.entity_id, rows);
+	}
+	const dependenciesByEntity = new Map<string, DependencyRow[]>();
+	for (const dependency of snapshot.dependencies) {
+		const rows = dependenciesByEntity.get(dependency.source_entity_id) ?? [];
+		rows.push(dependency);
+		dependenciesByEntity.set(dependency.source_entity_id, rows);
+	}
 	const blocks: ConstructedContext[] = [];
-
-	for (const ent of entities) {
-		const aspects = db
-			.prepare(
-				`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
-				 WHERE entity_id = ? AND agent_id = ?
-				 ORDER BY weight DESC LIMIT 10`,
-			)
-			.all(ent.id, agentId) as AspectRow[];
-
+	for (const entity of snapshot.entities) {
 		const lines: string[] = [];
 		const aspectIds: string[] = [];
 		const aspectNames: string[] = [];
 		let totalAttrs = 0;
-
-		for (const asp of aspects) {
-			const attrs = db
-				.prepare(
-					`SELECT content, importance, memory_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
-					 WHERE aspect_id = ? AND agent_id = ?
-					   AND status = 'active' AND kind != 'constraint'
-					 ORDER BY importance DESC LIMIT 5`,
-				)
-				.all(asp.id, agentId) as AttributeRow[];
-
-			const values = attrs
-				.filter((a) =>
-					a.memory_id
-						? isMemoryContentContextEligible(db, {
-								agentId,
-								sourceKind: "memory",
-								sourceId: a.memory_id,
-								content: a.content,
-							})
-						: scanMemoryContent(a.content).contextEligible,
-				)
-				.map((a) => cleanValue(a.content))
+		for (const aspect of aspectsByEntity.get(entity.id) ?? []) {
+			const values = (prepared.constructibleAttributesByAspect.get(aspect.id) ?? [])
+				.map((attribute) => cleanValue(attribute.content))
 				.filter((value) => !isNoise(value));
 			if (values.length === 0) continue;
-
-			aspectIds.push(asp.id);
-			aspectNames.push(asp.name);
+			aspectIds.push(aspect.id);
+			aspectNames.push(aspect.name);
 			totalAttrs += values.length;
-
-			const vals = values.join("; ");
-			lines.push(`- ${asp.name}: ${vals}`);
+			lines.push(`- ${aspect.name}: ${values.join("; ")}`);
 		}
 
-		// Constraints: always surface (invariant 5)
-		const constraints = db
-			.prepare(
-				`SELECT DISTINCT ea.content, ea.importance, ea.memory_id
-				 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
-				 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
-				   ON ea.aspect_id = asp.id
-				 WHERE asp.entity_id = ? AND ea.agent_id = ?
-				   AND ea.kind = 'constraint' AND ea.status = 'active'
-				 ORDER BY ea.importance DESC LIMIT 10`,
-			)
-			.all(ent.id, agentId) as ConstraintRow[];
-
+		const constraints = prepared.constraintsByEntity.get(entity.id) ?? [];
 		const cleanConstraints = constraints
-			.filter((c) =>
-				c.memory_id
-					? isMemoryContentContextEligible(db, {
-							agentId,
-							sourceKind: "memory",
-							sourceId: c.memory_id,
-							content: c.content,
-						})
-					: scanMemoryContent(c.content).contextEligible,
-			)
-			.map((c) => cleanValue(c.content))
+			.map((constraint) => cleanValue(constraint.content))
 			.filter((value) => !isNoise(value));
-		if (cleanConstraints.length > 0) {
-			const vals = cleanConstraints.join("; ");
-			lines.push(`- Constraints: ${vals}`);
-		}
+		if (cleanConstraints.length > 0) lines.push(`- Constraints: ${cleanConstraints.join("; ")}`);
 
-		// Dependencies: cross-reference names
-		const deps = db
-			.prepare(
-				`SELECT ed.target_entity_id, e.name
-				 FROM entity_dependencies ed INDEXED BY idx_entity_dependencies_source
-				 JOIN entities e ON e.id = ed.target_entity_id
-				 WHERE ed.source_entity_id = ? AND ed.agent_id = ?
-				   AND ed.strength >= 0.3
-				 ORDER BY ed.strength DESC LIMIT 8`,
-			)
-			.all(ent.id, agentId) as DependencyRow[];
-
-		if (deps.length > 0) {
-			lines.push(`- Related: ${deps.map((d) => d.name).join(", ")}`);
-		}
-
+		const dependencies = dependenciesByEntity.get(entity.id) ?? [];
+		if (dependencies.length > 0)
+			lines.push(`- Related: ${dependencies.map((dependency) => dependency.name).join(", ")}`);
 		if (lines.length === 0) continue;
 
-		const built = trimBlock(`[${ent.name} (${ent.entity_type})]\n${lines.join("\n")}`);
-		const score = densityScore(aspectIds.length, totalAttrs, cleanConstraints.length);
-
+		const built = trimBlock(`[${entity.name} (${entity.entity_type})]\n${lines.join("\n")}`);
 		blocks.push({
 			content: built.text,
 			truncated: built.truncated,
-			score,
+			score: densityScore(aspectIds.length, totalAttrs, cleanConstraints.length),
 			source: "constructed",
 			provenance: {
-				entityId: ent.id,
-				entityName: ent.name,
-				entityType: ent.entity_type,
+				entityId: entity.id,
+				entityName: entity.name,
+				entityType: entity.entity_type,
 				aspectIds,
 				aspectNames,
 				attributeCount: totalAttrs,
 				constraintCount: constraints.length,
-				dependencyEntityIds: deps.map((d) => d.target_entity_id),
+				dependencyEntityIds: dependencies.map((dependency) => dependency.target_entity_id),
 			},
 		});
 	}
-
-	// Sort by density score descending, then truncate to limit
 	blocks.sort((a, b) => b.score - a.score);
-	return blocks.slice(0, limit);
+	return blocks.slice(0, normalizeBlockLimit(limit));
+}
+
+/**
+ * Construct context from a previously loaded snapshot. This keeps all text
+ * assembly and content handling outside the owner callback.
+ */
+export async function constructContextBlocksFromSnapshot(
+	snapshot: ContextSnapshot,
+	limit: number,
+	prepared?: PreparedContextRows,
+): Promise<ReadonlyArray<ConstructedContext>> {
+	const rows = prepared ?? (await prepareContextRows(snapshot));
+	return buildConstructedContextFromRows(snapshot, rows, limit);
 }
 
 /** Owner-bound constructed context for recall paths that cannot read parent SQLite. */
@@ -264,140 +272,8 @@ export async function constructContextBlocksViaOwner(
 	focalEntityIds: ReadonlyArray<string>,
 	limit: number,
 ): Promise<ReadonlyArray<ConstructedContext>> {
-	if (focalEntityIds.length === 0) return [];
-	const query = <Row extends object>(sql: string, params: readonly unknown[], operation: string) =>
-		ownerReadAll<Row>(owner, sql, params, {
-			operation,
-			lane: "read",
-			workloadClass: "foreground",
-			deadlineMs: 30_000,
-			estimatedWorkUnits: 200,
-		});
-	const ph = focalEntityIds.map(() => "?").join(", ");
-	const entities = await query<EntityRow>(
-		`SELECT id, name, entity_type FROM entities WHERE id IN (${ph})`,
-		focalEntityIds,
-		"memory-search.constructed.entities",
-	);
-	if (entities.length === 0) return [];
-
-	let safetyTableExists: boolean | null = null;
-	const eligible = async (content: string, memoryId: string | null): Promise<boolean> => {
-		if (!scanMemoryContent(content).contextEligible) return false;
-		if (!memoryId) return true;
-		if (safetyTableExists === null) {
-			try {
-				const rows = await query<{ name: string }>(
-					"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_content_safety'",
-					[],
-					"memory-search.constructed.safety-table",
-				);
-				safetyTableExists = rows.length > 0;
-			} catch {
-				safetyTableExists = false;
-			}
-		}
-		if (!safetyTableExists) return true;
-		try {
-			const rows = await query<{ status: string; context_eligible: number }>(
-				`SELECT status, context_eligible FROM memory_content_safety
-			 WHERE agent_id = ? AND source_kind = 'memory' AND source_id = ?`,
-				[agentId, memoryId],
-				"memory-search.constructed.safety-row",
-			);
-			const row = rows[0];
-			return !row || (row.status === "clean" && row.context_eligible === 1);
-		} catch {
-			return false;
-		}
-	};
-
-	const blocks: ConstructedContext[] = [];
-	for (const ent of entities) {
-		const aspects = await query<AspectRow>(
-			`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
-			 WHERE entity_id = ? AND agent_id = ?
-			 ORDER BY weight DESC LIMIT 10`,
-			[ent.id, agentId],
-			"memory-search.constructed.aspects",
-		);
-		const lines: string[] = [];
-		const aspectIds: string[] = [];
-		const aspectNames: string[] = [];
-		let totalAttrs = 0;
-
-		for (const asp of aspects) {
-			const attrs = await query<AttributeRow>(
-				`SELECT content, importance, memory_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
-				 WHERE aspect_id = ? AND agent_id = ?
-				   AND status = 'active' AND kind != 'constraint'
-				 ORDER BY importance DESC LIMIT 5`,
-				[asp.id, agentId],
-				"memory-search.constructed.attributes",
-			);
-			const values: string[] = [];
-			for (const attr of attrs) {
-				if (!(await eligible(attr.content, attr.memory_id))) continue;
-				const value = cleanValue(attr.content);
-				if (!isNoise(value)) values.push(value);
-			}
-			if (values.length === 0) continue;
-			aspectIds.push(asp.id);
-			aspectNames.push(asp.name);
-			totalAttrs += values.length;
-			lines.push(`- ${asp.name}: ${values.join("; ")}`);
-		}
-
-		const constraints = await query<ConstraintRow>(
-			`SELECT DISTINCT ea.content, ea.importance, ea.memory_id
-			 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
-			 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
-			   ON ea.aspect_id = asp.id
-			 WHERE asp.entity_id = ? AND ea.agent_id = ?
-			   AND ea.kind = 'constraint' AND ea.status = 'active'
-			 ORDER BY ea.importance DESC LIMIT 10`,
-			[ent.id, agentId],
-			"memory-search.constructed.constraints",
-		);
-		const cleanConstraints: string[] = [];
-		for (const constraint of constraints) {
-			if (!(await eligible(constraint.content, constraint.memory_id))) continue;
-			const value = cleanValue(constraint.content);
-			if (!isNoise(value)) cleanConstraints.push(value);
-		}
-		if (cleanConstraints.length > 0) lines.push(`- Constraints: ${cleanConstraints.join("; ")}`);
-
-		const deps = await query<DependencyRow>(
-			`SELECT ed.target_entity_id, e.name
-			 FROM entity_dependencies ed INDEXED BY idx_entity_dependencies_source
-			 JOIN entities e ON e.id = ed.target_entity_id
-			 WHERE ed.source_entity_id = ? AND ed.agent_id = ?
-			   AND ed.strength >= 0.3
-			 ORDER BY ed.strength DESC LIMIT 8`,
-			[ent.id, agentId],
-			"memory-search.constructed.dependencies",
-		);
-		if (deps.length > 0) lines.push(`- Related: ${deps.map((dep) => dep.name).join(", ")}`);
-		if (lines.length === 0) continue;
-
-		const built = trimBlock(`[${ent.name} (${ent.entity_type})]\n${lines.join("\n")}`);
-		blocks.push({
-			content: built.text,
-			truncated: built.truncated,
-			score: densityScore(aspectIds.length, totalAttrs, cleanConstraints.length),
-			source: "constructed",
-			provenance: {
-				entityId: ent.id,
-				entityName: ent.name,
-				entityType: ent.entity_type,
-				aspectIds,
-				aspectNames,
-				attributeCount: totalAttrs,
-				constraintCount: constraints.length,
-				dependencyEntityIds: deps.map((dep) => dep.target_entity_id),
-			},
-		});
-	}
-	blocks.sort((a, b) => b.score - a.score);
-	return blocks.slice(0, limit);
+	const boundedLimit = normalizeBlockLimit(limit);
+	if (boundedLimit === 0) return [];
+	const snapshot = await loadContextSnapshotViaOwner(owner, agentId, focalEntityIds, boundedLimit);
+	return await constructContextBlocksFromSnapshot(snapshot, boundedLimit);
 }

--- a/platform/daemon/src/pipeline/context-snapshot.ts
+++ b/platform/daemon/src/pipeline/context-snapshot.ts
@@ -1,0 +1,446 @@
+/**
+ * Set-based, bounded owner reads for graph-backed recall context.
+ *
+ * The owner returns raw rows only. Safety scanning and all prompt-facing
+ * assembly remain in the daemon process after each SQLite read completes.
+ */
+
+import type { DbOwnerClient } from "../db-owner-client";
+import { ownerReadAll } from "../db-owner-sql";
+
+export type ContextSafetyLedgerState = "available" | "missing" | "unavailable";
+
+/**
+ * Explicit accounting for the bounded context operation. `partial` means
+ * that a focal-entity budget or safety-ledger failure limited the snapshot;
+ * it is not used for ordinary content filtering.
+ */
+export interface ContextSnapshotWork {
+	readonly focalEntityCount: number;
+	readonly selectedEntityCount: number;
+	readonly entityCount: number;
+	readonly entityLimit: number;
+	readonly omittedEntityCount: number;
+	readonly statementCount: number;
+	readonly estimatedWorkUnits: number;
+	readonly partial: boolean;
+	readonly safetyLedger: ContextSafetyLedgerState;
+}
+
+export interface ContextSnapshot {
+	readonly entityIds: ReadonlyArray<string>;
+	readonly entities: ReadonlyArray<EntityRow>;
+	readonly aspects: ReadonlyArray<AspectRow>;
+	readonly attributes: ReadonlyArray<AttributeRow>;
+	readonly constraints: ReadonlyArray<ConstraintRow>;
+	readonly dependencies: ReadonlyArray<DependencyRow>;
+	readonly safety: ReadonlyMap<string, SafetyRow>;
+	readonly safetyLedger: ContextSafetyLedgerState;
+	readonly work: ContextSnapshotWork;
+}
+
+/** The hard entity and row budgets for one context snapshot. */
+export const CONTEXT_MAX_ENTITIES = 32;
+export const CONTEXT_MAX_ASPECTS_PER_ENTITY = 10;
+export const CONTEXT_MAX_ATTRIBUTES_PER_ASPECT = 5;
+export const CONTEXT_MAX_CONSTRAINTS_PER_ENTITY = 10;
+export const CONTEXT_MAX_DEPENDENCIES_PER_ENTITY = 8;
+/** Keep safety lookups below SQLite's variable-parameter limit. */
+export const CONTEXT_SAFETY_BATCH_SIZE = 400;
+export const CONTEXT_SNAPSHOT_MAX_SAFETY_BATCHES = Math.ceil(
+	(CONTEXT_MAX_ENTITIES * CONTEXT_MAX_ASPECTS_PER_ENTITY * CONTEXT_MAX_ATTRIBUTES_PER_ASPECT * 2 +
+		CONTEXT_MAX_ENTITIES * CONTEXT_MAX_CONSTRAINTS_PER_ENTITY) /
+		CONTEXT_SAFETY_BATCH_SIZE,
+);
+export const CONTEXT_SNAPSHOT_MAX_STATEMENTS = 6 + CONTEXT_SNAPSHOT_MAX_SAFETY_BATCHES;
+export const CONTEXT_SNAPSHOT_WORK_UNIT_CEILING = 10_000;
+
+// ---------------------------------------------------------------------------
+// Internal row types
+// ---------------------------------------------------------------------------
+
+export interface EntityRow {
+	readonly id: string;
+	readonly name: string;
+	readonly entity_type: string;
+}
+
+export interface AspectRow {
+	readonly id: string;
+	readonly entity_id: string;
+	readonly name: string;
+}
+
+export interface AttributeRow {
+	readonly aspect_id: string;
+	readonly content: string;
+	readonly kind: string;
+	readonly status: string;
+	readonly importance: number;
+	readonly memory_id: string | null;
+	readonly all_row_number: number;
+	readonly kind_row_number: number;
+}
+
+export interface ConstraintRow {
+	readonly entity_id: string;
+	readonly content: string;
+	readonly importance: number;
+	readonly memory_id: string | null;
+}
+
+export interface DependencyRow {
+	readonly source_entity_id: string;
+	readonly target_entity_id: string;
+	readonly name: string;
+}
+
+export interface SafetyRow {
+	readonly source_id: string;
+	readonly status: string;
+	readonly context_eligible: number;
+}
+
+type AsyncSnapshotQuery = <Row extends object>(
+	sql: string,
+	params: readonly unknown[],
+	workUnits: number,
+) => Promise<ReadonlyArray<Row>>;
+
+function sanitizeEntityIds(ids: ReadonlyArray<string>): string[] {
+	const unique = new Set<string>();
+	for (const id of ids) {
+		if (typeof id === "string" && id.length > 0) unique.add(id);
+	}
+	return [...unique];
+}
+
+function normalizeEntityLimit(limit: number): number {
+	if (!Number.isFinite(limit) || limit <= 0) return 1;
+	return Math.min(CONTEXT_MAX_ENTITIES, Math.max(1, Math.trunc(limit)));
+}
+
+function emptySnapshot(focalEntityCount = 0, entityLimit = 0): ContextSnapshot {
+	return {
+		entityIds: [],
+		entities: [],
+		aspects: [],
+		attributes: [],
+		constraints: [],
+		dependencies: [],
+		safety: new Map(),
+		safetyLedger: "missing",
+		work: {
+			focalEntityCount,
+			selectedEntityCount: 0,
+			entityCount: 0,
+			entityLimit,
+			omittedEntityCount: 0,
+			statementCount: 0,
+			estimatedWorkUnits: 0,
+			partial: false,
+			safetyLedger: "missing",
+		},
+	};
+}
+
+function contextWork(
+	focalEntityCount: number,
+	selectedEntityCount: number,
+	entityCount: number,
+	entityLimit: number,
+	statementCount: number,
+	estimatedWorkUnits: number,
+	safetyLedger: ContextSafetyLedgerState,
+): ContextSnapshotWork {
+	const omittedEntityCount = Math.max(0, focalEntityCount - selectedEntityCount);
+	return {
+		focalEntityCount,
+		selectedEntityCount,
+		entityCount,
+		entityLimit,
+		omittedEntityCount,
+		statementCount,
+		estimatedWorkUnits,
+		partial: omittedEntityCount > 0 || safetyLedger === "unavailable",
+		safetyLedger,
+	};
+}
+
+function placeholders(ids: ReadonlyArray<string>): string {
+	return ids.map(() => "?").join(", ");
+}
+
+function estimatedUnits(value: number): number {
+	return Math.max(1, Math.min(CONTEXT_SNAPSHOT_WORK_UNIT_CEILING, value));
+}
+
+function entityAspectSql(entityIds: ReadonlyArray<string>): string {
+	return `WITH ranked AS (
+			SELECT id, entity_id, name,
+				ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY weight DESC, id) AS row_number
+			FROM entity_aspects INDEXED BY idx_entity_aspects_entity
+			WHERE entity_id IN (${placeholders(entityIds)}) AND agent_id = ?
+		)
+		SELECT id, entity_id, name
+		FROM ranked
+		WHERE row_number <= ?
+		ORDER BY entity_id, row_number`;
+}
+
+function attributeSql(aspectIds: ReadonlyArray<string>): string {
+	return `WITH ranked AS (
+			SELECT aspect_id, content, kind, status, importance, memory_id,
+				ROW_NUMBER() OVER (PARTITION BY aspect_id ORDER BY importance DESC, rowid) AS all_row_number,
+				ROW_NUMBER() OVER (
+					PARTITION BY aspect_id, (kind = 'constraint')
+					ORDER BY importance DESC, rowid
+				) AS kind_row_number
+			FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
+			WHERE aspect_id IN (${placeholders(aspectIds)})
+			  AND agent_id = ?
+			  AND status = 'active'
+		)
+		SELECT aspect_id, content, kind, status, importance, memory_id, all_row_number, kind_row_number
+		FROM ranked
+		WHERE all_row_number <= ?
+		   OR (kind != 'constraint' AND kind_row_number <= ?)
+		ORDER BY aspect_id, all_row_number, kind_row_number`;
+}
+
+function constraintSql(entityIds: ReadonlyArray<string>): string {
+	return `WITH candidates AS (
+			SELECT DISTINCT asp.entity_id, ea.content, ea.importance, ea.memory_id
+			FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
+			CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
+			  ON ea.aspect_id = asp.id
+			WHERE asp.entity_id IN (${placeholders(entityIds)})
+			  AND asp.agent_id = ?
+			  AND ea.agent_id = ?
+			  AND ea.kind = 'constraint'
+			  AND ea.status = 'active'
+		), ranked AS (
+			SELECT entity_id, content, importance, memory_id,
+				ROW_NUMBER() OVER (
+					PARTITION BY entity_id
+					ORDER BY importance DESC, content, COALESCE(memory_id, '')
+				) AS row_number
+			FROM candidates
+		)
+		SELECT entity_id, content, importance, memory_id
+		FROM ranked
+		WHERE row_number <= ?
+		ORDER BY entity_id, row_number`;
+}
+
+function dependencySql(entityIds: ReadonlyArray<string>): string {
+	return `WITH ranked AS (
+			SELECT ed.source_entity_id, ed.target_entity_id, e.name,
+				ROW_NUMBER() OVER (
+					PARTITION BY ed.source_entity_id
+					ORDER BY ed.strength DESC, ed.target_entity_id
+				) AS row_number
+			FROM entity_dependencies ed INDEXED BY idx_entity_dependencies_source
+			JOIN entities e
+			  ON e.id = ed.target_entity_id AND e.agent_id = ?
+			WHERE ed.source_entity_id IN (${placeholders(entityIds)})
+			  AND ed.agent_id = ?
+			  AND ed.strength >= 0.3
+		)
+		SELECT source_entity_id, target_entity_id, name
+		FROM ranked
+		WHERE row_number <= ?
+		ORDER BY source_entity_id, row_number`;
+}
+
+function safetySql(memoryIds: ReadonlyArray<string>): string {
+	return `SELECT source_id, status, context_eligible
+		FROM memory_content_safety
+		WHERE agent_id = ? AND source_kind = 'memory'
+		  AND source_id IN (${placeholders(memoryIds)})`;
+}
+
+// ---------------------------------------------------------------------------
+// Owner snapshot loading
+// ---------------------------------------------------------------------------
+
+function finalizeSnapshot(
+	focalEntityIds: ReadonlyArray<string>,
+	selectedEntityIds: ReadonlyArray<string>,
+	entities: ReadonlyArray<EntityRow>,
+	aspects: ReadonlyArray<AspectRow>,
+	attributes: ReadonlyArray<AttributeRow>,
+	constraints: ReadonlyArray<ConstraintRow>,
+	dependencies: ReadonlyArray<DependencyRow>,
+	safety: ReadonlyArray<SafetyRow>,
+	safetyLedger: ContextSafetyLedgerState,
+	entityLimit: number,
+	statementCount: number,
+	estimatedWorkUnits: number,
+): ContextSnapshot {
+	const entityById = new Map(entities.map((entity) => [entity.id, entity]));
+	const orderedEntities = selectedEntityIds.flatMap((id) => {
+		const entity = entityById.get(id);
+		return entity ? [entity] : [];
+	});
+	const entityIds = orderedEntities.map((entity) => entity.id);
+	const safetyById = new Map(safety.map((row) => [row.source_id, row]));
+	return {
+		entityIds,
+		entities: orderedEntities,
+		aspects,
+		attributes,
+		constraints,
+		dependencies,
+		safety: safetyById,
+		safetyLedger,
+		work: contextWork(
+			focalEntityIds.length,
+			selectedEntityIds.length,
+			orderedEntities.length,
+			entityLimit,
+			statementCount,
+			estimatedWorkUnits,
+			safetyLedger,
+		),
+	};
+}
+
+async function readContextSnapshotViaOwner(
+	query: AsyncSnapshotQuery,
+	agentId: string,
+	focalEntityIds: ReadonlyArray<string>,
+	entityLimitInput: number,
+): Promise<ContextSnapshot> {
+	const focalIds = sanitizeEntityIds(focalEntityIds);
+	if (focalIds.length === 0) return emptySnapshot();
+	const entityLimit = normalizeEntityLimit(entityLimitInput);
+	const selectedIds = focalIds.slice(0, entityLimit);
+	let statementCount = 0;
+	let estimatedWorkUnitsTotal = 0;
+	const read: AsyncSnapshotQuery = async <Row extends object>(
+		sql: string,
+		params: readonly unknown[],
+		workUnits: number,
+	): Promise<ReadonlyArray<Row>> => {
+		statementCount++;
+		const units = estimatedUnits(workUnits);
+		estimatedWorkUnitsTotal += units;
+		return await query<Row>(sql, params, units);
+	};
+
+	let safetyLedger: ContextSafetyLedgerState = "unavailable";
+	try {
+		const tableRows = await read<{ readonly name: string }>(
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_content_safety'",
+			[],
+			1,
+		);
+		safetyLedger = tableRows.length > 0 ? "available" : "missing";
+	} catch {
+		// A safety-schema failure must fail closed for memory-backed rows.
+	}
+
+	const entities = await read<EntityRow>(
+		`SELECT id, name, entity_type FROM entities
+			WHERE agent_id = ? AND id IN (${placeholders(selectedIds)})`,
+		[agentId, ...selectedIds],
+		selectedIds.length,
+	);
+	if (entities.length === 0)
+		return finalizeSnapshot(
+			focalIds,
+			selectedIds,
+			[],
+			[],
+			[],
+			[],
+			[],
+			[],
+			safetyLedger,
+			entityLimit,
+			statementCount,
+			estimatedWorkUnitsTotal,
+		);
+
+	const entityIds = entities.map((entity) => entity.id);
+	const aspects = await read<AspectRow>(
+		entityAspectSql(entityIds),
+		[...entityIds, agentId, CONTEXT_MAX_ASPECTS_PER_ENTITY],
+		entityIds.length * CONTEXT_MAX_ASPECTS_PER_ENTITY,
+	);
+	const aspectIds = aspects.map((aspect) => aspect.id);
+	const attributes =
+		aspectIds.length === 0
+			? []
+			: await read<AttributeRow>(
+					attributeSql(aspectIds),
+					[...aspectIds, agentId, CONTEXT_MAX_ATTRIBUTES_PER_ASPECT, CONTEXT_MAX_ATTRIBUTES_PER_ASPECT],
+					aspectIds.length * CONTEXT_MAX_ATTRIBUTES_PER_ASPECT * 2,
+				);
+	const constraints = await read<ConstraintRow>(
+		constraintSql(entityIds),
+		[...entityIds, agentId, agentId, CONTEXT_MAX_CONSTRAINTS_PER_ENTITY],
+		entityIds.length * CONTEXT_MAX_CONSTRAINTS_PER_ENTITY,
+	);
+	const dependencies = await read<DependencyRow>(
+		dependencySql(entityIds),
+		[agentId, ...entityIds, agentId, CONTEXT_MAX_DEPENDENCIES_PER_ENTITY],
+		entityIds.length * CONTEXT_MAX_DEPENDENCIES_PER_ENTITY,
+	);
+	const memoryIds = sanitizeEntityIds([
+		...attributes.flatMap((attribute) => (attribute.memory_id ? [attribute.memory_id] : [])),
+		...constraints.flatMap((constraint) => (constraint.memory_id ? [constraint.memory_id] : [])),
+	]);
+	let safety: ReadonlyArray<SafetyRow> = [];
+	if (safetyLedger === "available" && memoryIds.length > 0) {
+		const safetyRows: SafetyRow[] = [];
+		for (let offset = 0; offset < memoryIds.length; offset += CONTEXT_SAFETY_BATCH_SIZE) {
+			const batch = memoryIds.slice(offset, offset + CONTEXT_SAFETY_BATCH_SIZE);
+			try {
+				safetyRows.push(...(await read<SafetyRow>(safetySql(batch), [agentId, ...batch], batch.length)));
+			} catch {
+				// A failed safety batch makes every memory-backed projection unsafe.
+				safetyLedger = "unavailable";
+				break;
+			}
+		}
+		safety = safetyRows;
+	}
+	return finalizeSnapshot(
+		focalIds,
+		selectedIds,
+		entities,
+		aspects,
+		attributes,
+		constraints,
+		dependencies,
+		safety,
+		safetyLedger,
+		entityLimit,
+		statementCount,
+		estimatedWorkUnitsTotal,
+	);
+}
+
+/** Read a bounded, set-based context snapshot through the serialized owner. */
+export async function loadContextSnapshotViaOwner(
+	owner: DbOwnerClient,
+	agentId: string,
+	focalEntityIds: ReadonlyArray<string>,
+	entityLimit: number,
+): Promise<ContextSnapshot> {
+	const query: AsyncSnapshotQuery = async <Row extends object>(
+		sql: string,
+		params: readonly unknown[],
+		workUnits: number,
+	): Promise<ReadonlyArray<Row>> =>
+		await ownerReadAll<Row>(owner, sql, params, {
+			operation: "memory-search.context.snapshot",
+			lane: "read",
+			workloadClass: "foreground",
+			deadlineMs: 30_000,
+			estimatedWorkUnits: estimatedUnits(workUnits),
+		});
+	return await readContextSnapshotViaOwner(query, agentId, focalEntityIds, entityLimit);
+}

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1943,7 +1943,7 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2265,
+      "line": 2276,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path",
@@ -1951,7 +1951,7 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2343,
+      "line": 2354,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path",
@@ -1959,7 +1959,7 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2390,
+      "line": 2401,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path",
@@ -1967,7 +1967,7 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2469,
+      "line": 2480,
       "api": "withReadDbAsync",
       "source": "const dampenRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path",
@@ -1975,7 +1975,7 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2750,
+      "line": 2761,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path",
@@ -1983,7 +1983,7 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 2777,
+      "line": 2788,
       "api": "withReadDbAsync",
       "source": "const safeRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path",

--- a/web/docs/src/content/docs/api/memory/recall-search.md
+++ b/web/docs/src/content/docs/api/memory/recall-search.md
@@ -153,6 +153,15 @@ cause is distinct from `provider_unavailable`, which is reserved for provider
 outages and their 503 semantics. This differs from
 `aggregate.partial`, which means aggregate planning or synthesis stopped after
 retrieving only partial evidence.
+
+When graph entity context runs, `meta.context` reports its bounded work. It
+includes the number of focal entities considered, the selected entity budget,
+the set-based owner statement count, the estimated work units, and the safety
+ledger state. `meta.context.partial: true` means the focal-entity budget or
+safety-ledger availability limited context; `omittedEntityCount` identifies the
+budgeted omissions. `truncatedBlocks` reports constructed cards shortened to
+the per-card character limit. These fields make bounded or degraded context
+observable instead of silently dropping it.
 `meta.timings`, when present, reports daemon-side stage timings in
 milliseconds. Aggregate recall fills the same field with aggregate-specific
 stages such as `aggregate_planning`, `aggregate_followup_recalls`, and

--- a/web/docs/src/content/docs/memory.md
+++ b/web/docs/src/content/docs/memory.md
@@ -204,6 +204,14 @@ Supplementary results may include:
 - linked rationale memories for decision results,
 - constructed graph context cards.
 
+Graph entity context and constructed cards share one bounded, set-based owner
+snapshot. The snapshot limits focal entities by the constructed-card budget,
+loads aspects, attributes, constraints, dependencies, and persisted safety rows
+in bounded batches, and performs content scanning/text assembly after SQLite
+has released the owner read. Recall exposes `meta.context` with the selected
+entity count, statement/work-unit accounting, safety-ledger state, and an
+explicit partial flag when the focal budget or safety ledger limits context.
+
 The final response is capped to `limit`. Supplementary rows are marked with
 `supplementary: true` so callers can distinguish them from ordinary memory
 rows.


### PR DESCRIPTION
## Summary

Fixes #1777.

Recall graph context no longer performs per-entity/per-aspect owner reads or per-attribute safety lookups. It loads one bounded, set-based raw snapshot, performs safety scanning and context assembly after owner reads complete, and reports context omissions/work accounting in `meta.context`.

## Phased implementation plan

1. Trace the recall entity-context and constructed-card paths, preserving scope, provenance, ranking, and content-safety behavior.
2. Replace nested reads with a bounded owner snapshot: cap focal entities, window aspects/attributes/constraints/dependencies, batch safety rows below SQLite's variable-parameter limit, and account for every statement/work unit.
3. Keep content scanning, noise filtering, scoring, and string assembly outside SQLite execution; expose partial/truncated state through the canonical recall response contract.
4. Add only the necessary worst-case/event-loop, safety, response-contract, and constructed-card regression coverage, then run focused and repository checks.

## Changes

- Added `context-snapshot.ts`, a bounded set-based owner operation for graph context.
- Reused the raw snapshot for prompt-facing entity context and constructed-card assembly.
- Preserved clean, tainted, and missing-ledger safety behavior; safety lookup failures fail closed.
- Added deterministic per-entity row caps and parameter-safe safety batches.
- Made focal omissions, owner statement/work accounting, safety-ledger state, and shortened cards observable through `meta.context`.
- Added canonical core and SDK types/parsing for the new response metadata and updated recall documentation.
- Refreshed the event-loop ledger baseline for moved source locations.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: recall API documentation and event-loop baseline

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

The changed-surface checks listed below pass locally. The full-repository attempt is recorded honestly in Testing because this checkout's long run encountered unrelated baseline/environment failures.

## Migration Notes (if applicable)

N/A — no migrations.

## Testing

- [x] `bun test ./platform/daemon/src/pipeline/context-construction.test.ts` — 2 pass
- [x] `bun test ./platform/core/src/recall.test.ts` — 16 pass
- [x] `bun test --max-concurrency=1 libs/sdk` — 72 pass
- [x] Targeted recall metadata, graph-boundary, safety, and constructed-card tests — 3 pass
- [x] Focused coverage run across context, recall-contract, and graph tests — 26 pass; coverage includes the new snapshot/assembly paths
- [x] `bun test ./platform/daemon/src/pipeline/graph-traversal.test.ts` — 8 pass
- [x] `bun scripts/audit-event-loop-contract.ts` — inventory/ratchet pass (831 sites; 159 legacy DB markers)
- [x] `bun run --filter '@signet/core' typecheck`
- [x] `bun run --filter '@signet/daemon' typecheck`
- [x] Biome check on all changed TypeScript files
- [x] CI build, daemon typecheck, Biome, event-loop, smoke, and native acceptance checks pass
- [ ] Full repository test suite — attempted with `bun test --no-orphans --max-concurrency=1`; the long run was terminated after unrelated baseline/environment failures (native asset setup, path normalization, ACP timing, stale local configuration, and DB-owner resource failures). No changed-surface test failed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The worst-case fixture exercises 200 focal IDs, the max-width graph shape, parameter-safe safety batching, and parent-side yielding. It verifies the named statement/work-unit ceiling rather than relying on the number of static call sites. Safety rows are fetched in bounded batches; text scanning and assembly remain outside owner SQLite callbacks.
