### PR TITLE
fix(daemon): bound OS marketplace installs

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,18 +4,18 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 831 sites
+- Exact ledger inventory: 828 sites
 - Synchronous `withWriteTx()` sites: 62
 - Synchronous `withReadDb()` sites: 97
 - Async-named DB sites: 168
 - Async-named ON-PARENT DB sites: 166
 - Async-named OFF-PARENT DB sites: 2
-- Synchronous filesystem/process sites: 504
+- Synchronous filesystem/process sites: 501
 - Compile-visible legacy DB sites remaining: 159
   - `withWriteTx`: 62
   - `withReadDb`: 97
 
-The 831-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 62 synchronous writes, 97 synchronous reads, and 168 async-named DB sites are the complete database-call inventory; 159 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 166 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 828-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named DB callbacks. The 62 synchronous writes, 97 synchronous reads, and 168 async-named DB sites are the complete database-call inventory; 159 compatibility DB operations remain transitional callers for the later migration phase. The async-named DB counts above separate the 166 ON-PARENT callbacks from the 2 OFF-PARENT callbacks. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## Execution-home inventory
 
@@ -229,7 +229,7 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `routes/knowledge-routes.ts:606` (withReadDbAsync)
 - `routes/knowledge-routes.ts:623` (withReadDbAsync)
 - `routes/knowledge-routes.ts:728` (withReadDbAsync)
-- `routes/marketplace.ts:1128` (withWriteTx)
+- `routes/marketplace.ts:720` (withWriteTx)
 - `routes/mcp-analytics.ts:89` (withReadDb)
 - `routes/mcp-analytics.ts:171` (withReadDb)
 - `routes/memory-routes.ts:121` (withReadDbAsync)

--- a/docs/plans/issue-1773-install-lifecycle.md
+++ b/docs/plans/issue-1773-install-lifecycle.md
@@ -1,0 +1,82 @@
+# Plan: Make OS marketplace installs bounded and idempotent (issue #1773)
+
+> Closes https://github.com/Signet-AI/signetai/issues/1773.
+> Branch: `fix/1773-os-marketplace-install-timeout-and-duplicate-probes`.
+
+## Problem and baseline
+
+`POST /api/os/install` currently has a direct-URL implementation in
+`platform/daemon/src/routes/app-tray.ts` and delegates catalog installs to
+`POST /api/marketplace/mcp/install` over loopback HTTP. The marketplace route
+persists the server and starts a detached probe; the OS route then reads the
+server and starts a second awaited probe. The loopback call has a 10-second
+budget while catalog detail fetches can run for 20–25 seconds, so a visible
+failure can be followed by a late mutation and a retry race.
+
+The issue acceptance criteria require one application boundary below both
+routes, one deadline/cancellation signal, one installed-state mutation path,
+a single probe lifecycle, and retry-safe identity. The existing marketplace
+server JSON file and app-tray/probe files remain the durable state surfaces;
+this change does not introduce a second database or ambient route-to-route
+transport.
+
+## Phased implementation
+
+### Phase 1 — Establish the canonical install service
+
+1. Move shared marketplace server types, validation, catalog detail fetching,
+   identity generation, installed-server read/write, and cache invalidation
+   behind `mcp-install-service.ts`.
+2. Define typed direct and catalog requests plus an explicit result containing
+   `created`/`updated` semantics, an operation identifier, and completed vs
+   accepted status.
+3. Derive a stable idempotency key from the normalized target when the caller
+   does not provide `Idempotency-Key`; persist the key and operation ID with
+   the installed server so retries remain safe across route calls and daemon
+   restarts.
+
+### Phase 2 — Enforce deadline and cancellation ownership
+
+1. Create one bounded install deadline and combine it with the incoming HTTP
+   request signal.
+2. Thread the remaining budget/signal through catalog detail fetches, the
+   installed-state mutation fence, and the one awaited probe.
+3. Reject before mutation when the deadline/caller signal expires. Once the
+   synchronous mutation boundary is crossed, return `202 Accepted` semantics
+   with the operation ID if probing cannot finish; never detach a write that
+   was not reported as accepted.
+
+### Phase 3 — Migrate both routes
+
+1. Make `/api/os/install` call the service for both direct and catalog inputs;
+   retain only URL-shape parsing and OS-specific auto-placement in the route.
+2. Make `/api/marketplace/mcp/install` call the same service and preserve its
+   existing response fields for compatibility.
+3. Remove the loopback `fetchInternal` install call, duplicate direct installer,
+   and route-owned install probes. Keep manual registration and explicit
+   re-probe behavior on their existing paths.
+
+### Phase 4 — Regression coverage
+
+Add only the acceptance-critical service tests:
+
+- deadline/cancellation before mutation leaves installed state unchanged;
+- cancellation after mutation returns an operation ID and does not perform a
+  late probe-result write;
+- concurrent/retried requests with one stable key produce one mutation and one
+  probe;
+- direct and catalog requests use the same canonical mutation/probe boundary.
+
+Use injected service dependencies for deterministic timing and retain the
+existing marketplace route tests for unrelated catalog/tool behavior.
+
+### Phase 5 — Validation and delivery
+
+1. Run focused daemon tests, daemon typecheck/build, lint/format checks, and
+   the complete repository test suite.
+2. Inspect the final diff for route-to-route HTTP calls, duplicate persistence
+   or probe paths, deadline leaks, and unsafe input handling.
+3. Commit with a conventional fix subject, push the issue branch, and open a
+   PR whose body includes the issue-closing keyword, phased summary, test
+   evidence, and repository readiness checklist. Apply only relevant existing
+   labels and comment on #1773 with the completed fix and verification.

