### PR TITLE
fix(core): allow undeclared tool capability

### DIFF
--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -382,6 +382,92 @@ describe("inference config + decision engine", () => {
 		expect(decision.value.targetRef).toBe(makeRoutingTargetRef("gpt", "gpt54"));
 	});
 
+	it("allows memory extraction when tool support is not declared", () => {
+		const targetRef = makeRoutingTargetRef("compatible", "default");
+		const parsed = parseRoutingConfig({
+			inference: {
+				defaultPolicy: "background",
+				targets: {
+					compatible: {
+						executor: "openai-compatible",
+						endpoint: "https://gateway.example.test/v1",
+						models: {
+							default: { model: "glm-5.3-flash" },
+						},
+					},
+				},
+				policies: {
+					background: {
+						mode: "strict",
+						defaultTargets: [targetRef],
+					},
+				},
+				taskClasses: {
+					memory_extraction: { toolsRequired: true },
+				},
+				workloads: {
+					memoryExtraction: { target: targetRef, taskClass: "memory_extraction" },
+				},
+			},
+		});
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+
+		const decision = resolveRoutingDecision(
+			parsed.value,
+			{ operation: "memory_extraction" },
+			{ targets: { [targetRef]: ready } },
+		);
+		expect(decision.ok).toBe(true);
+		if (!decision.ok) return;
+		expect(decision.value.targetRef).toBe(targetRef);
+		expect(decision.value.trace.candidates[0]?.blockedBy).not.toContain("tool-use required");
+	});
+
+	it("blocks memory extraction when tool support is explicitly disabled", () => {
+		const targetRef = makeRoutingTargetRef("compatible", "default");
+		const parsed = parseRoutingConfig({
+			inference: {
+				defaultPolicy: "background",
+				targets: {
+					compatible: {
+						executor: "openai-compatible",
+						endpoint: "https://gateway.example.test/v1",
+						models: {
+							default: { model: "known-no-tools", toolUse: false },
+						},
+					},
+				},
+				policies: {
+					background: {
+						mode: "strict",
+						defaultTargets: [targetRef],
+					},
+				},
+				taskClasses: {
+					memory_extraction: { toolsRequired: true },
+				},
+				workloads: {
+					memoryExtraction: { target: targetRef, taskClass: "memory_extraction" },
+				},
+			},
+		});
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+
+		const decision = resolveRoutingDecision(
+			parsed.value,
+			{ operation: "memory_extraction" },
+			{ targets: { [targetRef]: ready } },
+		);
+		expect(decision.ok).toBe(false);
+		if (!("error" in decision)) return;
+		const trace = decision.error.details?.trace as
+			| { readonly candidates: readonly { readonly blockedBy: readonly string[] }[] }
+			| undefined;
+		expect(trace?.candidates[0]?.blockedBy).toContain("tool-use required");
+	});
+
 	it("parses ACPX as a first-class restricted harness-backed target", () => {
 		const parsed = parseRoutingConfig({
 			inference: {

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -94,6 +94,7 @@ export interface RoutingModelConfig {
 	readonly label?: string;
 	readonly reasoning?: RoutingReasoningDepth;
 	readonly contextWindow?: number;
+	/** Omitted means the provider has not declared its tool capability. */
 	readonly toolUse?: boolean;
 	readonly streaming?: boolean;
 	readonly multimodal?: boolean;
@@ -1314,7 +1315,10 @@ function buildCandidateTrace(
 	if (requiredPrivacy === "local_only" && target.kind !== "local") {
 		blockedBy.push("local_only request requires local executor");
 	}
-	if ((request.requireTools ?? config.taskClasses[classification.taskClass]?.toolsRequired) && model.toolUse !== true) {
+	if (
+		(request.requireTools ?? config.taskClasses[classification.taskClass]?.toolsRequired) &&
+		model.toolUse === false
+	) {
 		blockedBy.push("tool-use required");
 	}
 	if (

--- a/web/docs/src/content/docs/configuration/inference-routing.md
+++ b/web/docs/src/content/docs/configuration/inference-routing.md
@@ -228,7 +228,7 @@ Model fields:
 | `label` | string | Optional display label |
 | `reasoning` | string | `low`, `medium`, or `high` |
 | `contextWindow` | number | Maximum prompt tokens the model can accept |
-| `toolUse` | boolean | Whether tool use is supported |
+| `toolUse` | boolean (optional) | Whether tool use is supported. For tool-required tasks, explicit `false` blocks routing; omission means the capability is undeclared and does not block routing. |
 | `streaming` | boolean | Whether streaming is supported |
 | `multimodal` | boolean | Whether multimodal input is supported |
 | `costTier` | string | `low`, `medium`, or `high` |


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible providers and some ZAI coding-plan models omit `toolUse` from model metadata. Core routing treated the omitted value as unsupported, so tool-required memory extraction was rejected before the provider was called.

## Changes

- Change the core tool-capability gate to reject only an explicit `toolUse: false`.
- Treat omitted `toolUse` metadata as undeclared rather than unsupported.
- Add routing regressions for both omitted metadata and explicit `toolUse: false`.
- Document the optional field and its tri-state routing behavior.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [x] Other: inference-routing documentation

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification:

- `bun test platform/core/src/routing.test.ts platform/daemon/src/inference-router.test.ts` — 58 passed, 0 failed.
- `bun test platform/core` — 353 passed, 0 failed.
- `bunx biome check platform/core/src/routing.ts platform/core/src/routing.test.ts` — exit 0; existing warnings remain outside this change.
- `bun run typecheck` — exit 0.
- `bun run lint` — exit 0 with existing repository warnings.
- `bun run --cwd web/docs validate:content` — 91 pages and routes validated.
- The root `bun test` run was attempted but did not complete cleanly within the time limit; its failures were outside the changed routing files. No live request was made to a ZAI or custom provider endpoint.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The behavior is intentionally conservative in one direction: unknown capability metadata is allowed through routing to avoid false rejection, while providers known not to support tools can continue to set `toolUse: false` and remain blocked for tool-required tasks.
