### PR TITLE
fix(cli): preserve external embedding selection

### DIFF
--- a/platform/core/src/database-npm-root.test.ts
+++ b/platform/core/src/database-npm-root.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { join } from "node:path";
+
+const npmRoot = join(process.cwd(), "fake-npm-global");
+const platformName = process.platform === "win32" ? "windows" : process.platform;
+const extensionSuffix = process.platform === "win32" ? "dll" : process.platform === "darwin" ? "dylib" : "so";
+const architecture = process.arch === "x64" ? "x64" : process.arch;
+const expectedExtension = join(npmRoot, `sqlite-vec-${platformName}-${architecture}`, `vec0.${extensionSuffix}`);
+const execCalls: Array<{ command: string; args: readonly string[]; options: Record<string, unknown> }> = [];
+const realChildProcess = await import("node:child_process");
+const realFs = await import("node:fs");
+const execFileSync = mock((command: string, args: readonly string[], options: Record<string, unknown>) => {
+	execCalls.push({ command, args, options });
+	return `${npmRoot}\r\n`;
+});
+
+mock.module("node:child_process", () => ({ ...realChildProcess, execFileSync }));
+mock.module("node:fs", () => ({
+	...realFs,
+	existsSync: mock((candidate: string) => candidate === expectedExtension),
+	readdirSync: mock(() => []),
+}));
+
+const originalSignetVecPath = process.env.SIGNET_VEC_PATH;
+delete process.env.SIGNET_VEC_PATH;
+const { findSqliteVecExtension } = await import("./database");
+
+afterAll(() => {
+	if (originalSignetVecPath === undefined) delete process.env.SIGNET_VEC_PATH;
+	else process.env.SIGNET_VEC_PATH = originalSignetVecPath;
+});
+
+describe("sqlite-vec npm global lookup", () => {
+	test("hides the Windows npm launcher and caches the lookup", () => {
+		expect(findSqliteVecExtension()).toBe(expectedExtension);
+		expect(findSqliteVecExtension()).toBe(expectedExtension);
+
+		expect(execFileSync).toHaveBeenCalledTimes(1);
+		expect(execCalls[0]).toMatchObject({
+			command: process.platform === "win32" ? "npm.cmd" : "npm",
+			args: ["root", "-g"],
+			options: {
+				encoding: "utf8",
+				timeout: 3000,
+				windowsHide: true,
+			},
+		});
+	});
+});

--- a/platform/core/src/database.ts
+++ b/platform/core/src/database.ts
@@ -3,6 +3,7 @@
  * Runtime-detecting: uses bun:sqlite under Bun, better-sqlite3 under Node.js
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -12,7 +13,7 @@ import { MEMORY_CONTENT_SAFETY_POLICY_VERSION, scanMemoryContent } from "./memor
 import { isDaemonDerivedMemorySourceType } from "./memory-provenance";
 import { runMigrations } from "./migrations/index";
 import { resolveSqliteJournalConfig } from "./sqlite-journal";
-import type { Conversation, Embedding, Memory } from "./types";
+import type { Memory } from "./types";
 import type { MemoryHistory, MemoryJob } from "./types";
 
 // Compute __dirname at runtime so bun's bundler doesn't bake in a static path