--- a/platform/core/src/signet-os-types.ts
+++ b/platform/core/src/signet-os-types.ts
@@ -75,6 +75,8 @@ export interface AutoCardManifest {
 
 export interface McpProbeResult {
 	readonly serverId: string;
+	/** Present when the probe belongs to an install operation. */
+	readonly installOperationId?: string;
 	readonly ok: boolean;
 	readonly error?: string;
 	readonly declaredManifest?: SignetAppManifest;

--- a/platform/daemon/src/marketplace-client-budget.test.ts
+++ b/platform/daemon/src/marketplace-client-budget.test.ts
@@ -34,6 +34,21 @@ describe("MarketplaceMcpClientBudget", () => {
 		expect(budget.status()).toEqual({ activeClients: 0, activeProcesses: 0, pending: 0, limit: 1 });
 	});
 
+	it("removes an aborted waiter without consuming a later permit", async () => {
+		const budget = new MarketplaceMcpClientBudget(1);
+		const active = await budget.acquire(1_000);
+		const controller = new AbortController();
+		const queued = budget.acquire(1_000, controller.signal);
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		controller.abort();
+		await expect(queued).rejects.toMatchObject({ name: "AbortError" });
+		expect(budget.status().pending).toBe(0);
+
+		active.release();
+		expect(budget.status()).toMatchObject({ activeClients: 0, pending: 0 });
+	});
+
 	it("invokes cleanup when an operation reaches its deadline", async () => {
 		let closed = false;
 

--- a/platform/daemon/src/marketplace-client-budget.ts
+++ b/platform/daemon/src/marketplace-client-budget.ts
@@ -36,8 +36,8 @@ export class MarketplaceMcpClientBudget {
 		this.max = normalizeLimit(max);
 	}
 
-	async acquire(timeoutMs: number): Promise<MarketplaceMcpClientPermit> {
-		await this.acquireSlot(timeoutMs);
+	async acquire(timeoutMs: number, signal?: AbortSignal): Promise<MarketplaceMcpClientPermit> {
+		await this.acquireSlot(timeoutMs, signal);
 
 		let processStarted = false;
 		let released = false;
@@ -66,10 +66,11 @@ export class MarketplaceMcpClientBudget {
 		};
 	}
 
-	private async acquireSlot(timeoutMs: number): Promise<void> {
+	private async acquireSlot(timeoutMs: number, signal?: AbortSignal): Promise<void> {
 		if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
 			throw new Error("marketplace MCP timeout must be positive");
 		}
+		if (signal?.aborted) throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 
 		if (this.active < this.max) {
 			this.active++;
@@ -83,18 +84,34 @@ export class MarketplaceMcpClientBudget {
 				settled = true;
 				const index = this.queue.indexOf(entry);
 				if (index >= 0) this.queue.splice(index, 1);
+				cleanup();
 				reject(new Error(`marketplace MCP client budget timed out after ${timeoutMs}ms`));
 			}, timeoutMs);
+			const cleanup = (): void => {
+				clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
+			};
+			const rejectAborted = (): void => {
+				if (settled) return;
+				settled = true;
+				const index = this.queue.indexOf(entry);
+				if (index >= 0) this.queue.splice(index, 1);
+				cleanup();
+				reject(signal?.reason ?? new DOMException("The operation was aborted", "AbortError"));
+			};
+			const onAbort = (): void => rejectAborted();
 			const entry: QueueEntry = {
 				start: (): void => {
 					if (settled) return;
 					settled = true;
-					clearTimeout(timer);
+					cleanup();
 					this.active++;
 					resolve();
 				},
 			};
+			signal?.addEventListener("abort", onAbort, { once: true });
 			this.queue.push(entry);
+			if (signal?.aborted) rejectAborted();
 		});
 	}
 
@@ -133,9 +150,10 @@ export function getMarketplaceMcpRuntimeStatus(): MarketplaceMcpRuntimeStatus {
 export async function withMarketplaceMcpPermit<T>(
 	timeoutMs: number,
 	fn: (permit: MarketplaceMcpClientPermit, remainingTimeoutMs: number) => Promise<T>,
+	signal?: AbortSignal,
 ): Promise<T> {
 	const startedAt = Date.now();
-	const permit = await marketplaceMcpClientBudget.acquire(timeoutMs);
+	const permit = await marketplaceMcpClientBudget.acquire(timeoutMs, signal);
 	try {
 		const remainingTimeoutMs = Math.max(1, timeoutMs - (Date.now() - startedAt));
 		return await fn(permit, remainingTimeoutMs);
@@ -154,8 +172,10 @@ export async function withMarketplaceMcpTimeout<T>(
 	timeoutMs: number,
 	label: string,
 	onTimeout: () => Promise<void>,
+	signal?: AbortSignal,
 ): Promise<T> {
 	let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+	let onAbort: (() => void) | null = null;
 	try {
 		return await Promise.race([
 			promise,
@@ -165,8 +185,24 @@ export async function withMarketplaceMcpTimeout<T>(
 					reject(new Error(`${label} timed out after ${timeoutMs}ms`));
 				}, timeoutMs);
 			}),
+			...(signal
+				? [
+						new Promise<T>((_resolve, reject) => {
+							onAbort = (): void => {
+								void onTimeout().catch(() => undefined);
+								reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
+							};
+							if (signal.aborted) {
+								onAbort();
+								return;
+							}
+							signal.addEventListener("abort", onAbort, { once: true });
+						}),
+					]
+				: []),
 		]);
 	} finally {
 		if (timeoutHandle) clearTimeout(timeoutHandle);
+		if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 	}
 }

--- a/platform/daemon/src/marketplace-tools-cache.ts
+++ b/platform/daemon/src/marketplace-tools-cache.ts
@@ -1,0 +1,14 @@
+import type { MarketplaceMcpServerHealth, MarketplaceMcpTool } from "./routes/marketplace.js";
+
+export interface MarketplaceToolsCache {
+	readonly fetchedAt: number;
+	readonly tools: readonly MarketplaceMcpTool[];
+	readonly serverHealth: readonly MarketplaceMcpServerHealth[];
+}
+
+export const marketplaceToolsCache = new Map<string, MarketplaceToolsCache>();
+export const marketplaceToolsLoadInFlight = new Map<string, Promise<MarketplaceToolsCache>>();
+
+export function invalidateMarketplaceToolsCache(): void {
+	marketplaceToolsCache.clear();
+}

--- a/platform/daemon/src/mcp-install-service.test.ts
+++ b/platform/daemon/src/mcp-install-service.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "bun:test";
+import type { McpProbeResult } from "@signet/core";
+import {
+	installMcpServer,
+	type InstalledMarketplaceMcpServer,
+	type MarketplaceMcpInstallDependencies,
+	type MarketplaceMcpProbeOptions,
+} from "./mcp-install-service.js";
+
+interface InstallHarness {
+	readonly dependencies: MarketplaceMcpInstallDependencies;
+	readonly getInstalled: () => readonly InstalledMarketplaceMcpServer[];
+	readonly counts: {
+		writes: number;
+		invalidations: number;
+		probes: number;
+		stores: number;
+	};
+}
+
+function makeProbe(serverId: string): McpProbeResult {
+	return {
+		serverId,
+		ok: true,
+		autoCard: {
+			name: serverId,
+			tools: [],
+			resources: [],
+			hasAppResources: false,
+			defaultSize: { w: 4, h: 3 },
+		},
+		toolCount: 0,
+		resourceCount: 0,
+		hasAppResources: false,
+		probedAt: new Date().toISOString(),
+	};
+}
+
+function makeHarness(
+	probe?: (server: InstalledMarketplaceMcpServer, options: MarketplaceMcpProbeOptions) => Promise<McpProbeResult>,
+	fetchDetail?: MarketplaceMcpInstallDependencies["fetchDetail"],
+): InstallHarness {
+	let installed: InstalledMarketplaceMcpServer[] = [];
+	let storedProbe: McpProbeResult | null = null;
+	const counts = { writes: 0, invalidations: 0, probes: 0, stores: 0 };
+	const dependencies: MarketplaceMcpInstallDependencies = {
+		readInstalledServers: () => installed,
+		writeInstalledServers: (servers) => {
+			counts.writes++;
+			installed = [...servers];
+		},
+		fetchDetail:
+			fetchDetail ??
+			(async () => ({
+				nameHint: "Catalog Server",
+				description: "A catalog test server",
+				config: {
+					transport: "http",
+					url: "https://catalog.example.test/mcp",
+					headers: {},
+					timeoutMs: 20_000,
+				},
+			})),
+		invalidateToolsCache: () => {
+			counts.invalidations++;
+		},
+		probeServer: async (server, options) => {
+			counts.probes++;
+			if (probe) return probe(server, options);
+			return makeProbe(server.id);
+		},
+		storeProbeResult: (result) => {
+			counts.stores++;
+			storedProbe = result;
+		},
+		loadProbeResult: () => storedProbe,
+	};
+	return { dependencies, getInstalled: () => installed, counts };
+}
+
+describe("installMcpServer", () => {
+	it("does not mutate after a catalog deadline expires before preparation completes", async () => {
+		let releaseDetail: (() => void) | undefined;
+		let detailSignal: AbortSignal | undefined;
+		const detail = new Promise<void>((resolve) => {
+			releaseDetail = resolve;
+		});
+		const harness = makeHarness(undefined, async (_source, _catalogId, options) => {
+			detailSignal = options.signal;
+			await detail;
+			return {
+				nameHint: "Late Catalog Server",
+				description: "Late detail",
+				config: {
+					transport: "http",
+					url: "https://catalog.example.test/late",
+					headers: {},
+					timeoutMs: 20_000,
+				},
+			};
+		});
+
+		const install = installMcpServer(
+			{ kind: "catalog", source: "mcpservers.org", catalogId: "late-server" },
+			{ timeoutMs: 40 },
+			harness.dependencies,
+		);
+		const rejected = expect(install).rejects.toMatchObject({ code: "timeout" });
+		await Bun.sleep(100);
+		releaseDetail?.();
+
+		await rejected;
+		expect(detailSignal?.aborted).toBe(true);
+		expect(harness.counts.writes).toBe(0);
+		expect(harness.getInstalled()).toHaveLength(0);
+	});
+
+	it("returns an accepted operation when the deadline expires after mutation", async () => {
+		const harness = makeHarness(async () => {
+			await Bun.sleep(150);
+			return makeProbe("slow-server");
+		});
+
+		const result = await installMcpServer(
+			{ kind: "direct", url: "https://slow.example.test/mcp", name: "Slow Server" },
+			{ timeoutMs: 100 },
+			harness.dependencies,
+		);
+
+		expect(result.status).toBe("accepted");
+		expect(result.operationId).toMatch(/^mcp-install-/);
+		expect(result.created).toBe(true);
+		expect(harness.counts.writes).toBe(1);
+		expect(harness.counts.stores).toBe(0);
+	});
+
+	it("coalesces concurrent retries and probes an install only once", async () => {
+		const harness = makeHarness(async (server) => {
+			await Bun.sleep(15);
+			return makeProbe(server.id);
+		});
+		const request = { kind: "direct" as const, url: "https://retry.example.test/mcp", name: "Retry Server" };
+
+		const [first, second] = await Promise.all([
+			installMcpServer(request, { idempotencyKey: "retry-key" }, harness.dependencies),
+			installMcpServer(request, { idempotencyKey: "retry-key" }, harness.dependencies),
+		]);
+		const retry = await installMcpServer(request, { idempotencyKey: "retry-key" }, harness.dependencies);
+
+		expect(first.operationId).toBe(second.operationId);
+		expect(retry.operationId).toBe(first.operationId);
+		expect(retry.mutation).toBe("unchanged");
+		expect(harness.counts.writes).toBe(1);
+		expect(harness.counts.probes).toBe(1);
+		expect(harness.counts.stores).toBe(1);
+	});
+
+	it("uses the same mutation, cache, and probe boundary for direct and catalog installs", async () => {
+		const harness = makeHarness();
+
+		const direct = await installMcpServer(
+			{ kind: "direct", url: "https://direct.example.test/mcp" },
+			{},
+			harness.dependencies,
+		);
+		const catalog = await installMcpServer(
+			{
+				kind: "catalog",
+				source: "mcpservers.org",
+				catalogId: "catalog-server",
+				config: {
+					transport: "http",
+					url: "https://catalog.example.test/mcp",
+				},
+			},
+			{},
+			harness.dependencies,
+		);
+
+		expect(direct.status).toBe("completed");
+		expect(catalog.status).toBe("completed");
+		expect(harness.counts.writes).toBe(2);
+		expect(harness.counts.invalidations).toBe(2);
+		expect(harness.counts.probes).toBe(2);
+		expect(harness.counts.stores).toBe(2);
+	});
+});

--- a/platform/daemon/src/mcp-install-service.ts
+++ b/platform/daemon/src/mcp-install-service.ts
@@ -1,0 +1,929 @@
+/** Canonical MCP installation application service for all daemon install routes. */
+
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { McpProbeResult } from "@signet/core";
+import { resolveDefaultBasePath } from "@signet/core";
+import { loadProbeResult, probeServer as defaultProbeServer, storeProbeResult } from "./mcp-probe.js";
+import { invalidateMarketplaceToolsCache } from "./marketplace-tools-cache.js";
+import { validatePublicHttpUrl } from "./url-validation.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_TIMEOUT_MS = 120_000;
+const DETAIL_TIMEOUT_MS = 25_000;
+const MAX_README_BYTES = 2 * 1024 * 1024;
+const GITHUB_RAW_HOST = "https://raw.githubusercontent.com";
+
+export type MarketplaceMcpTransport = "stdio" | "http";
+export type MarketplaceMcpCatalogSource = "mcpservers.org" | "modelcontextprotocol/servers" | "github";
+
+export interface MarketplaceMcpScope {
+	readonly harnesses: readonly string[];
+	readonly workspaces: readonly string[];
+	readonly channels: readonly string[];
+}
+
+export interface MarketplaceMcpConfigStdio {
+	readonly transport: "stdio";
+	readonly command: string;
+	readonly args: readonly string[];
+	readonly env: Readonly<Record<string, string>>;
+	readonly cwd?: string;
+	readonly timeoutMs: number;
+}
+
+export interface MarketplaceMcpConfigHttp {
+	readonly transport: "http";
+	readonly url: string;
+	readonly headers: Readonly<Record<string, string>>;
+	readonly timeoutMs: number;
+}
+
+export type MarketplaceMcpConfig = MarketplaceMcpConfigStdio | MarketplaceMcpConfigHttp;
+
+export interface InstalledMarketplaceMcpServer {
+	readonly id: string;
+	readonly source: MarketplaceMcpCatalogSource | "manual";
+	readonly catalogId?: string;
+	readonly name: string;
+	readonly description: string;
+	readonly category: string;
+	readonly homepage?: string;
+	readonly official: boolean;
+	readonly enabled: boolean;
+	readonly scope: MarketplaceMcpScope;
+	readonly config: MarketplaceMcpConfig;
+	readonly installedAt: string;
+	readonly updatedAt: string;
+	/** Stable key used to make a retried install a no-op. */
+	readonly installKey?: string;
+	/** Operation id returned when this install crossed the mutation boundary. */
+	readonly installOperationId?: string;
+}
+
+export interface MarketplaceMcpDetail {
+	readonly nameHint?: string;
+	readonly config?: MarketplaceMcpConfig;
+	readonly githubUrl?: string;
+	readonly description: string;
+}
+
+export type MarketplaceMcpInstallRequest =
+	| {
+			readonly kind: "direct";
+			readonly url: string;
+			readonly name?: string;
+	  }
+	| {
+			readonly kind: "catalog";
+			readonly source: MarketplaceMcpCatalogSource;
+			readonly catalogId: string;
+			readonly alias?: string;
+			readonly config?: unknown;
+			readonly scope?: unknown;
+	  };
+
+export interface MarketplaceMcpInstallOptions {
+	readonly signal?: AbortSignal;
+	readonly timeoutMs?: number;
+	readonly idempotencyKey?: string;
+}
+
+export type MarketplaceMcpInstallMutation = "created" | "updated" | "unchanged";
+export type MarketplaceMcpInstallStatus = "completed" | "accepted";
+
+export interface MarketplaceMcpInstallResult {
+	readonly status: MarketplaceMcpInstallStatus;
+	readonly operationId: string;
+	readonly server: InstalledMarketplaceMcpServer;
+	readonly mutation: MarketplaceMcpInstallMutation;
+	readonly created: boolean;
+	readonly updated: boolean;
+	readonly probe?: McpProbeResult;
+}
+
+export interface MarketplaceMcpProbeOptions {
+	readonly signal: AbortSignal;
+	readonly timeoutMs: number;
+}
+
+export interface MarketplaceMcpInstallDependencies {
+	readonly readInstalledServers?: () => InstalledMarketplaceMcpServer[];
+	readonly writeInstalledServers?: (servers: readonly InstalledMarketplaceMcpServer[]) => void;
+	readonly fetchDetail?: (
+		source: MarketplaceMcpCatalogSource,
+		catalogId: string,
+		options: { readonly signal: AbortSignal; readonly timeoutMs: number },
+	) => Promise<MarketplaceMcpDetail>;
+	readonly invalidateToolsCache?: () => void;
+	readonly probeServer?: (
+		server: InstalledMarketplaceMcpServer,
+		options: MarketplaceMcpProbeOptions,
+	) => Promise<McpProbeResult>;
+	readonly storeProbeResult?: (result: McpProbeResult) => void;
+	readonly loadProbeResult?: (serverId: string) => McpProbeResult | null;
+}
+
+export class MarketplaceInstallError extends Error {
+	readonly code: "invalid_request" | "timeout" | "missing_config";
+
+	constructor(message: string, code: "invalid_request" | "timeout" | "missing_config") {
+		super(message);
+		this.name = "MarketplaceInstallError";
+		this.code = code;
+	}
+}
+
+interface InstallContext {
+	readonly signal: AbortSignal;
+	readonly deadlineAt: number;
+	readonly expire: () => void;
+	readonly cleanup: () => void;
+}
+
+interface InstallPlan {
+	readonly server: InstalledMarketplaceMcpServer;
+	readonly next: readonly InstalledMarketplaceMcpServer[];
+	readonly mutation: MarketplaceMcpInstallMutation;
+	readonly created: boolean;
+	readonly idempotent: boolean;
+}
+
+const inFlightInstalls = new Map<string, Promise<MarketplaceMcpInstallResult>>();
+
+function getAgentsDir(): string {
+	return resolveDefaultBasePath();
+}
+
+function getMarketplaceDir(): string {
+	return join(getAgentsDir(), "marketplace");
+}
+
+function getInstalledMcpPath(): string {
+	return join(getMarketplaceDir(), "mcp-servers.json");
+}
+
+function ensureMarketplaceDir(): void {
+	const dir = getMarketplaceDir();
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toStringRecord(value: unknown): Record<string, string> {
+	if (!isRecord(value)) return {};
+	const out: Record<string, string> = {};
+	for (const [key, item] of Object.entries(value)) {
+		if (typeof item === "string") out[key] = item;
+	}
+	return out;
+}
+
+function toStringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string");
+}
+
+function normalizeScopeValues(values: unknown): string[] {
+	const seen = new Set<string>();
+	const normalized: string[] = [];
+	for (const value of toStringArray(values)) {
+		const item = value.trim();
+		if (item.length === 0) continue;
+		const key = item.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		normalized.push(item);
+	}
+	return normalized;
+}
+
+export function normalizeScope(value: unknown): MarketplaceMcpScope {
+	if (!isRecord(value)) {
+		return { harnesses: [], workspaces: [], channels: [] };
+	}
+	return {
+		harnesses: normalizeScopeValues(value.harnesses),
+		workspaces: normalizeScopeValues(value.workspaces),
+		channels: normalizeScopeValues(value.channels),
+	};
+}
+
+export function normalizeMcpConfig(value: unknown, timeoutMs = 20_000): MarketplaceMcpConfig | null {
+	if (!isRecord(value)) return null;
+
+	if (typeof value.url === "string") {
+		return {
+			transport: "http",
+			url: value.url,
+			headers: toStringRecord(value.headers),
+			timeoutMs,
+		};
+	}
+
+	if (typeof value.command === "string") {
+		return {
+			transport: "stdio",
+			command: value.command,
+			args: toStringArray(value.args),
+			env: toStringRecord(value.env),
+			cwd: typeof value.cwd === "string" ? value.cwd : undefined,
+			timeoutMs,
+		};
+	}
+
+	if (Array.isArray(value.command)) {
+		const commandParts = toStringArray(value.command);
+		if (commandParts.length === 0) return null;
+		return {
+			transport: "stdio",
+			command: commandParts[0],
+			args: [...commandParts.slice(1), ...toStringArray(value.args)],
+			env: toStringRecord(value.env),
+			cwd: typeof value.cwd === "string" ? value.cwd : undefined,
+			timeoutMs,
+		};
+	}
+
+	return null;
+}
+
+export function sanitizeServerId(value: string): string {
+	const normalized = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9_-]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return normalized.length > 0 ? normalized : "mcp-server";
+}
+
+export function makeUniqueServerId(baseId: string, installed: readonly InstalledMarketplaceMcpServer[]): string {
+	if (!installed.some((server) => server.id === baseId)) return baseId;
+	let index = 2;
+	while (installed.some((server) => server.id === `${baseId}-${index}`)) index++;
+	return `${baseId}-${index}`;
+}
+
+export function inferNameFromCatalogId(catalogId: string): string {
+	const repo = catalogId.split("/").at(-1) ?? catalogId;
+	const cleaned = repo
+		.replace(/^mcp[-_]?/i, "")
+		.replace(/[-_]+/g, " ")
+		.trim();
+	if (!cleaned) return catalogId;
+	return cleaned
+		.split(" ")
+		.map((word) => (word.length > 0 ? `${word[0].toUpperCase()}${word.slice(1)}` : word))
+		.join(" ");
+}
+
+export function inferNameFromUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		let name = parsed.hostname.replace(/^(www|api|mcp)\./, "").replace(/\.(com|org|io|dev|app|net)$/, "");
+		const pathParts = parsed.pathname
+			.split("/")
+			.filter((part) => part.length > 0 && part !== "mcp" && part !== "sse" && part !== "v1");
+		if (pathParts.length > 0) name = `${name}-${pathParts[0]}`;
+		return name
+			.replace(/[-_]+/g, " ")
+			.trim()
+			.split(" ")
+			.map((word) => (word.length > 0 ? `${word[0].toUpperCase()}${word.slice(1)}` : word))
+			.join(" ");
+	} catch {
+		return "MCP Server";
+	}
+}
+
+export function inferCategory(text: string): string {
+	const source = text.toLowerCase();
+	if (/browser|scrap|crawl|web/.test(source)) return "Web";
+	if (/slack|discord|email|sms|message|chat/.test(source)) return "Communication";
+	if (/database|sql|postgres|mysql|sqlite|d1|redis|vector/.test(source)) return "Database";
+	if (/github|git|ci|deploy|build|code|dev/.test(source)) return "Development";
+	if (/cloud|aws|gcp|azure|vercel|cloudflare/.test(source)) return "Cloud";
+	if (/finance|stock|market|crypto|trading/.test(source)) return "Finance";
+	if (/memory|knowledge|search|docs|rag/.test(source)) return "Knowledge";
+	if (/file|storage|drive|s3|bucket/.test(source)) return "Storage";
+	return "Other";
+}
+
+function parseInstalledServer(value: unknown): InstalledMarketplaceMcpServer | null {
+	if (!isRecord(value)) return null;
+	if (typeof value.id !== "string" || typeof value.name !== "string") return null;
+	if (
+		value.source !== "mcpservers.org" &&
+		value.source !== "modelcontextprotocol/servers" &&
+		value.source !== "manual" &&
+		value.source !== "github"
+	)
+		return null;
+	if (typeof value.description !== "string" || typeof value.category !== "string") return null;
+	if (typeof value.official !== "boolean" || typeof value.enabled !== "boolean") return null;
+	if (typeof value.installedAt !== "string" || typeof value.updatedAt !== "string") return null;
+
+	const config = normalizeMcpConfig(value.config);
+	if (!config) return null;
+
+	return {
+		id: value.id,
+		source: value.source,
+		catalogId: typeof value.catalogId === "string" ? value.catalogId : undefined,
+		name: value.name,
+		description: value.description,
+		category: value.category,
+		homepage: typeof value.homepage === "string" ? value.homepage : undefined,
+		official: value.official,
+		enabled: value.enabled,
+		scope: normalizeScope(value.scope),
+		config,
+		installedAt: value.installedAt,
+		updatedAt: value.updatedAt,
+		installKey: typeof value.installKey === "string" ? value.installKey : undefined,
+		installOperationId: typeof value.installOperationId === "string" ? value.installOperationId : undefined,
+	};
+}
+
+export function readInstalledServers(): InstalledMarketplaceMcpServer[] {
+	const path = getInstalledMcpPath();
+	if (!existsSync(path)) return [];
+	try {
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (!Array.isArray(raw)) return [];
+		return raw.map(parseInstalledServer).filter((item): item is InstalledMarketplaceMcpServer => item !== null);
+	} catch {
+		return [];
+	}
+}
+
+export function writeInstalledServers(servers: readonly InstalledMarketplaceMcpServer[]): void {
+	ensureMarketplaceDir();
+	writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));
+}
+
+export function parseCatalogSelection(
+	rawId: string,
+	rawSource?: string,
+): { source: MarketplaceMcpCatalogSource; catalogId: string } {
+	if (rawId.startsWith("modelcontextprotocol/servers:")) {
+		return { source: "modelcontextprotocol/servers", catalogId: rawId.slice("modelcontextprotocol/servers:".length) };
+	}
+	if (rawId.startsWith("mcpservers.org:")) {
+		return { source: "mcpservers.org", catalogId: rawId.slice("mcpservers.org:".length) };
+	}
+	if (rawId.startsWith("github:")) {
+		return { source: "github", catalogId: rawId.slice("github:".length) };
+	}
+	if (rawSource === "modelcontextprotocol/servers") return { source: rawSource, catalogId: rawId };
+	if (rawSource === "github") return { source: rawSource, catalogId: rawId };
+	return { source: "mcpservers.org", catalogId: rawId };
+}
+
+function isCatalogSource(value: string): value is MarketplaceMcpCatalogSource {
+	return value === "mcpservers.org" || value === "modelcontextprotocol/servers" || value === "github";
+}
+
+function normalizeOptionalName(value: string | undefined): string | undefined {
+	const normalized = value?.trim();
+	return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeInstallRequest(request: MarketplaceMcpInstallRequest): MarketplaceMcpInstallRequest {
+	if (request.kind === "direct") {
+		const url = request.url.trim();
+		const error = validatePublicHttpUrl(url);
+		if (error) throw new MarketplaceInstallError(error, "invalid_request");
+		return { kind: "direct", url, name: normalizeOptionalName(request.name) };
+	}
+
+	if (!isCatalogSource(request.source))
+		throw new MarketplaceInstallError("Invalid marketplace source", "invalid_request");
+	const catalogId = request.catalogId.trim();
+	if (catalogId.length === 0 || catalogId.includes("..") || catalogId.startsWith("/")) {
+		throw new MarketplaceInstallError("Invalid catalog id", "invalid_request");
+	}
+	return {
+		kind: "catalog",
+		source: request.source,
+		catalogId,
+		alias: normalizeOptionalName(request.alias),
+		config: request.config,
+		scope: request.scope,
+	};
+}
+
+function hashInstallKey(value: string): string {
+	return `mcp-install-key:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function deriveInstallKey(request: MarketplaceMcpInstallRequest): string {
+	const raw =
+		request.kind === "direct"
+			? `direct:${request.url}:${request.name ?? ""}`
+			: `catalog:${request.source}:${request.catalogId}:${request.alias ?? ""}`;
+	return hashInstallKey(raw);
+}
+
+function normalizeIdempotencyKey(value: string | undefined, fallback: string): string {
+	const normalized = value?.trim();
+	if (!normalized || normalized.length > 256) return fallback;
+	return hashInstallKey(`explicit:${normalized}`);
+}
+
+function resolveTimeout(value: number | undefined): number {
+	if (!Number.isFinite(value) || value === undefined) return DEFAULT_TIMEOUT_MS;
+	return Math.max(1, Math.min(MAX_TIMEOUT_MS, Math.floor(value)));
+}
+
+function createInstallContext(options: MarketplaceMcpInstallOptions): InstallContext {
+	const timeoutMs = resolveTimeout(options.timeoutMs);
+	const deadlineController = new AbortController();
+	const deadlineTimer = setTimeout(
+		() => deadlineController.abort(new DOMException("The MCP install deadline expired", "TimeoutError")),
+		timeoutMs,
+	);
+	const signal = options.signal
+		? AbortSignal.any([options.signal, deadlineController.signal])
+		: deadlineController.signal;
+	return {
+		signal,
+		deadlineAt: Date.now() + timeoutMs,
+		expire: (): void => deadlineController.abort(new DOMException("The MCP install deadline expired", "TimeoutError")),
+		cleanup: (): void => clearTimeout(deadlineTimer),
+	};
+}
+
+function remainingMs(context: InstallContext): number {
+	return Math.max(0, context.deadlineAt - Date.now());
+}
+
+function isActive(context: InstallContext): boolean {
+	return !context.signal.aborted && remainingMs(context) > 0;
+}
+
+function requireActive(context: InstallContext, stage: string): void {
+	if (!isActive(context)) {
+		throw new MarketplaceInstallError(`MCP install timed out or was cancelled during ${stage}`, "timeout");
+	}
+}
+
+async function waitForInstallStage<T>(promise: Promise<T>, context: InstallContext, stage: string): Promise<T> {
+	const timeoutMs = remainingMs(context);
+	requireActive(context, stage);
+	let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+	let onAbort: (() => void) | null = null;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_resolve, reject) => {
+				const rejectExpired = (): void => {
+					context.expire();
+					reject(new MarketplaceInstallError(`MCP install timed out or was cancelled during ${stage}`, "timeout"));
+				};
+				onAbort = rejectExpired;
+				timeoutHandle = setTimeout(rejectExpired, timeoutMs);
+				if (context.signal.aborted) {
+					rejectExpired();
+				} else {
+					context.signal.addEventListener("abort", rejectExpired, { once: true });
+					if (context.signal.aborted) rejectExpired();
+				}
+			}),
+		]);
+	} finally {
+		if (timeoutHandle) clearTimeout(timeoutHandle);
+		if (onAbort) context.signal.removeEventListener("abort", onAbort);
+	}
+}
+
+function acceptedResult(operationId: string, plan: InstallPlan): MarketplaceMcpInstallResult {
+	return {
+		status: "accepted",
+		operationId,
+		server: plan.server,
+		mutation: plan.mutation,
+		created: plan.created,
+		updated: plan.mutation === "updated",
+	};
+}
+
+function completedResult(operationId: string, plan: InstallPlan, probe: McpProbeResult): MarketplaceMcpInstallResult {
+	return {
+		status: "completed",
+		operationId,
+		server: plan.server,
+		mutation: plan.mutation,
+		created: plan.created,
+		updated: plan.mutation === "updated",
+		probe,
+	};
+}
+
+function idempotentResult(
+	operationId: string,
+	plan: InstallPlan,
+	dependencies: Required<MarketplaceMcpInstallDependencies>,
+): MarketplaceMcpInstallResult {
+	const probe = dependencies.loadProbeResult(plan.server.id);
+	const priorOperationId = plan.server.installOperationId ?? operationId;
+	// An update keeps the server id, so an older probe file must not make a
+	// timed-out update look completed.
+	if (probe && probe.probedAt >= plan.server.updatedAt) {
+		return completedResult(priorOperationId, plan, probe);
+	}
+	return acceptedResult(priorOperationId, plan);
+}
+
+function buildDirectPlan(
+	request: Extract<MarketplaceMcpInstallRequest, { kind: "direct" }>,
+	installed: readonly InstalledMarketplaceMcpServer[],
+	operationId: string,
+	installKey: string,
+): InstallPlan {
+	const existing = installed.find((server) => server.config.transport === "http" && server.config.url === request.url);
+	if (existing) {
+		if (existing.installKey === installKey) {
+			return { server: existing, next: installed, mutation: "unchanged", created: false, idempotent: true };
+		}
+		const name = request.name ?? existing.name;
+		const updated: InstalledMarketplaceMcpServer = {
+			...existing,
+			enabled: true,
+			name,
+			installKey,
+			installOperationId: operationId,
+			updatedAt: new Date().toISOString(),
+		};
+		return {
+			server: updated,
+			next: installed.map((server) => (server.id === existing.id ? updated : server)),
+			mutation: "updated",
+			created: false,
+			idempotent: false,
+		};
+	}
+
+	const name = request.name ?? inferNameFromUrl(request.url);
+	const now = new Date().toISOString();
+	const server: InstalledMarketplaceMcpServer = {
+		id: makeUniqueServerId(sanitizeServerId(name), installed),
+		source: "manual",
+		name,
+		description: `${name} MCP server`,
+		category: inferCategory(name),
+		homepage: request.url,
+		official: false,
+		enabled: true,
+		scope: normalizeScope(undefined),
+		config: { transport: "http", url: request.url, headers: {}, timeoutMs: 20_000 },
+		installedAt: now,
+		updatedAt: now,
+		installKey,
+		installOperationId: operationId,
+	};
+	return { server, next: [...installed, server], mutation: "created", created: true, idempotent: false };
+}
+
+function buildCatalogPlan(
+	request: Extract<MarketplaceMcpInstallRequest, { kind: "catalog" }>,
+	detail: MarketplaceMcpDetail | undefined,
+	normalizedConfig: MarketplaceMcpConfig,
+	installed: readonly InstalledMarketplaceMcpServer[],
+	operationId: string,
+	installKey: string,
+): InstallPlan {
+	const existing = installed.find(
+		(server) => server.catalogId === request.catalogId && server.source === request.source,
+	);
+	if (existing) {
+		if (existing.installKey === installKey) {
+			return { server: existing, next: installed, mutation: "unchanged", created: false, idempotent: true };
+		}
+		const updated: InstalledMarketplaceMcpServer = {
+			...existing,
+			enabled: true,
+			scope: request.scope === undefined ? existing.scope : normalizeScope(request.scope),
+			config: normalizedConfig,
+			installKey,
+			installOperationId: operationId,
+			updatedAt: new Date().toISOString(),
+		};
+		return {
+			server: updated,
+			next: installed.map((server) => (server.id === existing.id ? updated : server)),
+			mutation: "updated",
+			created: false,
+			idempotent: false,
+		};
+	}
+
+	const sourceName = request.alias ?? detail?.nameHint ?? inferNameFromCatalogId(request.catalogId);
+	const homepage =
+		request.source === "modelcontextprotocol/servers"
+			? `https://github.com/modelcontextprotocol/servers/tree/main/src/${request.catalogId}`
+			: request.source === "github"
+				? `https://github.com/${request.catalogId}`
+				: `https://mcpservers.org/en/servers/${request.catalogId}`;
+	const now = new Date().toISOString();
+	const server: InstalledMarketplaceMcpServer = {
+		id: makeUniqueServerId(sanitizeServerId(sourceName), installed),
+		source: request.source,
+		catalogId: request.catalogId,
+		name: sourceName,
+		description: detail?.description ?? `${sourceName} MCP server`,
+		category: inferCategory(`${sourceName} ${detail?.description ?? ""}`),
+		homepage,
+		official: request.source === "modelcontextprotocol/servers",
+		enabled: true,
+		scope: normalizeScope(request.scope),
+		config: normalizedConfig,
+		installedAt: now,
+		updatedAt: now,
+		installKey,
+		installOperationId: operationId,
+	};
+	return { server, next: [...installed, server], mutation: "created", created: true, idempotent: false };
+}
+
+function resolveDependencies(input: MarketplaceMcpInstallDependencies): Required<MarketplaceMcpInstallDependencies> {
+	return {
+		readInstalledServers: input.readInstalledServers ?? readInstalledServers,
+		writeInstalledServers: input.writeInstalledServers ?? writeInstalledServers,
+		fetchDetail: input.fetchDetail ?? fetchDetailBySource,
+		invalidateToolsCache: input.invalidateToolsCache ?? invalidateMarketplaceToolsCache,
+		probeServer: input.probeServer ?? defaultProbeServer,
+		storeProbeResult: input.storeProbeResult ?? storeProbeResult,
+		loadProbeResult: input.loadProbeResult ?? loadProbeResult,
+	};
+}
+
+async function preparePlan(
+	request: MarketplaceMcpInstallRequest,
+	context: InstallContext,
+	operationId: string,
+	installKey: string,
+	dependencies: Required<MarketplaceMcpInstallDependencies>,
+): Promise<InstallPlan> {
+	requireActive(context, "preparation");
+	const installed = dependencies.readInstalledServers();
+	if (request.kind === "direct") return buildDirectPlan(request, installed, operationId, installKey);
+	const existing = installed.find(
+		(server) =>
+			server.catalogId === request.catalogId && server.source === request.source && server.installKey === installKey,
+	);
+	if (existing) {
+		return { server: existing, next: installed, mutation: "unchanged", created: false, idempotent: true };
+	}
+
+	let detail: MarketplaceMcpDetail | undefined;
+	let normalizedConfig = normalizeMcpConfig(request.config);
+	if (!normalizedConfig) {
+		const timeoutMs = remainingMs(context);
+		requireActive(context, "catalog detail fetch");
+		try {
+			detail = await waitForInstallStage(
+				dependencies.fetchDetail(request.source, request.catalogId, {
+					signal: context.signal,
+					timeoutMs,
+				}),
+				context,
+				"catalog detail fetch",
+			);
+		} catch (error) {
+			if (!isActive(context)) {
+				throw new MarketplaceInstallError(
+					"MCP install timed out or was cancelled during catalog detail fetch",
+					"timeout",
+				);
+			}
+			throw error;
+		}
+		normalizedConfig = detail.config ?? null;
+	}
+	if (!normalizedConfig) {
+		throw new MarketplaceInstallError(
+			"No standard MCP config found for this server. Use manual registration instead.",
+			"missing_config",
+		);
+	}
+	return buildCatalogPlan(request, detail, normalizedConfig, installed, operationId, installKey);
+}
+
+async function runInstallWithinContext(
+	request: MarketplaceMcpInstallRequest,
+	context: InstallContext,
+	installKey: string,
+	dependencies: Required<MarketplaceMcpInstallDependencies>,
+): Promise<MarketplaceMcpInstallResult> {
+	const operationId = `mcp-install-${randomUUID()}`;
+	const plan = await preparePlan(request, context, operationId, installKey, dependencies);
+	if (plan.idempotent) return idempotentResult(operationId, plan, dependencies);
+
+	// This synchronous call is the one canonical installed-state mutation. The
+	// deadline fence immediately before it prevents a catalog fetch that timed
+	// out from mutating state after the caller has received a failure.
+	requireActive(context, "installed-state mutation");
+	dependencies.writeInstalledServers(plan.next);
+	dependencies.invalidateToolsCache();
+
+	// The mutation is now accepted. If the caller deadline expires from here on,
+	// return the operation id rather than allowing a detached probe-result write.
+	if (!isActive(context)) return acceptedResult(operationId, plan);
+
+	let probe: McpProbeResult;
+	try {
+		probe = await waitForInstallStage(
+			dependencies.probeServer(plan.server, {
+				signal: context.signal,
+				timeoutMs: Math.max(1, remainingMs(context)),
+			}),
+			context,
+			"probe",
+		);
+	} catch {
+		return acceptedResult(operationId, plan);
+	}
+
+	if (!isActive(context)) return acceptedResult(operationId, plan);
+	try {
+		dependencies.storeProbeResult(probe);
+	} catch {
+		return acceptedResult(operationId, plan);
+	}
+	return completedResult(operationId, plan, probe);
+}
+
+async function runInstall(
+	request: MarketplaceMcpInstallRequest,
+	options: MarketplaceMcpInstallOptions,
+	installKey: string,
+	dependencies: Required<MarketplaceMcpInstallDependencies>,
+): Promise<MarketplaceMcpInstallResult> {
+	const context = createInstallContext(options);
+	try {
+		return await runInstallWithinContext(request, context, installKey, dependencies);
+	} finally {
+		context.cleanup();
+	}
+}
+
+/**
+ * Install a direct or catalog MCP server through one bounded, idempotent path.
+ * Concurrent requests for the same stable key share one operation.
+ */
+export async function installMcpServer(
+	input: MarketplaceMcpInstallRequest,
+	options: MarketplaceMcpInstallOptions = {},
+	dependencyInput: MarketplaceMcpInstallDependencies = {},
+): Promise<MarketplaceMcpInstallResult> {
+	const request = normalizeInstallRequest(input);
+	const derivedKey = deriveInstallKey(request);
+	const installKey = normalizeIdempotencyKey(options.idempotencyKey, derivedKey);
+	const existing = inFlightInstalls.get(installKey);
+	if (existing) return existing;
+
+	const dependencies = resolveDependencies(dependencyInput);
+	const operation = runInstall(request, options, installKey, dependencies);
+	inFlightInstalls.set(installKey, operation);
+	try {
+		return await operation;
+	} finally {
+		if (inFlightInstalls.get(installKey) === operation) inFlightInstalls.delete(installKey);
+	}
+}
+
+function combineSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+	const timeoutSignal = AbortSignal.timeout(Math.max(1, timeoutMs));
+	return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
+export async function readCapped(response: Response): Promise<string> {
+	const length = response.headers.get("content-length");
+	if (length && Number.parseInt(length, 10) > MAX_README_BYTES) {
+		throw new Error(`response too large: ${length} bytes`);
+	}
+	const text = await response.text();
+	if (text.length > MAX_README_BYTES) throw new Error(`response too large: ${text.length} chars`);
+	return text;
+}
+
+async function fetchText(url: string, signal: AbortSignal, timeoutMs: number): Promise<string> {
+	const response = await fetch(url, {
+		headers: { "User-Agent": "signet-daemon-marketplace" },
+		signal: combineSignal(signal, Math.min(timeoutMs, DETAIL_TIMEOUT_MS)),
+	});
+	if (!response.ok) throw new Error(`detail fetch failed: ${response.status}`);
+	return readCapped(response);
+}
+
+/** Parse a standard MCP config from a catalog README/detail page. */
+export function extractStandardMcpConfig(markdown: string): MarketplaceMcpDetail {
+	const titleMatch = markdown.match(/^([^\n]+)\n[-=]{3,}\n/m);
+	let description = "";
+	if (titleMatch) {
+		const rest = markdown.slice(markdown.indexOf(titleMatch[0]) + titleMatch[0].length);
+		const descriptionMatch = rest.match(/^([^\n]+)$/m);
+		if (descriptionMatch) description = descriptionMatch[1].trim();
+	}
+
+	const githubMatch = markdown.match(/\[GitHub\]\((https:\/\/github\.com\/[^)]+)\)/i);
+	const githubUrl = githubMatch ? githubMatch[1] : undefined;
+	const configSection = markdown.search(/standard config/i);
+	const target = configSection >= 0 ? markdown.slice(configSection) : markdown;
+	const codeBlockRe = /```(?:json|javascript|js)?\s*([\s\S]*?)```/gi;
+	let config: MarketplaceMcpConfig | undefined;
+	let nameHint: string | undefined;
+	let match: RegExpExecArray | null;
+
+	while ((match = codeBlockRe.exec(target)) !== null) {
+		const body = match[1].trim();
+		if (!body.includes("mcpServers") && !body.includes('"mcp"')) continue;
+		try {
+			const parsed = JSON.parse(body) as unknown;
+			if (!isRecord(parsed)) continue;
+			const servers = isRecord(parsed.mcpServers)
+				? parsed.mcpServers
+				: isRecord(parsed.mcp) && isRecord(parsed.mcp.servers)
+					? parsed.mcp.servers
+					: null;
+			if (!servers) continue;
+			const first = Object.entries(servers)[0];
+			if (!first) continue;
+			nameHint = first[0];
+			config = normalizeMcpConfig(first[1]) ?? undefined;
+			if (config) break;
+		} catch {
+			// Ignore non-JSON code blocks and continue looking for a standard block.
+		}
+	}
+
+	return { nameHint, config, githubUrl, description };
+}
+
+async function fetchMcpServersOrgDetail(
+	catalogId: string,
+	options: { signal: AbortSignal; timeoutMs: number },
+): Promise<MarketplaceMcpDetail> {
+	const markdown = await fetchText(
+		`https://r.jina.ai/http://mcpservers.org/en/servers/${catalogId}`,
+		options.signal,
+		options.timeoutMs,
+	);
+	return extractStandardMcpConfig(markdown);
+}
+
+async function fetchReferenceServerDetail(
+	catalogId: string,
+	options: { signal: AbortSignal; timeoutMs: number },
+): Promise<MarketplaceMcpDetail> {
+	const encodedPath = catalogId
+		.split("/")
+		.map((part) => encodeURIComponent(part))
+		.join("/");
+	const markdown = await fetchText(
+		`https://raw.githubusercontent.com/modelcontextprotocol/servers/main/src/${encodedPath}/README.md`,
+		options.signal,
+		options.timeoutMs,
+	);
+	return extractStandardMcpConfig(markdown);
+}
+
+async function fetchGithubServerDetail(
+	catalogId: string,
+	options: { signal: AbortSignal; timeoutMs: number },
+): Promise<MarketplaceMcpDetail> {
+	if (!/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(catalogId)) {
+		throw new Error("invalid github catalog id: expected org/repo");
+	}
+	const encodedPath = catalogId
+		.split("/")
+		.map((part) => encodeURIComponent(part))
+		.join("/");
+	const headers = { "User-Agent": "signet-daemon-marketplace" };
+	const signal = combineSignal(options.signal, Math.min(options.timeoutMs, DETAIL_TIMEOUT_MS));
+	const main = await fetch(`${GITHUB_RAW_HOST}/${encodedPath}/main/README.md`, { headers, signal });
+	if (main.ok) return extractStandardMcpConfig(await readCapped(main));
+	if (main.status !== 404) throw new Error(`github detail fetch failed: ${main.status}`);
+
+	const master = await fetch(`${GITHUB_RAW_HOST}/${encodedPath}/master/README.md`, { headers, signal });
+	if (!master.ok) throw new Error(`github detail fetch failed: main 404, master ${master.status}`);
+	return extractStandardMcpConfig(await readCapped(master));
+}
+
+/** Fetch and parse catalog detail under the caller's remaining deadline. */
+export function fetchDetailBySource(
+	source: MarketplaceMcpCatalogSource,
+	catalogId: string,
+	options: { readonly signal?: AbortSignal; readonly timeoutMs?: number } = {},
+): Promise<MarketplaceMcpDetail> {
+	const timeoutMs = Math.max(1, Math.min(DETAIL_TIMEOUT_MS, options.timeoutMs ?? DETAIL_TIMEOUT_MS));
+	const signal = combineSignal(options.signal, timeoutMs);
+	const fetchOptions = { signal, timeoutMs };
+	if (source === "modelcontextprotocol/servers") return fetchReferenceServerDetail(catalogId, fetchOptions);
+	if (source === "github") return fetchGithubServerDetail(catalogId, fetchOptions);
+	return fetchMcpServersOrgDetail(catalogId, fetchOptions);
+}

--- a/platform/daemon/src/mcp-install-service.ts
+++ b/platform/daemon/src/mcp-install-service.ts
@@ -106,6 +106,7 @@ export interface MarketplaceMcpInstallResult {
 export interface MarketplaceMcpProbeOptions {
 	readonly signal: AbortSignal;
 	readonly timeoutMs: number;
+	readonly operationId?: string;
 }
 
 export interface MarketplaceMcpInstallDependencies {
@@ -532,7 +533,11 @@ function idempotentResult(
 	const priorOperationId = plan.server.installOperationId ?? operationId;
 	// An update keeps the server id, so an older probe file must not make a
 	// timed-out update look completed.
-	if (probe && probe.probedAt >= plan.server.updatedAt) {
+	if (
+		probe &&
+		((plan.server.installOperationId !== undefined && probe.installOperationId === plan.server.installOperationId) ||
+			(probe.installOperationId === undefined && probe.probedAt > plan.server.updatedAt))
+	) {
 		return completedResult(priorOperationId, plan, probe);
 	}
 	return acceptedResult(priorOperationId, plan);
@@ -740,6 +745,7 @@ async function runInstallWithinContext(
 			dependencies.probeServer(plan.server, {
 				signal: context.signal,
 				timeoutMs: Math.max(1, remainingMs(context)),
+				operationId,
 			}),
 			context,
 			"probe",

--- a/platform/daemon/src/mcp-probe.ts
+++ b/platform/daemon/src/mcp-probe.ts
@@ -300,6 +300,7 @@ export async function probeServer(
 	options?: MarketplaceMcpProbeOptions,
 ): Promise<McpProbeResult> {
 	const now = new Date().toISOString();
+	const installOperationId = options?.operationId;
 
 	try {
 		const probeData = await withProbeClient(
@@ -415,6 +416,7 @@ export async function probeServer(
 
 		return {
 			serverId: server.id,
+			...(installOperationId ? { installOperationId } : {}),
 			ok: true,
 			declaredManifest: declaredManifest ?? undefined,
 			autoCard,
@@ -432,6 +434,7 @@ export async function probeServer(
 		// show "reconnecting" state, auto-upgrade when server appears
 		return {
 			serverId: server.id,
+			...(installOperationId ? { installOperationId } : {}),
 			ok: false,
 			error: msg,
 			autoCard: generateAutoCard([], [], server.name),

--- a/platform/daemon/src/mcp-probe.ts
+++ b/platform/daemon/src/mcp-probe.ts
@@ -20,7 +20,7 @@ import { withMarketplaceMcpPermit, withMarketplaceMcpTimeout } from "./marketpla
 // Note: validatePublicHttpUrl from url-validation.ts is used by the install
 // endpoint (server-side fetch = real SSRF risk). Manifest ui/icon fields are
 // client-side (iframe/img) so they only need scheme validation, not address blocking.
-import type { InstalledMarketplaceMcpServer } from "./routes/marketplace.js";
+import type { InstalledMarketplaceMcpServer, MarketplaceMcpProbeOptions } from "./mcp-install-service.js";
 import { getSecret } from "./secrets.js";
 import { deleteCachedWidget, loadCachedWidget } from "./widget-gen.js";
 
@@ -79,56 +79,67 @@ async function resolveSecretReferences(values: Readonly<Record<string, string>>)
 async function withProbeClient<T>(
 	server: InstalledMarketplaceMcpServer,
 	fn: (client: Client) => Promise<T>,
+	options: MarketplaceMcpProbeOptions = {
+		signal: AbortSignal.timeout(Math.min(server.config.timeoutMs, 30_000)),
+		timeoutMs: Math.min(server.config.timeoutMs, 30_000),
+	},
 ): Promise<T> {
-	const timeoutMs = Math.min(server.config.timeoutMs, 30_000);
-	return withMarketplaceMcpPermit(timeoutMs, async (permit, remainingTimeoutMs) => {
-		const client = new Client({
-			name: "signet-os-probe",
-			version: "0.1.0",
-		});
-		let closePromise: Promise<void> | null = null;
-		const close = (): Promise<void> => {
-			if (!closePromise) {
-				closePromise = client.close().catch(() => undefined);
-			}
-			return closePromise;
-		};
-
-		const run = async (): Promise<T> => {
-			if (server.config.transport === "stdio") {
-				const runtimeEnv: Record<string, string> = {};
-				for (const [k, v] of Object.entries(process.env)) {
-					if (typeof v === "string") runtimeEnv[k] = v;
+	const timeoutMs = Math.max(1, Math.min(server.config.timeoutMs, 30_000, options.timeoutMs));
+	if (options.signal.aborted)
+		throw options.signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+	return withMarketplaceMcpPermit(
+		timeoutMs,
+		async (permit, remainingTimeoutMs) => {
+			const client = new Client({
+				name: "signet-os-probe",
+				version: "0.1.0",
+			});
+			let closePromise: Promise<void> | null = null;
+			const close = (): Promise<void> => {
+				if (!closePromise) {
+					closePromise = client.close().catch(() => undefined);
 				}
-				const resolvedEnv = await resolveSecretReferences(server.config.env);
-				const transport = new StdioClientTransport({
-					command: server.config.command,
-					args: [...server.config.args],
-					env: { ...runtimeEnv, ...resolvedEnv },
-					cwd: server.config.cwd,
-				});
+				return closePromise;
+			};
 
-				permit.markProcessStarted();
+			const run = async (): Promise<T> => {
+				if (server.config.transport === "stdio") {
+					const runtimeEnv: Record<string, string> = {};
+					for (const [k, v] of Object.entries(process.env)) {
+						if (typeof v === "string") runtimeEnv[k] = v;
+					}
+					const resolvedEnv = await resolveSecretReferences(server.config.env);
+					const transport = new StdioClientTransport({
+						command: server.config.command,
+						args: [...server.config.args],
+						env: { ...runtimeEnv, ...resolvedEnv },
+						cwd: server.config.cwd,
+					});
+
+					permit.markProcessStarted();
+					await client.connect(transport);
+					return fn(client);
+				}
+
+				const resolvedHeaders = await resolveSecretReferences(server.config.headers);
+				const transport = new StreamableHTTPClientTransport(new URL(server.config.url), {
+					requestInit: {
+						headers: resolvedHeaders,
+						signal: options.signal,
+					},
+				});
 				await client.connect(transport);
 				return fn(client);
+			};
+
+			try {
+				return await withMarketplaceMcpTimeout(run(), remainingTimeoutMs, `Probe ${server.id}`, close, options.signal);
+			} finally {
+				await close();
 			}
-
-			const resolvedHeaders = await resolveSecretReferences(server.config.headers);
-			const transport = new StreamableHTTPClientTransport(new URL(server.config.url), {
-				requestInit: {
-					headers: resolvedHeaders,
-				},
-			});
-			await client.connect(transport);
-			return fn(client);
-		};
-
-		try {
-			return await withMarketplaceMcpTimeout(run(), remainingTimeoutMs, `Probe ${server.id}`, close);
-		} finally {
-			await close();
-		}
-	});
+		},
+		options.signal,
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -284,83 +295,90 @@ export function generateAutoCard(
  * failed result with an auto-card containing zero tools — the server
  * can be re-probed when it comes online.
  */
-export async function probeServer(server: InstalledMarketplaceMcpServer): Promise<McpProbeResult> {
+export async function probeServer(
+	server: InstalledMarketplaceMcpServer,
+	options?: MarketplaceMcpProbeOptions,
+): Promise<McpProbeResult> {
 	const now = new Date().toISOString();
 
 	try {
-		const probeData = await withProbeClient(server, async (client) => {
-			// 1. List tools
-			const toolsResult = (await client.listTools()) as {
-				tools?: Array<{
-					name: string;
-					description?: string;
-					inputSchema?: unknown;
-					annotations?: { readOnlyHint?: boolean };
-				}>;
-			};
-			const rawTools = toolsResult.tools ?? [];
-
-			// 2. List resources (may not be supported by all servers)
-			let rawResources: Array<{
-				uri: string;
-				name: string;
-				description?: string;
-				mimeType?: string;
-			}> = [];
-			try {
-				const resourcesResult = (await client.listResources()) as {
-					resources?: Array<{
-						uri: string;
+		const probeData = await withProbeClient(
+			server,
+			async (client) => {
+				// 1. List tools
+				const toolsResult = (await client.listTools()) as {
+					tools?: Array<{
 						name: string;
 						description?: string;
-						mimeType?: string;
+						inputSchema?: unknown;
+						annotations?: { readOnlyHint?: boolean };
 					}>;
 				};
-				rawResources = resourcesResult.resources ?? [];
-			} catch {
-				// Resources not supported — that's fine
-				logger.debug("probe", `Server ${server.id} does not support listResources`);
-			}
+				const rawTools = toolsResult.tools ?? [];
 
-			// 3. Try to get server info/metadata for signet block
-			let serverMetadata: unknown = null;
-			try {
-				// The MCP SDK client may expose server info after connection
-				const serverInfo = (client as unknown as { getServerVersion?: () => unknown }).getServerVersion?.();
-				if (isRecord(serverInfo)) {
-					serverMetadata = serverInfo;
-				}
-			} catch {
-				// No server metadata available
-			}
-
-			// Also check if the server exposes metadata via a resource
-			if (!serverMetadata) {
+				// 2. List resources (may not be supported by all servers)
+				let rawResources: Array<{
+					uri: string;
+					name: string;
+					description?: string;
+					mimeType?: string;
+				}> = [];
 				try {
-					// Convention: some servers expose metadata at signet://manifest
-					const metaResource = rawResources.find(
-						(r) => r.uri === "signet://manifest" || r.uri === "signet://app" || r.name === "signet-manifest",
-					);
-					if (metaResource) {
-						const content = await client.readResource({ uri: metaResource.uri });
-						if (isRecord(content) && Array.isArray(content.contents) && content.contents.length > 0) {
-							const firstContent = content.contents[0] as Record<string, unknown>;
-							if (typeof firstContent?.text === "string") {
-								try {
-									serverMetadata = JSON.parse(firstContent.text);
-								} catch {
-									// Not valid JSON
+					const resourcesResult = (await client.listResources()) as {
+						resources?: Array<{
+							uri: string;
+							name: string;
+							description?: string;
+							mimeType?: string;
+						}>;
+					};
+					rawResources = resourcesResult.resources ?? [];
+				} catch {
+					// Resources not supported — that's fine
+					logger.debug("probe", `Server ${server.id} does not support listResources`);
+				}
+
+				// 3. Try to get server info/metadata for signet block
+				let serverMetadata: unknown = null;
+				try {
+					// The MCP SDK client may expose server info after connection
+					const serverInfo = (client as unknown as { getServerVersion?: () => unknown }).getServerVersion?.();
+					if (isRecord(serverInfo)) {
+						serverMetadata = serverInfo;
+					}
+				} catch {
+					// No server metadata available
+				}
+
+				// Also check if the server exposes metadata via a resource
+				if (!serverMetadata) {
+					try {
+						// Convention: some servers expose metadata at signet://manifest
+						const metaResource = rawResources.find(
+							(r) => r.uri === "signet://manifest" || r.uri === "signet://app" || r.name === "signet-manifest",
+						);
+						if (metaResource) {
+							const content = await client.readResource({ uri: metaResource.uri });
+							if (isRecord(content) && Array.isArray(content.contents) && content.contents.length > 0) {
+								const firstContent = content.contents[0] as Record<string, unknown>;
+								if (typeof firstContent?.text === "string") {
+									try {
+										serverMetadata = JSON.parse(firstContent.text);
+									} catch {
+										// Not valid JSON
+									}
 								}
 							}
 						}
+					} catch {
+						// Resource read failed — that's fine
 					}
-				} catch {
-					// Resource read failed — that's fine
 				}
-			}
 
-			return { rawTools, rawResources, serverMetadata };
-		});
+				return { rawTools, rawResources, serverMetadata };
+			},
+			options,
+		);
 
 		// Parse tools into AutoCardToolAction format
 		const tools: AutoCardToolAction[] = probeData.rawTools

--- a/platform/daemon/src/routes/app-tray.test.ts
+++ b/platform/daemon/src/routes/app-tray.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import type { McpProbeResult } from "@signet/core";
+import { Hono } from "hono";
+import { mountAppTrayRoutes } from "./app-tray.js";
+import type {
+	InstalledMarketplaceMcpServer,
+	MarketplaceMcpInstallDependencies,
+	MarketplaceMcpProbeOptions,
+} from "../mcp-install-service.js";
+
+function makeProbe(serverId: string): McpProbeResult {
+	return {
+		serverId,
+		ok: true,
+		autoCard: {
+			name: serverId,
+			tools: [],
+			resources: [],
+			hasAppResources: false,
+			defaultSize: { w: 4, h: 3 },
+		},
+		toolCount: 0,
+		resourceCount: 0,
+		hasAppResources: false,
+		probedAt: new Date().toISOString(),
+	};
+}
+
+describe("app-tray install route", () => {
+	it("shares one idempotent install and probe for concurrent requests", async () => {
+		let installed: InstalledMarketplaceMcpServer[] = [];
+		let probes = 0;
+		let stores = 0;
+		const dependencies: MarketplaceMcpInstallDependencies = {
+			readInstalledServers: () => installed,
+			writeInstalledServers: (servers) => {
+				installed = [...servers];
+			},
+			invalidateToolsCache: () => undefined,
+			probeServer: async (server, _options: MarketplaceMcpProbeOptions) => {
+				probes++;
+				await Bun.sleep(15);
+				return makeProbe(server.id);
+			},
+			storeProbeResult: () => {
+				stores++;
+			},
+			loadProbeResult: () => null,
+		};
+		const app = new Hono();
+		mountAppTrayRoutes(app, dependencies);
+		const init: RequestInit = {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ url: "https://route-retry.example.test/mcp", name: "Route Retry" }),
+		};
+
+		const [first, second] = await Promise.all([
+			app.request("/api/os/install", init),
+			app.request("/api/os/install", init),
+		]);
+		const firstBody = (await first.json()) as {
+			status: string;
+			widgetId: string;
+			operationId: string;
+			created: boolean;
+		};
+		const secondBody = (await second.json()) as { operationId: string };
+
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
+		expect(firstBody.status).toBe("completed");
+		expect(firstBody.created).toBe(true);
+		expect(firstBody.widgetId).toBe("route-retry");
+		expect(secondBody.operationId).toBe(firstBody.operationId);
+		expect(installed).toHaveLength(1);
+		expect(probes).toBe(1);
+		expect(stores).toBe(1);
+	});
+});

--- a/platform/daemon/src/routes/app-tray.ts
+++ b/platform/daemon/src/routes/app-tray.ts
@@ -1,15 +1,15 @@
 /** App Tray API routes — CRUD for app tray entries and MCP install endpoint. */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { AutoCardResource, AutoCardToolAction, SignetAppManifest } from "@signet/core";
+import type { AutoCardResource, AutoCardToolAction } from "@signet/core";
 import type { Hono } from "hono";
 
 import { resolveDefaultBasePath } from "@signet/core";
-import { fetchInternal } from "../internal-fetch.js";
 import { logger } from "../logger.js";
-import { loadAppTray, loadProbeResult, probeServer, reprobeServer, storeProbeResult } from "../mcp-probe.js";
-import { isPrivateHostname } from "../url-validation.js";
+import { installMcpServer, MarketplaceInstallError } from "../mcp-install-service.js";
+import type { MarketplaceMcpInstallDependencies } from "../mcp-install-service.js";
+import { loadAppTray, loadProbeResult, reprobeServer } from "../mcp-probe.js";
 import { readInstalledServersPublic } from "./marketplace-helpers.js";
 
 function isValidState(s: string): s is "tray" | "grid" | "dock" {
@@ -63,7 +63,7 @@ function findFreeGridPosition(
 /**
  * Mount app tray routes on the Hono app.
  */
-export function mountAppTrayRoutes(app: Hono): void {
+export function mountAppTrayRoutes(app: Hono, installDependencies: MarketplaceMcpInstallDependencies = {}): void {
 	/**
 	 * GET /api/os/tray — list all app tray entries.
 	 * Automatically syncs installed MCP servers that are missing
@@ -247,62 +247,51 @@ export function mountAppTrayRoutes(app: Hono): void {
 			return c.json({ ok: false, widgetId: "", manifest: null, error: "url is required" }, 400);
 		}
 
-		// Validate URL scheme and block private/loopback addresses (SSRF prevention)
-		try {
-			const parsed = new URL(url);
-			if (!["https:", "http:"].includes(parsed.protocol)) {
-				return c.json({ ok: false, widgetId: "", manifest: null, error: "Only HTTP/HTTPS URLs are supported" }, 400);
-			}
-
-			if (isPrivateHostname(parsed.hostname)) {
-				return c.json(
-					{ ok: false, widgetId: "", manifest: null, error: "Private/loopback addresses are not allowed" },
-					400,
-				);
-			}
-		} catch {
-			return c.json({ ok: false, widgetId: "", manifest: null, error: "Invalid URL format" }, 400);
-		}
-
 		const nameOverride = body.name?.trim() || undefined;
 		const autoPlace = body.autoPlace === true;
 
 		try {
-			const mcpServersOrgMatch = url.match(/^https?:\/\/(?:www\.)?mcpservers\.org\/servers\/(.+?)(?:\/|\?|#|$)/);
-
+			const mcpServersOrgMatch = url.match(
+				/^https?:\/\/(?:www\.)?mcpservers\.org\/(?:[a-z][a-z-]{1,9}\/)?servers\/(.+?)(?:\/|\?|#|$)/,
+			);
 			const installResult = mcpServersOrgMatch
-				? await installViaCatalog(mcpServersOrgMatch[1], "mcpservers.org", nameOverride)
-				: await installDirectHttp(url, nameOverride);
+				? await installMcpServer(
+						{
+							kind: "catalog",
+							source: "mcpservers.org",
+							catalogId: mcpServersOrgMatch[1],
+							alias: nameOverride,
+						},
+						{
+							signal: c.req.raw.signal,
+							idempotencyKey: c.req.header("Idempotency-Key"),
+						},
+						installDependencies,
+					)
+				: await installMcpServer(
+						{ kind: "direct", url, name: nameOverride },
+						{
+							signal: c.req.raw.signal,
+							idempotencyKey: c.req.header("Idempotency-Key"),
+						},
+						installDependencies,
+					);
 
-			// Probe the server
-			const installed = readInstalledServersPublic();
-			const server = installed.find((s) => s.id === installResult.serverId);
-
-			let manifest: SignetAppManifest | null = null;
-			if (server) {
-				try {
-					const probeResult = await probeServer(server);
-					storeProbeResult(probeResult);
-					manifest = probeResult.declaredManifest ?? null;
-				} catch (err) {
-					logger.warn("probe", `Install probe failed for ${installResult.serverId}: ${err}`);
-					// Install still succeeds — auto-card will be used
-				}
-			}
+			const manifest = installResult.probe?.declaredManifest ?? null;
 
 			// If autoPlace, find free grid position and update tray entry
-			if (autoPlace) {
+			if (autoPlace && installResult.status === "completed") {
 				const tray = loadAppTray();
-				const entry = tray.find((e) => e.id === installResult.serverId);
+				const entry = tray.find((e) => e.id === installResult.server.id);
 				if (entry) {
 					const occupiedPositions = tray.flatMap((e) =>
-						e.state === "grid" && e.gridPosition && e.id !== installResult.serverId ? [e.gridPosition] : [],
+						e.state === "grid" && e.gridPosition && e.id !== installResult.server.id ? [e.gridPosition] : [],
 					);
 
 					const defaultSize = manifest?.defaultSize ?? entry.autoCard?.defaultSize ?? { w: 4, h: 3 };
 					const pos = findFreeGridPosition(occupiedPositions, defaultSize.w, defaultSize.h);
 
-					const idx = tray.findIndex((e) => e.id === installResult.serverId);
+					const idx = tray.findIndex((e) => e.id === installResult.server.id);
 					if (idx >= 0) {
 						tray[idx] = {
 							...tray[idx],
@@ -317,15 +306,30 @@ export function mountAppTrayRoutes(app: Hono): void {
 				}
 			}
 
-			return c.json({
-				ok: true,
-				widgetId: installResult.serverId,
-				manifest,
-			});
+			return c.json(
+				{
+					ok: true,
+					widgetId: installResult.server.id,
+					manifest,
+					created: installResult.created,
+					updated: installResult.updated,
+					status: installResult.status,
+					operationId: installResult.operationId,
+				},
+				installResult.status === "accepted" ? 202 : 200,
+			);
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			logger.error("probe", `Install failed: ${msg}`);
-			return c.json({ ok: false, widgetId: "", manifest: null, error: msg }, 500);
+			const status =
+				error instanceof MarketplaceInstallError
+					? error.code === "timeout"
+						? 504
+						: error.code === "missing_config"
+							? 422
+							: 400
+					: 500;
+			return c.json({ ok: false, widgetId: "", manifest: null, error: msg }, status);
 		}
 	});
 }
@@ -338,191 +342,9 @@ function getMarketplaceDir(): string {
 	return join(getAgentsDir(), "marketplace");
 }
 
-function getInstalledMcpPath(): string {
-	return join(getMarketplaceDir(), "mcp-servers.json");
-}
-
 function ensureMarketplaceDir(): void {
 	const dir = getMarketplaceDir();
 	if (!existsSync(dir)) {
 		mkdirSync(dir, { recursive: true });
 	}
-}
-
-function sanitizeServerId(value: string): string {
-	const normalized = value
-		.trim()
-		.toLowerCase()
-		.replace(/[^a-z0-9_-]+/g, "-")
-		.replace(/^-+|-+$/g, "");
-	return normalized.length > 0 ? normalized : "mcp-server";
-}
-
-function inferNameFromUrl(url: string): string {
-	try {
-		const parsed = new URL(url);
-		// Use hostname without common prefixes
-		let name = parsed.hostname.replace(/^(www|api|mcp)\./, "").replace(/\.(com|org|io|dev|app|net)$/, "");
-		// Add path hint if useful
-		const pathParts = parsed.pathname
-			.split("/")
-			.filter((p) => p.length > 0 && p !== "mcp" && p !== "sse" && p !== "v1");
-		if (pathParts.length > 0) {
-			name = `${name}-${pathParts[0]}`;
-		}
-		return name
-			.replace(/[-_]+/g, " ")
-			.trim()
-			.split(" ")
-			.map((w) => (w.length > 0 ? `${w[0].toUpperCase()}${w.slice(1)}` : w))
-			.join(" ");
-	} catch {
-		return "MCP Server";
-	}
-}
-
-function inferCategory(text: string): string {
-	const source = text.toLowerCase();
-	if (/browser|scrap|crawl|web/.test(source)) return "Web";
-	if (/slack|discord|email|sms|message|chat/.test(source)) return "Communication";
-	if (/database|sql|postgres|mysql|sqlite|redis|vector/.test(source)) return "Database";
-	if (/github|git|ci|deploy|build|code|dev/.test(source)) return "Development";
-	if (/cloud|aws|gcp|azure|vercel|cloudflare/.test(source)) return "Cloud";
-	if (/finance|stock|market|crypto|trading/.test(source)) return "Finance";
-	if (/memory|knowledge|search|docs|rag/.test(source)) return "Knowledge";
-	if (/file|storage|drive|s3|bucket/.test(source)) return "Storage";
-	return "Other";
-}
-
-interface InstalledServer {
-	readonly id: string;
-	readonly source: string;
-	readonly catalogId?: string;
-	readonly name: string;
-	readonly description: string;
-	readonly category: string;
-	readonly homepage?: string;
-	readonly official: boolean;
-	readonly enabled: boolean;
-	readonly scope: { harnesses: string[]; workspaces: string[]; channels: string[] };
-	readonly config: Record<string, unknown>;
-	readonly installedAt: string;
-	readonly updatedAt: string;
-}
-
-function readInstalledServersRaw(): InstalledServer[] {
-	const path = getInstalledMcpPath();
-	if (!existsSync(path)) return [];
-	try {
-		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
-		if (!Array.isArray(raw)) return [];
-		return raw as InstalledServer[];
-	} catch {
-		return [];
-	}
-}
-
-function writeInstalledServersRaw(servers: InstalledServer[]): void {
-	ensureMarketplaceDir();
-	writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));
-}
-
-function makeUniqueServerId(baseId: string, installed: readonly InstalledServer[]): string {
-	if (!installed.some((s) => s.id === baseId)) return baseId;
-	let i = 2;
-	while (installed.some((s) => s.id === `${baseId}-${i}`)) {
-		i++;
-	}
-	return `${baseId}-${i}`;
-}
-
-/**
- * Install a direct HTTP MCP server URL as a manual server.
- */
-async function installDirectHttp(url: string, nameOverride?: string): Promise<{ serverId: string; isNew: boolean }> {
-	const installed = readInstalledServersRaw();
-
-	// Check if already installed by matching URL
-	const existing = installed.find(
-		(s) => s.config && typeof s.config === "object" && "url" in s.config && s.config.url === url,
-	);
-	if (existing) {
-		// Update name if override provided
-		if (nameOverride && nameOverride !== existing.name) {
-			const updated = installed.map((s) =>
-				s.id === existing.id ? { ...s, name: nameOverride, updatedAt: new Date().toISOString() } : s,
-			);
-			writeInstalledServersRaw(updated);
-		}
-		return { serverId: existing.id, isNew: false };
-	}
-
-	const name = nameOverride ?? inferNameFromUrl(url);
-	const baseId = sanitizeServerId(name);
-	const id = makeUniqueServerId(baseId, installed);
-	const now = new Date().toISOString();
-
-	const server: InstalledServer = {
-		id,
-		source: "manual",
-		name,
-		description: `${name} MCP server`,
-		category: inferCategory(name),
-		homepage: url,
-		official: false,
-		enabled: true,
-		scope: { harnesses: [], workspaces: [], channels: [] },
-		config: {
-			transport: "http",
-			url,
-			headers: {},
-			timeoutMs: 20000,
-		},
-		installedAt: now,
-		updatedAt: now,
-	};
-
-	writeInstalledServersRaw([...installed, server]);
-	return { serverId: id, isNew: true };
-}
-
-/**
- * Install an MCP server from a catalog source (mcpservers.org).
- * Delegates to the existing /api/marketplace/mcp/install endpoint logic
- * by calling it internally via fetch.
- */
-async function installViaCatalog(
-	catalogId: string,
-	source: "mcpservers.org" | "modelcontextprotocol/servers",
-	nameOverride?: string,
-): Promise<{ serverId: string; isNew: boolean }> {
-	// Use internal HTTP call to the marketplace install endpoint.
-	// This reuses all existing logic (config fetch, dedup, etc.) without
-	// duplicating it.
-	const port = process.env.SIGNET_PORT || "3850";
-	const res = await fetchInternal(`http://127.0.0.1:${port}/api/marketplace/mcp/install`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			id: `${source}:${catalogId}`,
-			source,
-			alias: nameOverride,
-		}),
-	});
-
-	const data = (await res.json()) as {
-		success?: boolean;
-		server?: { id: string };
-		updated?: boolean;
-		error?: string;
-	};
-
-	if (!data.success || !data.server) {
-		throw new Error(data.error ?? "Marketplace install failed");
-	}
-
-	return {
-		serverId: data.server.id,
-		isNew: !data.updated,
-	};
 }

--- a/platform/daemon/src/routes/marketplace-helpers.ts
+++ b/platform/daemon/src/routes/marketplace-helpers.ts
@@ -1,50 +1,9 @@
-/**
- * Marketplace helpers — shared utilities extracted to avoid circular imports.
- *
- * The readInstalledServers function from marketplace.ts is not exported,
- * so we provide a public re-implementation here that reads the same file.
- *
- * COUPLING NOTE: This reads ~/.agents/marketplace/mcp-servers.json directly.
- * If marketplace.ts ever changes the file path or format, this must be updated
- * to match. See also: marketplace.ts readInstalledServers().
- */
+/** Shared access to the canonical installed MCP server state owner. */
 
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { resolveDefaultBasePath } from "@signet/core";
-import type { InstalledMarketplaceMcpServer } from "./marketplace.js";
+import { readInstalledServers } from "../mcp-install-service.js";
+import type { InstalledMarketplaceMcpServer } from "../mcp-install-service.js";
 
-function getAgentsDir(): string {
-	return resolveDefaultBasePath();
-}
-
-function getInstalledMcpPath(): string {
-	return join(getAgentsDir(), "marketplace", "mcp-servers.json");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-/**
- * Read installed MCP servers from the marketplace config file.
- * This is a public accessor for the same data marketplace.ts manages.
- */
+/** Read installed MCP servers for app-tray and other daemon adapters. */
 export function readInstalledServersPublic(): InstalledMarketplaceMcpServer[] {
-	const path = getInstalledMcpPath();
-	if (!existsSync(path)) return [];
-
-	try {
-		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
-		if (!Array.isArray(raw)) return [];
-		return raw.filter(
-			(item): item is InstalledMarketplaceMcpServer =>
-				isRecord(item) &&
-				typeof item.id === "string" &&
-				typeof item.name === "string" &&
-				typeof item.enabled === "boolean",
-		);
-	} catch {
-		return [];
-	}
+	return readInstalledServers();
 }

--- a/platform/daemon/src/routes/marketplace.ts
+++ b/platform/daemon/src/routes/marketplace.ts
@@ -18,7 +18,34 @@ import {
 	withMarketplaceMcpPermit,
 	withMarketplaceMcpTimeout,
 } from "../marketplace-client-budget.js";
+import {
+	fetchDetailBySource,
+	inferCategory,
+	inferNameFromCatalogId,
+	installMcpServer,
+	MarketplaceInstallError,
+	makeUniqueServerId,
+	normalizeMcpConfig,
+	normalizeScope,
+	parseCatalogSelection,
+	readCapped,
+	sanitizeServerId,
+	readInstalledServers,
+	writeInstalledServers,
+} from "../mcp-install-service.js";
+import type {
+	InstalledMarketplaceMcpServer,
+	MarketplaceMcpCatalogSource,
+	MarketplaceMcpInstallDependencies,
+	MarketplaceMcpScope,
+} from "../mcp-install-service.js";
 import { probeServer, removeProbeResult, storeProbeResult } from "../mcp-probe.js";
+import {
+	invalidateMarketplaceToolsCache,
+	marketplaceToolsCache,
+	marketplaceToolsLoadInFlight,
+} from "../marketplace-tools-cache.js";
+import type { MarketplaceToolsCache } from "../marketplace-tools-cache.js";
 import { resolveScopedAgent } from "../request-scope.js";
 import { getSecret } from "../secrets.js";
 import { authConfig } from "./state.js";
@@ -30,15 +57,14 @@ const TOOLS_TTL_MS = 30 * 1000;
 /** mcpservers.org locale prefix — shared across catalog listing, detail fetch, and homepage URLs. */
 const MCPSERVERS_LOCALE = "en";
 
-export type MarketplaceMcpTransport = "stdio" | "http";
-export type MarketplaceMcpCatalogSource = "mcpservers.org" | "modelcontextprotocol/servers" | "github";
+export type {
+	MarketplaceMcpCatalogSource,
+	MarketplaceMcpConfig,
+	MarketplaceMcpScope,
+	MarketplaceMcpTransport,
+} from "../mcp-install-service.js";
+export { extractStandardMcpConfig } from "../mcp-install-service.js";
 export type MarketplaceMcpExposureMode = "compact" | "hybrid" | "expanded";
-
-export interface MarketplaceMcpScope {
-	readonly harnesses: readonly string[];
-	readonly workspaces: readonly string[];
-	readonly channels: readonly string[];
-}
 
 export interface MarketplaceMcpExposurePolicy {
 	readonly mode: MarketplaceMcpExposureMode;
@@ -53,39 +79,11 @@ export interface MarketplaceMcpScopeContext {
 	readonly channel?: string;
 }
 
-export interface MarketplaceMcpConfigStdio {
-	readonly transport: "stdio";
-	readonly command: string;
-	readonly args: readonly string[];
-	readonly env: Readonly<Record<string, string>>;
-	readonly cwd?: string;
-	readonly timeoutMs: number;
-}
-
-export interface MarketplaceMcpConfigHttp {
-	readonly transport: "http";
-	readonly url: string;
-	readonly headers: Readonly<Record<string, string>>;
-	readonly timeoutMs: number;
-}
-
-export type MarketplaceMcpConfig = MarketplaceMcpConfigStdio | MarketplaceMcpConfigHttp;
-
-export interface InstalledMarketplaceMcpServer {
-	readonly id: string;
-	readonly source: MarketplaceMcpCatalogSource | "manual";
-	readonly catalogId?: string;
-	readonly name: string;
-	readonly description: string;
-	readonly category: string;
-	readonly homepage?: string;
-	readonly official: boolean;
-	readonly enabled: boolean;
-	readonly scope: MarketplaceMcpScope;
-	readonly config: MarketplaceMcpConfig;
-	readonly installedAt: string;
-	readonly updatedAt: string;
-}
+export type {
+	InstalledMarketplaceMcpServer,
+	MarketplaceMcpConfigHttp,
+	MarketplaceMcpConfigStdio,
+} from "../mcp-install-service.js";
 
 export interface MarketplaceMcpCatalogEntry {
 	readonly id: string;
@@ -100,13 +98,7 @@ export interface MarketplaceMcpCatalogEntry {
 	readonly sourceUrl: string;
 }
 
-interface MarketplaceToolsCache {
-	readonly fetchedAt: number;
-	readonly tools: readonly MarketplaceMcpTool[];
-	readonly serverHealth: readonly MarketplaceMcpServerHealth[];
-}
-
-interface MarketplaceMcpTool {
+export interface MarketplaceMcpTool {
 	readonly id: string;
 	readonly serverId: string;
 	readonly serverName: string;
@@ -116,7 +108,7 @@ interface MarketplaceMcpTool {
 	readonly inputSchema: unknown;
 }
 
-interface MarketplaceMcpServerHealth {
+export interface MarketplaceMcpServerHealth {
 	readonly serverId: string;
 	readonly serverName: string;
 	readonly ok: boolean;
@@ -129,14 +121,6 @@ interface ParsedCatalogPage {
 	readonly entries: readonly MarketplaceMcpCatalogEntry[];
 }
 
-interface DetailConfig {
-	readonly nameHint?: string;
-	readonly config?: MarketplaceMcpConfig;
-	readonly githubUrl?: string;
-	readonly description: string;
-}
-
-const DEFAULT_TIMEOUT_MS = 20_000;
 const SECRET_REF_PREFIX = "secret://";
 // Sentinel: "never explicitly set" — not process start time, which would
 // be misleading since this default is returned whenever no policy file exists.
@@ -152,19 +136,12 @@ let referenceCatalogCache: {
 	readonly fetchedAt: number;
 	readonly entries: readonly MarketplaceMcpCatalogEntry[];
 } | null = null;
-const toolsCache = new Map<string, MarketplaceToolsCache>();
-const toolsLoadInFlight = new Map<string, Promise<MarketplaceToolsCache>>();
-
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
 }
 
 function getMarketplaceDir(): string {
 	return join(getAgentsDir(), "marketplace");
-}
-
-function getInstalledMcpPath(): string {
-	return join(getMarketplaceDir(), "mcp-servers.json");
 }
 
 function getExposurePolicyPath(): string {
@@ -180,50 +157,6 @@ function ensureMarketplaceDir(): void {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function toStringRecord(value: unknown): Record<string, string> {
-	if (!isRecord(value)) return {};
-	const out: Record<string, string> = {};
-	for (const [k, v] of Object.entries(value)) {
-		if (typeof v === "string") out[k] = v;
-	}
-	return out;
-}
-
-function toStringArray(value: unknown): string[] {
-	if (!Array.isArray(value)) return [];
-	return value.filter((v): v is string => typeof v === "string");
-}
-
-function normalizeScopeValues(values: unknown): string[] {
-	const seen = new Set<string>();
-	const normalized: string[] = [];
-	for (const value of toStringArray(values)) {
-		const item = value.trim();
-		if (item.length === 0) continue;
-		const key = item.toLowerCase();
-		if (seen.has(key)) continue;
-		seen.add(key);
-		normalized.push(item);
-	}
-	return normalized;
-}
-
-function normalizeScope(value: unknown): MarketplaceMcpScope {
-	if (!isRecord(value)) {
-		return {
-			harnesses: [],
-			workspaces: [],
-			channels: [],
-		};
-	}
-
-	return {
-		harnesses: normalizeScopeValues(value.harnesses),
-		workspaces: normalizeScopeValues(value.workspaces),
-		channels: normalizeScopeValues(value.channels),
-	};
 }
 
 function normalizeScopeContextValue(value: string | undefined): string | undefined {
@@ -386,102 +319,12 @@ async function resolveSecretReferences(values: Readonly<Record<string, string>>)
 	return resolved;
 }
 
-function sanitizeServerId(value: string): string {
-	const normalized = value
-		.trim()
-		.toLowerCase()
-		.replace(/[^a-z0-9_-]+/g, "-")
-		.replace(/^-+|-+$/g, "");
-	return normalized.length > 0 ? normalized : "mcp-server";
-}
-
 function makeCatalogEntryId(source: MarketplaceMcpCatalogSource, catalogId: string): string {
 	return `${source}:${catalogId}`;
 }
 
 function catalogSelectionKey(source: MarketplaceMcpCatalogSource, catalogId: string): string {
 	return `${source}:${catalogId}`;
-}
-
-function parseCatalogSelection(
-	rawId: string,
-	rawSource?: string,
-): { source: MarketplaceMcpCatalogSource; catalogId: string } {
-	if (rawId.startsWith("modelcontextprotocol/servers:")) {
-		return {
-			source: "modelcontextprotocol/servers",
-			catalogId: rawId.slice("modelcontextprotocol/servers:".length),
-		};
-	}
-
-	if (rawId.startsWith("mcpservers.org:")) {
-		return {
-			source: "mcpservers.org",
-			catalogId: rawId.slice("mcpservers.org:".length),
-		};
-	}
-
-	if (rawId.startsWith("github:")) {
-		return {
-			source: "github",
-			catalogId: rawId.slice("github:".length),
-		};
-	}
-
-	if (rawSource === "modelcontextprotocol/servers") {
-		return { source: rawSource, catalogId: rawId };
-	}
-
-	if (rawSource === "github") {
-		return { source: rawSource, catalogId: rawId };
-	}
-
-	return { source: "mcpservers.org", catalogId: rawId };
-}
-
-function makeUniqueServerId(baseId: string, installed: readonly InstalledMarketplaceMcpServer[]): string {
-	if (!installed.some((s) => s.id === baseId)) return baseId;
-	let i = 2;
-	while (installed.some((s) => s.id === `${baseId}-${i}`)) {
-		i++;
-	}
-	return `${baseId}-${i}`;
-}
-
-function inferNameFromCatalogId(catalogId: string): string {
-	const repo = catalogId.split("/").at(-1) ?? catalogId;
-	const cleaned = repo
-		.replace(/^mcp[-_]?/i, "")
-		.replace(/[-_]+/g, " ")
-		.trim();
-	if (!cleaned) return catalogId;
-	return cleaned
-		.split(" ")
-		.map((w) => (w.length > 0 ? `${w[0].toUpperCase()}${w.slice(1)}` : w))
-		.join(" ");
-}
-
-function inferCategory(text: string): string {
-	const source = text.toLowerCase();
-	if (/browser|scrap|crawl|web/.test(source)) return "Web";
-	if (/slack|discord|email|sms|message|chat/.test(source)) {
-		return "Communication";
-	}
-	if (/database|sql|postgres|mysql|sqlite|d1|redis|vector/.test(source)) {
-		return "Database";
-	}
-	if (/github|git|ci|deploy|build|code|dev/.test(source)) {
-		return "Development";
-	}
-	if (/cloud|aws|gcp|azure|vercel|cloudflare/.test(source)) {
-		return "Cloud";
-	}
-	if (/finance|stock|market|crypto|trading/.test(source)) {
-		return "Finance";
-	}
-	if (/memory|knowledge|search|docs|rag/.test(source)) return "Knowledge";
-	if (/file|storage|drive|s3|bucket/.test(source)) return "Storage";
-	return "Other";
 }
 
 function parseCatalogMarkdown(markdown: string, page: number): ParsedCatalogPage {
@@ -665,253 +508,6 @@ async function fetchCatalogPage(page: number): Promise<ParsedCatalogPage> {
 	return parsed;
 }
 
-function normalizeMcpConfig(value: unknown, timeoutMs = DEFAULT_TIMEOUT_MS): MarketplaceMcpConfig | null {
-	if (!isRecord(value)) return null;
-
-	if (typeof value.url === "string") {
-		return {
-			transport: "http",
-			url: value.url,
-			headers: toStringRecord(value.headers),
-			timeoutMs,
-		};
-	}
-
-	if (typeof value.command === "string") {
-		return {
-			transport: "stdio",
-			command: value.command,
-			args: toStringArray(value.args),
-			env: toStringRecord(value.env),
-			cwd: typeof value.cwd === "string" ? value.cwd : undefined,
-			timeoutMs,
-		};
-	}
-
-	if (Array.isArray(value.command)) {
-		const commandParts = toStringArray(value.command);
-		if (commandParts.length === 0) return null;
-		return {
-			transport: "stdio",
-			command: commandParts[0],
-			args: [...commandParts.slice(1), ...toStringArray(value.args)],
-			env: toStringRecord(value.env),
-			cwd: typeof value.cwd === "string" ? value.cwd : undefined,
-			timeoutMs,
-		};
-	}
-
-	return null;
-}
-
-export function extractStandardMcpConfig(markdown: string): DetailConfig {
-	const titleMatch = markdown.match(/^([^\n]+)\n[-=]{3,}\n/m);
-	const title = titleMatch ? titleMatch[1].trim() : undefined;
-
-	let description = "";
-	if (titleMatch) {
-		const headingStart = markdown.indexOf(titleMatch[0]);
-		const rest = markdown.slice(headingStart + titleMatch[0].length);
-		const descMatch = rest.match(/^([^\n]+)$/m);
-		if (descMatch) {
-			description = descMatch[1].trim();
-		}
-	}
-
-	const githubMatch = markdown.match(/\[GitHub\]\((https:\/\/github\.com\/[^)]+)\)/i);
-	const githubUrl = githubMatch ? githubMatch[1] : undefined;
-
-	const idx = markdown.search(/standard config/i);
-	const target = idx >= 0 ? markdown.slice(idx) : markdown;
-	const codeBlockRe = /```(?:json|javascript|js)?\s*([\s\S]*?)```/gi;
-
-	let config: MarketplaceMcpConfig | null = null;
-	let nameHint: string | undefined;
-	let m: RegExpExecArray | null;
-
-	while ((m = codeBlockRe.exec(target)) !== null) {
-		const body = m[1].trim();
-		if (!body.includes("mcpServers") && !body.includes('"mcp"')) continue;
-		try {
-			const parsed = JSON.parse(body) as unknown;
-			if (!isRecord(parsed)) continue;
-
-			let serversRecord: Record<string, unknown> | null = null;
-			if (isRecord(parsed.mcpServers)) {
-				serversRecord = parsed.mcpServers;
-			} else if (isRecord(parsed.mcp) && isRecord(parsed.mcp.servers)) {
-				serversRecord = parsed.mcp.servers;
-			}
-
-			if (!serversRecord) continue;
-			const first = Object.entries(serversRecord)[0];
-			if (!first) continue;
-			nameHint = first[0];
-			config = normalizeMcpConfig(first[1]);
-			if (config) break;
-		} catch {
-			// Ignore non-JSON or non-standard blocks
-		}
-	}
-
-	return {
-		nameHint,
-		config: config ?? undefined,
-		githubUrl,
-		description,
-	};
-}
-
-function parseInstalledServer(value: unknown): InstalledMarketplaceMcpServer | null {
-	if (!isRecord(value)) return null;
-	if (typeof value.id !== "string") return null;
-	if (
-		value.source !== "mcpservers.org" &&
-		value.source !== "modelcontextprotocol/servers" &&
-		value.source !== "manual" &&
-		value.source !== "github"
-	)
-		return null;
-	if (typeof value.name !== "string") return null;
-	if (typeof value.description !== "string") return null;
-	if (typeof value.category !== "string") return null;
-	if (typeof value.official !== "boolean") return null;
-	if (typeof value.enabled !== "boolean") return null;
-	if (typeof value.installedAt !== "string") return null;
-	if (typeof value.updatedAt !== "string") return null;
-
-	const config = normalizeMcpConfig(value.config);
-	if (!config) return null;
-
-	return {
-		id: value.id,
-		source: value.source,
-		catalogId: typeof value.catalogId === "string" ? value.catalogId : undefined,
-		name: value.name,
-		description: value.description,
-		category: value.category,
-		homepage: typeof value.homepage === "string" ? value.homepage : undefined,
-		official: value.official,
-		enabled: value.enabled,
-		scope: normalizeScope(value.scope),
-		config,
-		installedAt: value.installedAt,
-		updatedAt: value.updatedAt,
-	};
-}
-
-/** NOTE: marketplace-helpers.ts has a public copy of this function to avoid circular imports.
- *  If you change the path or format here, update marketplace-helpers.ts to match. */
-function readInstalledServers(): InstalledMarketplaceMcpServer[] {
-	const path = getInstalledMcpPath();
-	if (!existsSync(path)) return [];
-
-	try {
-		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
-		if (!Array.isArray(raw)) return [];
-		return raw
-			.map((item) => parseInstalledServer(item))
-			.filter((item): item is InstalledMarketplaceMcpServer => item !== null);
-	} catch {
-		return [];
-	}
-}
-
-function writeInstalledServers(servers: readonly InstalledMarketplaceMcpServer[]): void {
-	ensureMarketplaceDir();
-	writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));
-}
-
-async function fetchMcpServersOrgDetail(catalogId: string): Promise<DetailConfig> {
-	const url = `https://r.jina.ai/http://mcpservers.org/${MCPSERVERS_LOCALE}/servers/${catalogId}`;
-	const res = await fetch(url, {
-		headers: { "User-Agent": "signet-daemon-marketplace" },
-		signal: AbortSignal.timeout(25_000),
-	});
-
-	if (!res.ok) {
-		throw new Error(`detail fetch failed: ${res.status}`);
-	}
-
-	const markdown = await readCapped(res);
-	return extractStandardMcpConfig(markdown);
-}
-
-/** Fetch README from the modelcontextprotocol/servers repo for a reference server. */
-async function fetchReferenceServerDetail(catalogId: string): Promise<DetailConfig> {
-	const encodedPath = catalogId
-		.split("/")
-		.map((part) => encodeURIComponent(part))
-		.join("/");
-	const url = `https://raw.githubusercontent.com/modelcontextprotocol/servers/main/src/${encodedPath}/README.md`;
-	const res = await fetch(url, {
-		headers: { "User-Agent": "signet-daemon-marketplace" },
-		signal: AbortSignal.timeout(25_000),
-	});
-
-	if (!res.ok) {
-		throw new Error(`reference detail fetch failed: ${res.status}`);
-	}
-
-	const markdown = await readCapped(res);
-	return extractStandardMcpConfig(markdown);
-}
-
-const GITHUB_RAW_HOST = "https://raw.githubusercontent.com" as const;
-const MAX_README_BYTES = 2 * 1024 * 1024; // 2 MB cap on fetched READMEs
-
-/** Read response body with a size cap to prevent memory exhaustion. */
-async function readCapped(res: Response): Promise<string> {
-	const len = res.headers.get("content-length");
-	if (len && Number.parseInt(len, 10) > MAX_README_BYTES) {
-		throw new Error(`response too large: ${len} bytes`);
-	}
-	const text = await res.text();
-	if (text.length > MAX_README_BYTES) {
-		throw new Error(`response too large: ${text.length} chars`);
-	}
-	return text;
-}
-
-/**
- * Fetch README.md from a GitHub repo to extract MCP server config.
- * Security: only fetches from raw.githubusercontent.com with strict
- * org/repo validation — no arbitrary URLs or redirects followed.
- */
-async function fetchGithubServerDetail(catalogId: string): Promise<DetailConfig> {
-	if (!/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(catalogId)) {
-		throw new Error("invalid github catalog id: expected org/repo");
-	}
-	const encodedPath = catalogId
-		.split("/")
-		.map((part) => encodeURIComponent(part))
-		.join("/");
-	const headers = { "User-Agent": "signet-daemon-marketplace" };
-	const timeout = 25_000;
-	const url = `${GITHUB_RAW_HOST}/${encodedPath}/main/README.md`;
-	const res = await fetch(url, { headers, signal: AbortSignal.timeout(timeout) });
-
-	if (!res.ok) {
-		if (res.status === 404) {
-			const fallback = `${GITHUB_RAW_HOST}/${encodedPath}/master/README.md`;
-			const res2 = await fetch(fallback, { headers, signal: AbortSignal.timeout(timeout) });
-			if (res2.ok) return extractStandardMcpConfig(await readCapped(res2));
-			throw new Error(`github detail fetch failed: main 404, master ${res2.status}`);
-		}
-		throw new Error(`github detail fetch failed: ${res.status}`);
-	}
-
-	const markdown = await readCapped(res);
-	return extractStandardMcpConfig(markdown);
-}
-
-/** Route detail fetch to the appropriate handler based on catalog source. */
-function fetchDetailBySource(source: MarketplaceMcpCatalogSource, catalogId: string): Promise<DetailConfig> {
-	if (source === "modelcontextprotocol/servers") return fetchReferenceServerDetail(catalogId);
-	if (source === "github") return fetchGithubServerDetail(catalogId);
-	return fetchMcpServersOrgDetail(catalogId);
-}
-
 async function withConnectedClient<T>(
 	server: InstalledMarketplaceMcpServer,
 	fn: (client: Client) => Promise<T>,
@@ -979,13 +575,13 @@ async function loadMarketplaceTools(
 		.sort()
 		.join("|");
 
-	const cached = toolsCache.get(cacheKey);
+	const cached = marketplaceToolsCache.get(cacheKey);
 	const now = Date.now();
 	if (cached && now - cached.fetchedAt < TOOLS_TTL_MS) {
 		return cached;
 	}
 
-	const existingLoad = toolsLoadInFlight.get(cacheKey);
+	const existingLoad = marketplaceToolsLoadInFlight.get(cacheKey);
 	if (existingLoad) return existingLoad;
 
 	const load = (async (): Promise<MarketplaceToolsCache> => {
@@ -1055,20 +651,16 @@ async function loadMarketplaceTools(
 			serverHealth: toolBuckets.map((b) => b.health),
 		};
 
-		toolsCache.set(cacheKey, nextCache);
+		marketplaceToolsCache.set(cacheKey, nextCache);
 		return nextCache;
 	})();
 
-	toolsLoadInFlight.set(cacheKey, load);
+	marketplaceToolsLoadInFlight.set(cacheKey, load);
 	try {
 		return await load;
 	} finally {
-		if (toolsLoadInFlight.get(cacheKey) === load) toolsLoadInFlight.delete(cacheKey);
+		if (marketplaceToolsLoadInFlight.get(cacheKey) === load) marketplaceToolsLoadInFlight.delete(cacheKey);
 	}
-}
-
-function invalidateMarketplaceToolsCache(): void {
-	toolsCache.clear();
 }
 
 function tokenizeQuery(value: string): string[] {
@@ -1139,13 +731,13 @@ function recordMcpInvocation(record: McpInvocationRecord): void {
 				record.success ? 1 : 0,
 				record.errorText ?? null,
 			);
-		}, "routes/marketplace.ts:1128");
+		}, "routes/marketplace.ts:720");
 	} catch (err) {
 		logger.warn("skills", "Failed to record MCP invocation", err instanceof Error ? err : undefined);
 	}
 }
 
-export function mountMarketplaceRoutes(app: Hono): void {
+export function mountMarketplaceRoutes(app: Hono, installDependencies: MarketplaceMcpInstallDependencies = {}): void {
 	app.get("/api/marketplace/mcp", (c) => {
 		const servers = readInstalledServers();
 		const context = extractContextFromRequest(c);
@@ -1351,92 +943,45 @@ export function mountMarketplaceRoutes(app: Hono): void {
 		}
 
 		const selection = parseCatalogSelection(body.id, body.source);
-		const catalogId = selection.catalogId;
-		if (catalogId.includes("..") || catalogId.startsWith("/")) {
-			return c.json({ error: "Invalid catalog id" }, 400);
-		}
-
-		let normalized = normalizeMcpConfig(body.config);
-		let detail: DetailConfig | undefined;
-		const scope = normalizeScope(body.scope);
-
-		if (!normalized) {
-			try {
-				detail = await fetchDetailBySource(selection.source, catalogId);
-			} catch (error) {
-				return c.json({ error: `Failed to fetch server detail: ${String(error)}` }, 502);
-			}
-			normalized = detail?.config ?? null;
-		}
-
-		if (!normalized) {
+		try {
+			const result = await installMcpServer(
+				{
+					kind: "catalog",
+					source: selection.source,
+					catalogId: selection.catalogId,
+					alias: body.alias,
+					config: body.config,
+					scope: body.scope,
+				},
+				{
+					signal: c.req.raw.signal,
+					idempotencyKey: c.req.header("Idempotency-Key"),
+				},
+				installDependencies,
+			);
 			return c.json(
 				{
-					error: "No standard MCP config found for this server. Use manual registration instead.",
+					success: true,
+					server: result.server,
+					created: result.created,
+					updated: result.updated,
+					status: result.status,
+					operationId: result.operationId,
 				},
-				422,
+				result.status === "accepted" ? 202 : 200,
 			);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const status =
+				error instanceof MarketplaceInstallError
+					? error.code === "missing_config"
+						? 422
+						: error.code === "timeout"
+							? 504
+							: 400
+					: 502;
+			return c.json({ error: message }, status);
 		}
-
-		const now = new Date().toISOString();
-		const installed = readInstalledServers();
-
-		const existing = installed.find((s) => s.catalogId === catalogId && s.source === selection.source);
-		if (existing) {
-			const updated: InstalledMarketplaceMcpServer = {
-				...existing,
-				enabled: true,
-				scope: body.scope === undefined ? existing.scope : scope,
-				config: normalized,
-				updatedAt: now,
-			};
-			const next = installed.map((s) => (s.id === existing.id ? updated : s));
-			writeInstalledServers(next);
-			invalidateMarketplaceToolsCache();
-			// Fire-and-forget probe on install/update
-			void probeServer(updated)
-				.then(storeProbeResult)
-				.catch((err) => {
-					logger.warn("probe", `Post-install probe failed for ${updated.id}: ${err}`);
-				});
-			return c.json({ success: true, server: updated, updated: true });
-		}
-
-		const sourceName = body.alias?.trim() || detail?.nameHint || inferNameFromCatalogId(catalogId);
-		const baseId = sanitizeServerId(body.alias?.trim() || sourceName);
-		const id = makeUniqueServerId(baseId, installed);
-		const homepage =
-			selection.source === "modelcontextprotocol/servers"
-				? `https://github.com/modelcontextprotocol/servers/tree/main/src/${catalogId}`
-				: selection.source === "github"
-					? `https://github.com/${catalogId}`
-					: `https://mcpservers.org/${MCPSERVERS_LOCALE}/servers/${catalogId}`;
-
-		const server: InstalledMarketplaceMcpServer = {
-			id,
-			source: selection.source,
-			catalogId,
-			name: sourceName,
-			description: detail?.description ?? `${sourceName} MCP server`,
-			category: inferCategory(`${sourceName} ${detail?.description ?? ""}`),
-			homepage,
-			official: selection.source === "modelcontextprotocol/servers",
-			enabled: true,
-			scope,
-			config: normalized,
-			installedAt: now,
-			updatedAt: now,
-		};
-
-		writeInstalledServers([...installed, server]);
-		invalidateMarketplaceToolsCache();
-		// Fire-and-forget probe on new install
-		void probeServer(server)
-			.then(storeProbeResult)
-			.catch((err) => {
-				logger.warn("probe", `Post-install probe failed for ${server.id}: ${err}`);
-			});
-		return c.json({ success: true, server, updated: false });
 	});
 
 	app.post("/api/marketplace/mcp/register", async (c) => {

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1556,35 +1556,35 @@
     },
     {
       "path": "mcp-install-service.ts",
-      "line": 169,
+      "line": 170,
       "api": "existsSync",
       "source": "if (!existsSync(dir)) mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "mcp-install-service.ts",
-      "line": 169,
+      "line": 170,
       "api": "mkdirSync",
       "source": "if (!existsSync(dir)) mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "mcp-install-service.ts",
-      "line": 353,
+      "line": 354,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return [];",
       "category": "hot-path"
     },
     {
       "path": "mcp-install-service.ts",
-      "line": 355,
+      "line": 356,
       "api": "readFileSync",
       "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
       "category": "hot-path"
     },
     {
       "path": "mcp-install-service.ts",
-      "line": 365,
+      "line": 366,
       "api": "writeFileSync",
       "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
       "category": "hot-path"
@@ -1605,63 +1605,63 @@
     },
     {
       "path": "mcp-probe.ts",
-      "line": 458,
+      "line": 461,
       "api": "writeFileSync",
       "source": "writeFileSync(manifestPath, JSON.stringify(result, null, 2));",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 492,
+      "line": 495,
       "api": "writeFileSync",
       "source": "writeFileSync(getAppTrayPath(), JSON.stringify(tray, null, 2));",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 518,
+      "line": 521,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return [];",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 521,
+      "line": 524,
       "api": "readFileSync",
       "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 540,
+      "line": 543,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return null;",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 543,
+      "line": 546,
       "api": "readFileSync",
       "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 559,
+      "line": 562,
       "api": "existsSync",
       "source": "if (existsSync(manifestPath)) {",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 560,
+      "line": 563,
       "api": "unlinkSync",
       "source": "unlinkSync(manifestPath);",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 570,
+      "line": 573,
       "api": "writeFileSync",
       "source": "writeFileSync(getAppTrayPath(), JSON.stringify(filtered, null, 2));",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1555,6 +1555,41 @@
       "category": "hot-path"
     },
     {
+      "path": "mcp-install-service.ts",
+      "line": 169,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-install-service.ts",
+      "line": 169,
+      "api": "mkdirSync",
+      "source": "if (!existsSync(dir)) mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-install-service.ts",
+      "line": 353,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-install-service.ts",
+      "line": 355,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-install-service.ts",
+      "line": 365,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
+      "category": "hot-path"
+    },
+    {
       "path": "mcp-probe.ts",
       "line": 45,
       "api": "existsSync",
@@ -1570,63 +1605,63 @@
     },
     {
       "path": "mcp-probe.ts",
-      "line": 440,
+      "line": 458,
       "api": "writeFileSync",
       "source": "writeFileSync(manifestPath, JSON.stringify(result, null, 2));",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 474,
+      "line": 492,
       "api": "writeFileSync",
       "source": "writeFileSync(getAppTrayPath(), JSON.stringify(tray, null, 2));",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 500,
+      "line": 518,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return [];",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 503,
+      "line": 521,
       "api": "readFileSync",
       "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 522,
+      "line": 540,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return null;",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 525,
+      "line": 543,
       "api": "readFileSync",
       "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 541,
+      "line": 559,
       "api": "existsSync",
       "source": "if (existsSync(manifestPath)) {",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 542,
+      "line": 560,
       "api": "unlinkSync",
       "source": "unlinkSync(manifestPath);",
       "category": "hot-path"
     },
     {
       "path": "mcp-probe.ts",
-      "line": 552,
+      "line": 570,
       "api": "writeFileSync",
       "source": "writeFileSync(getAppTrayPath(), JSON.stringify(filtered, null, 2));",
       "category": "hot-path"
@@ -3069,7 +3104,7 @@
     },
     {
       "path": "routes/app-tray.ts",
-      "line": 315,
+      "line": 304,
       "api": "writeFileSync",
       "source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
       "category": "hot-path"
@@ -3086,27 +3121,6 @@
       "line": 348,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 415,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 417,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 427,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
       "category": "hot-path"
     },
     {
@@ -3505,20 +3519,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/marketplace-helpers.ts",
-      "line": 35,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-helpers.ts",
-      "line": 38,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/marketplace-reviews.ts",
       "line": 62,
       "api": "existsSync",
@@ -3576,70 +3576,49 @@
     },
     {
       "path": "routes/marketplace.ts",
-      "line": 176,
+      "line": 153,
       "api": "existsSync",
       "source": "if (!existsSync(dir)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/marketplace.ts",
-      "line": 177,
+      "line": 154,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/marketplace.ts",
-      "line": 323,
+      "line": 256,
       "api": "existsSync",
       "source": "if (!existsSync(path)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/marketplace.ts",
-      "line": 328,
+      "line": 261,
       "api": "statSync",
       "source": "const mtime = statSync(path).mtime.toISOString();",
       "category": "hot-path"
     },
     {
       "path": "routes/marketplace.ts",
-      "line": 329,
+      "line": 262,
       "api": "readFileSync",
       "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
       "category": "hot-path"
     },
     {
       "path": "routes/marketplace.ts",
-      "line": 338,
+      "line": 271,
       "api": "writeFileSync",
       "source": "writeFileSync(getExposurePolicyPath(), JSON.stringify(policy, null, 2));",
       "category": "hot-path"
     },
     {
       "path": "routes/marketplace.ts",
-      "line": 807,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 810,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 822,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 1128,
+      "line": 720,
       "api": "withWriteTx",
       "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
       "category": "hot-path"

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -157,6 +157,20 @@ silently disappear from the API reference.
 `limit`. The counts cover marketplace discovery, probes, and user operations;
 the limit is the daemon-wide client/process budget.
 
+## MCP install lifecycle
+
+`POST /api/os/install` and `POST /api/marketplace/mcp/install` share one
+canonical install service. The service validates and persists the server once,
+then runs at most one probe. Callers may send an `Idempotency-Key`; when they
+do not, the normalized install target supplies a stable retry key.
+
+A successful `200` response includes `created`, `updated`, `status: "completed"`,
+and `operationId`. If the installed state was accepted but the probe could not
+finish before the request deadline or cancellation, the daemon returns `202`
+with `status: "accepted"`, the installed server/widget id, and `operationId`.
+A deadline or cancellation before the mutation returns an error and does not
+later mutate installed state.
+
 
 ## Dashboard
 


### PR DESCRIPTION
## Summary

Closes #1773.

Consolidate direct-URL and marketplace-catalog MCP installs behind one daemon application service. The service owns validation, identity, persistence, cache invalidation, deadline/cancellation propagation, idempotency, and the single bounded probe lifecycle.

## Changes

- Removed the `/api/os/install` loopback call to `/api/marketplace/mcp/install`.
- Removed the duplicate direct installer and route-owned second probe.
- Added `platform/daemon/src/mcp-install-service.ts` with typed direct/catalog requests, hashed stable retry keys, explicit `created`/`updated` results, operation IDs, and `completed`/`accepted` status.
- Added deadline fences so catalog detail fetches and probe work cannot mutate after a pre-mutation timeout; post-mutation timeouts return `202`/`accepted` with the operation ID and do not perform a detached probe-result write.
- Threaded cancellation through catalog fetches, client-budget admission, and probe cleanup.
- Kept marketplace response fields compatible while adding lifecycle metadata.
- Correlated persisted probe results with their install operation so a stale update probe cannot report a newer accepted install as complete.
- Refreshed the generated event-loop contract ledger after removing duplicate filesystem/state paths.
- Updated the daemon API route inventory and added the requested phased plan at `docs/plans/issue-1773-install-lifecycle.md`.

## Acceptance criteria

- [x] No daemon route calls another daemon route over HTTP for installation.
- [x] The outer operation deadline and request cancellation govern catalog fetch and mutation.
- [x] Pre-mutation timeout rejects without state mutation; post-mutation timeout returns an accepted operation ID.
- [x] One install starts at most one probe lifecycle.
- [x] Direct and catalog installs share canonical validation, identity, persistence, cache invalidation, and probe behavior.
- [x] Regression coverage proves timeout-before-mutation, timeout-after-acceptance, retry idempotency, and single-probe behavior.

## Phased implementation plan

1. Establish the canonical install service and shared state owner.
2. Enforce one total deadline/cancellation signal and accepted-operation semantics.
3. Migrate both HTTP routes and remove the displaced paths.
4. Add only acceptance-critical regression tests.
5. Run validation, push the branch, and complete the self-review.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon API documentation and issue plan

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no formal spec is changed; daemon API inventory was updated.
- [x] Agent scoping verified on all new/changed data queries — no database queries added.
- [x] Input/config validation and bounds checks added.
- [x] Error handling and fallback paths tested (no silent swallow).
- [x] Security checks applied to admin/mutation endpoints — existing route auth wiring is unchanged and URL SSRF validation is now canonical.
- [x] Docs updated for API/spec/status changes — route inventory and lifecycle docs updated.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally (build and focused regression tests also pass).

## Testing

- [x] `bun run build` passes.
- [x] `bun run typecheck` passes.
- [x] `bun run lint` exits 0; the repository reports existing unrelated Biome warnings, with no diagnostics in changed files.
- [x] `bun run format:check` passes.
- [x] Focused daemon regression/catalog tests: `15 pass, 0 fail` across the install service, app-tray route, marketplace route, and client-budget tests.
- [ ] Full workspace suite — attempted with both `bun run test` and the hermetic `bun run test:hermetic --no-orphans --max-concurrency=1 ...` command. The local runs encountered unrelated existing native-embedding, DB-owner timing/SQLite-vec, and manifest-lock contention failures before completing. The focused tests, full build/typecheck/lint/format checks, event-loop audit, and all current PR CI gates pass.
- [ ] Tested against a running daemon — not required for this deterministic route/service regression; no external MCP endpoint was used.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

- The working tree and fresh clone are on the external drive at `/Volumes/AverySSD/SignetAI-Pr's/1773-os-marketplace-install-timeout-and-duplicate-probes`.
- The accepted status is intentionally explicit: installed state is durable, while an incomplete probe is not silently written after the operation deadline. Clients can use the returned operation ID and the existing reprobe surface.