@@ -35,6 +36,32 @@ function getPlatformPackageName(): string {
 // Find the sqlite-vec extension path
 // Handles bun's hoisted node_modules structure where platform packages
 // are in separate .bun directories
+let cachedNpmGlobalRoot: string | null | undefined;
+
+function findNpmGlobalRoot(): string | null {
+	if (cachedNpmGlobalRoot !== undefined) return cachedNpmGlobalRoot;
+
+	try {
+		// npm is a .cmd launcher on Windows. Calling it directly avoids routing
+		// through PowerShell, and windowsHide prevents a console window for every
+		// database/owner initialization.
+		const command = platform === "win32" ? "npm.cmd" : "npm";
+		const root = (
+			execFileSync(command, ["root", "-g"], {
+				encoding: "utf8",
+				timeout: 3000,
+				windowsHide: true,
+			}) as string
+		).trim();
+		cachedNpmGlobalRoot = root || null;
+	} catch {
+		// npm not available or timed out — continue with static paths
+		cachedNpmGlobalRoot = null;
+	}
+
+	return cachedNpmGlobalRoot;
+}
+
 function findSqliteVecExtension(): string | null {
 	// Explicit override — always wins
 	const envPath = process.env.SIGNET_VEC_PATH;
@@ -43,18 +70,13 @@ function findSqliteVecExtension(): string | null {
 	const platformPkg = getPlatformPackageName();
 	const extFile = `vec0.${getExtensionSuffix()}`;
 
-	// Try `npm root -g` to find the actual global prefix (works regardless of runtime)
-	try {
-		const { execFileSync } = require("node:child_process");
-		const npmRoot = (execFileSync("npm", ["root", "-g"], { encoding: "utf8", timeout: 3000 }) as string).trim();
-		if (npmRoot) {
-			const direct = join(npmRoot, platformPkg, extFile);
-			if (existsSync(direct)) return direct;
-			const nested = join(npmRoot, "signetai", "node_modules", platformPkg, extFile);
-			if (existsSync(nested)) return nested;
-		}
-	} catch {
-		// npm not available or timed out — continue with static paths
+	// Try npm's resolved global prefix before the static fallbacks.
+	const npmRoot = findNpmGlobalRoot();
+	if (npmRoot) {
+		const direct = join(npmRoot, platformPkg, extFile);
+		if (existsSync(direct)) return direct;
+		const nested = join(npmRoot, "signetai", "node_modules", platformPkg, extFile);
+		if (existsSync(nested)) return nested;
 	}
 
 	// Try common locations in order
@@ -205,7 +227,6 @@ export class Database {
 	private dbPath: string;
 	private db: SQLiteDatabase | null = null;
 	private options?: { readonly?: boolean };
-	private vecEnabled = false;
 
 	constructor(dbPath: string, options?: { readonly?: boolean }) {
 		this.dbPath = dbPath;
@@ -242,7 +263,7 @@ export class Database {
 		}
 
 		// Load sqlite-vec extension for vector search capabilities
-		this.vecEnabled = loadSqliteVec(this.db);
+		loadSqliteVec(this.db);
 
 		// Enable WAL only when the filesystem supports SQLite's shared-memory
 		// and locking requirements. Darwin network filesystems such as SMB/NFS

--- a/surfaces/cli/src/features/setup-embedding-validation.test.ts
+++ b/surfaces/cli/src/features/setup-embedding-validation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SetupDetection } from "@signet/core";
@@ -71,12 +71,11 @@ function stubDeps(overrides: Partial<SetupDeps> = {}): SetupDeps {
 	};
 }
 
-describe("fresh setup native embedding model validation", () => {
+describe("fresh setup embedding model validation", () => {
 	let root: string;
 
 	afterEach(() => {
 		if (ORIGINAL_HOME === undefined) {
-			// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 			delete process.env.HOME;
 		} else {
 			process.env.HOME = ORIGINAL_HOME;
@@ -160,8 +159,8 @@ describe("fresh setup native embedding model validation", () => {
 		expect(syncNativeEmbeddingModel.mock.calls.length).toBe(0);
 	});
 
-	it("downgrades to native when ollama is unreachable in non-interactive mode", async () => {
-		root = mkdtempSync(join(tmpdir(), "setup-ollama-downgrade-"));
+	it("keeps ollama selected when it is unreachable in non-interactive mode", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-ollama-unavailable-"));
 		const basePath = join(root, "agents");
 
 		const syncNativeEmbeddingModel = mock(async () => ({
@@ -188,11 +187,18 @@ describe("fresh setup native embedding model validation", () => {
 				syncNativeEmbeddingModel,
 			});
 
-			await setupWizard({ nonInteractive: true, embeddingProvider: "ollama" }, deps);
+			await setupWizard(
+				{ nonInteractive: true, embeddingProvider: "ollama", embeddingModel: "qwen3-embedding-4b" },
+				deps,
+			);
 
 			const output = logCalls.join("\n");
-			expect(output).toContain("Downgrading");
-			expect(syncNativeEmbeddingModel.mock.calls.length).toBeGreaterThanOrEqual(1);
+			expect(output).toContain("Keeping embedding provider 'ollama'");
+			expect(output).toContain("embeddings stay unavailable");
+			expect(syncNativeEmbeddingModel.mock.calls.length).toBe(0);
+			const config = readFileSync(join(basePath, "agent.yaml"), "utf8");
+			expect(config).toContain("provider: ollama");
+			expect(config).toContain("qwen3-embedding-4b");
 		} finally {
 			console.log = originalLog;
 			globalThis.fetch = originalFetch;

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -700,15 +700,13 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 	// One question covers both how a local daemon binds AND whether to skip a
 	// local daemon entirely in favor of a remote one. (networkMode is irrelevant
 	// when remote — no local daemon is started.)
-	let networkMode: NetworkMode;
-	let daemonUrl: string | undefined;
 	const requestedRemoteUrl = normalizeDaemonOrigin(deps.normalizeStringValue(options.remoteUrl));
 	if (options.remoteUrl && !requestedRemoteUrl) {
 		failSetupValidation("--remote-url must be a bare http:// or https:// origin (no path, query, or credentials).");
 	}
 
-	networkMode = deps.normalizeChoice(options.networkMode, NETWORK_MODES) ?? existingNetworkMode;
-	daemonUrl = requestedRemoteUrl ?? undefined;
+	const networkMode: NetworkMode = deps.normalizeChoice(options.networkMode, NETWORK_MODES) ?? existingNetworkMode;
+	const daemonUrl = requestedRemoteUrl ?? undefined;
 
 	// Deployment type only tailors non-interactive/reconfigure defaults (e.g.
 	// VPS prefers non-local extraction providers). It has no effect in the
@@ -716,10 +714,8 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 	// works for non-interactive use.
 	const deploymentType: DeploymentTypeChoice = requestedDeploymentType ?? "local";
 
-	let embeddingProvider: EmbeddingProviderChoice;
-
 	const providerFromConfig = deps.normalizeChoice(existingEmbedding.provider, EMBEDDING_PROVIDER_CHOICES);
-	embeddingProvider =
+	const embeddingProvider: EmbeddingProviderChoice =
 		requestedEmbeddingProvider ?? providerFromConfig ?? defaultEmbeddingProviderForDeployment(deploymentType);
 
 	let embeddingModel = "nomic-embed-text";
@@ -739,10 +735,12 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 		const ollamaCheck = await validateOllamaModelNonInteractive(configuredModel);
 		if (!ollamaCheck.available || !ollamaCheck.modelInstalled) {
 			console.log(chalk.yellow(`  ⚠ ${ollamaCheck.error ?? "Ollama embedding model not available"}`));
-			console.log(chalk.yellow("  Downgrading embedding provider to 'native' (built-in ONNX)."));
-			embeddingProvider = "native";
-			embeddingModel = "nomic-embed-text-v1.5";
-			embeddingDimensions = 768;
+			console.log(
+				chalk.yellow(
+					"  Keeping embedding provider 'ollama'; setup will continue, but embeddings stay unavailable until Ollama is reachable and the model is installed.",
+				),
+			);
+			console.log(chalk.dim("  Run 'signet doctor' after fixing Ollama, or rerun 'signet setup'."));
 		}
 	} else if (embeddingProvider === "openai") {
 		const configuredModel =
@@ -760,10 +758,7 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 	const existingSetupExtractionProvider =
 		deps.normalizeChoice(existingPipeline.extractionProvider, EXTRACTION_PROVIDER_CHOICES) ||
 		deps.normalizeChoice(existingExtraction.provider, EXTRACTION_PROVIDER_CHOICES);
-	let extractionProvider: ExtractionProviderChoice;
-	let extractionModel = "haiku";
-
-	extractionProvider = resolveSetupExtractionProvider({
+	const extractionProvider: ExtractionProviderChoice = resolveSetupExtractionProvider({
 		deploymentType,
 		requestedProvider: requestedExtractionProvider,
 		providerFromConfig: existingSetupExtractionProvider,
@@ -772,6 +767,7 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 		availableProviders: availableToolExtractionProviders,
 		preferredHarnesses: harnesses,
 	});
+	let extractionModel = "haiku";
 
 	if (extractionProvider === "acpx") {
 		extractionModel =
@@ -827,14 +823,10 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 	// Optional distinct provider for aggregate recall (query-time evidence
 	// synthesis). pi-ai-only (no harness subprocess). When unset, aggregate
 	// recall falls through to the default policy (the extraction provider).
-	let aggregateRecallProvider: string | undefined;
-	let aggregateRecallModel: string | undefined;
-	let aggregateRecallEndpoint: string | undefined;
-
-	aggregateRecallProvider =
+	const aggregateRecallProvider =
 		deps.normalizeChoice(options.aggregateRecallProvider, aggregateRecallProviderIds()) ?? undefined ?? undefined;
-	aggregateRecallModel = deps.normalizeStringValue(options.aggregateRecallModel) ?? undefined;
-	aggregateRecallEndpoint =
+	const aggregateRecallModel = deps.normalizeStringValue(options.aggregateRecallModel) ?? undefined;
+	const aggregateRecallEndpoint =
 		normalizeHttpEndpoint(deps.normalizeStringValue(options.aggregateRecallEndpoint)) ??
 		(aggregateRecallProvider === "openai-compatible" ? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT : undefined);
 

--- a/web/docs/src/content/docs/cli/getting-started.md
+++ b/web/docs/src/content/docs/cli/getting-started.md
@@ -99,6 +99,8 @@ Current setup accepts `claude-code`, `codex`, `kimi`, `opencode`, `forge`, `open
 | `--search-balance <alpha>` | Semantic/keyword balance from `0` through `1`. |
 | `--enable-dreaming` | Enable background memory consolidation. |
 
+When an explicitly selected Ollama service or model is unavailable during non-interactive setup, Signet keeps Ollama selected and reports the problem; it does not silently switch to native embeddings. Setup continues with embeddings unavailable until Ollama is ready; use `signet doctor` to check readiness.
+
 Validated extraction providers are `acpx`, `claude-code`, `codex`, `llama-cpp`, `ollama`, `opencode`, `openrouter`, `openai-compatible`, and `none`. Explicit provider flags override defaults inferred from `--deployment-type`.
 
 Current `signet setup --help` lists `llama-cpp` as an embedding provider, but setup validation rejects it. Use the validated embedding values above until that discrepancy is fixed.


### PR DESCRIPTION
## Summary

Preserve an explicitly selected external embedding provider and model during non-interactive setup when its preflight check is unavailable. This prevents Signet from silently switching to native embeddings and avoids native warmup on that path.

## Changes

- Keep Ollama and the configured model selected; continue setup with an explicit degraded warning.
- Use npm.cmd, hidden child-process windows, a timeout, and a cached global-root lookup for sqlite-vec resolution on Windows.
- Add regression coverage and document the separate embedding-readiness behavior.

## Type

- [ ] feat — new user-facing feature (bumps minor)
- [x] fix — bug fix
- [ ] refactor — restructure without behavior change
- [ ] chore — build, deps, config, docs
- [ ] perf — performance improvement
- [ ] test — test coverage

## Packages affected

- [x] @signet/core
- [ ] @signet/daemon
- [x] @signet/cli / dashboard
- [ ] @signet/sdk
- [ ] @signet/connector-*
- [x] @signet/web
- [ ] predictor
- [ ] Other: specify if needed

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (INDEX.md + dependencies.yaml)
- [ ] Agent scoping verified on all new/changed data queries
- [ ] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations.

## Testing

- [x] bun test platform/core/src/database-npm-root.test.ts
- [x] bun run --filter '@signet/core' typecheck
- [x] bun run --filter '@signet/core' build
- [ ] bun test passes
- [ ] bun run lint passes
- [ ] Tested against running daemon
- [ ] N/A

The focused setup behavior assertions pass, but the test process still exits through the existing Windows temp-directory EBUSY teardown failure. The full CLI build remains blocked by pre-existing missing generated integration bundles, and docs content validation remains blocked by pre-existing frontmatter failures.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see Assisted-by: Codex in the commit message)

## Notes

Setup success means the workspace/configuration/daemon setup completed; provider readiness remains separately observable through signet doctor. An unavailable explicitly selected provider is kept selected so it can recover without silently changing embedding semantics.
