### PR TITLE
ci: add pre-commit validation hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+exec bun run hooks:pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,14 @@ Contributor workflow, from source:
 git clone https://github.com/Signet-AI/signetai.git
 cd signetai
 bun install
+bun run hooks:install
 bun run build
 bun test
 ```
+
+`bun install` also installs the tracked Git hooks for the current worktree through
+the `prepare` script. Run `bun run hooks:install` explicitly when re-enabling
+them after changing worktrees or Git configuration.
 
 Before submitting changes, run the full check suite:
 
@@ -31,6 +36,24 @@ bun run typecheck   # Workspace typecheck (includes the daemon backlog tracked i
 bun run lint        # Biome static analysis
 bun run format      # Biome auto-format
 bun test            # All maintained repository tests (excludes vendored references/)
+```
+
+Git hooks
+---
+
+The pre-commit hook runs staged Biome validation and the workspace typecheck.
+The typecheck observes the current working tree rather than reconstructing the
+staged index, so unrelated unstaged changes can affect its result. It also prints
+a documentation reminder when a commit may change user-visible behavior, APIs,
+schemas, configuration, or lifecycle. The documentation step is intentionally
+advisory; it does not run a separate documentation checker.
+
+```bash
+# Reinstall the hooks for this worktree
+bun run hooks:install
+
+# Run the pre-commit checks without creating a commit
+bun run hooks:pre-commit
 ```
 
 Common local loops:

--- a/package.json
+++ b/package.json
@@ -83,7 +83,10 @@
 		"bench": "bun scripts/bench-memory.ts",
 		"bench:ingest": "bun scripts/bench-memory.ts ingest",
 		"bench:evaluate": "bun scripts/bench-memory.ts --resume run --from-phase search",
-		"eval:transcript-import": "bun scripts/evals/transcript-import-real-daemon.ts"
+		"eval:transcript-import": "bun scripts/evals/transcript-import-real-daemon.ts",
+		"hooks:install": "bun scripts/install-git-hooks.ts",
+		"hooks:pre-commit": "bun scripts/pre-commit.ts",
+		"prepare": "bun run hooks:install"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.5",

--- a/scripts/install-git-hooks.test.ts
+++ b/scripts/install-git-hooks.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const installer = join(root, "scripts", "install-git-hooks.ts");
+
+describe("install-git-hooks", () => {
+	test("skips when Git is unavailable", () => {
+		const binDir = mkdtempSync(join(tmpdir(), "signet-no-git-"));
+
+		try {
+			const result = spawnSync(process.execPath, [installer], {
+				encoding: "utf8",
+				env: {
+					...process.env,
+					PATH: binDir,
+				},
+			});
+
+			expect(result.status, result.stderr).toBe(0);
+			expect(result.stdout).toContain("Git executable not found; skipping hook installation.");
+		} finally {
+			rmSync(binDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/scripts/install-git-hooks.ts
+++ b/scripts/install-git-hooks.ts
@@ -30,6 +30,11 @@ function describeFailure(result: GitResult): string {
 }
 
 function main(): void {
+	if (Bun.which("git") === null) {
+		console.log("Git executable not found; skipping hook installation.");
+		return;
+	}
+
 	const repository = runGit(["rev-parse", "--show-toplevel"]);
 	if (repository.exitCode !== 0) {
 		console.log("Git repository not found; skipping hook installation.");

--- a/scripts/install-git-hooks.ts
+++ b/scripts/install-git-hooks.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+interface GitResult {
+	readonly exitCode: number;
+	readonly stderr: string;
+	readonly stdout: string;
+}
+
+function runGit(args: readonly string[]): GitResult {
+	const result = Bun.spawnSync({
+		cmd: ["git", ...args],
+		cwd: ROOT,
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	const decoder = new TextDecoder();
+	return {
+		exitCode: result.exitCode,
+		stderr: decoder.decode(result.stderr),
+		stdout: decoder.decode(result.stdout),
+	};
+}
+
+function describeFailure(result: GitResult): string {
+	return result.stderr.trim() || result.stdout.trim() || `git exited with status ${result.exitCode}`;
+}
+
+function main(): void {
+	const repository = runGit(["rev-parse", "--show-toplevel"]);
+	if (repository.exitCode !== 0) {
+		console.log("Git repository not found; skipping hook installation.");
+		return;
+	}
+
+	if (resolve(repository.stdout.trim()) !== ROOT) {
+		throw new Error(`Git root is not ${ROOT}`);
+	}
+
+	const worktreeConfig = runGit(["config", "--get", "extensions.worktreeConfig"]);
+	if (worktreeConfig.stdout.trim() !== "true") {
+		const enable = runGit(["config", "extensions.worktreeConfig", "true"]);
+		if (enable.exitCode !== 0) {
+			throw new Error(`Could not enable worktree-local Git configuration: ${describeFailure(enable)}`);
+		}
+	}
+
+	const hooks = runGit(["config", "--worktree", "core.hooksPath", ".githooks"]);
+	if (hooks.exitCode !== 0) {
+		throw new Error(`Could not configure the Git hooks path: ${describeFailure(hooks)}`);
+	}
+
+	console.log("Git hooks installed for this worktree: .githooks");
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+}

--- a/scripts/pre-commit.ts
+++ b/scripts/pre-commit.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const BIOME_EXTENSIONS = [
+	".astro",
+	".cjs",
+	".cts",
+	".js",
+	".json",
+	".jsonc",
+	".mjs",
+	".mts",
+	".jsx",
+	".ts",
+	".tsx",
+] as const;
+const BIOME_EXCLUDED_PARTS = new Set([
+	".astro",
+	".bench",
+	".svelte-kit",
+	".wrangler",
+	"build",
+	"built",
+	"coverage",
+	"dist",
+	"fixtures",
+	"generated",
+	"node_modules",
+	"references",
+	"target",
+]);
+
+function stagedFiles(): readonly string[] {
+	const result = Bun.spawnSync({
+		cmd: ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+		cwd: ROOT,
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	if (result.exitCode !== 0) throw new Error("Could not inspect staged files");
+	return new TextDecoder().decode(result.stdout).split("\n").filter(Boolean);
+}
+
+function hasBiomeFiles(): boolean {
+	return stagedFiles().some((file) => {
+		const normalized = file.replaceAll("\\", "/");
+		const extension = BIOME_EXTENSIONS.find((candidate) => normalized.endsWith(candidate));
+		if (extension === undefined) return false;
+		return !normalized.split("/").some((part) => BIOME_EXCLUDED_PARTS.has(part));
+	});
+}
+
+async function run(label: string, command: readonly string[]): Promise<number> {
+	console.log(`\n${label}`);
+	const child = Bun.spawn([...command], {
+		cwd: ROOT,
+		stderr: "inherit",
+		stdout: "inherit",
+	});
+	return child.exited;
+}
+
+async function main(): Promise<void> {
+	console.log(
+		"Documentation reminder: if this commit changes user-visible behavior, APIs, schemas, configuration, or lifecycle, update the owning documentation as necessary.",
+	);
+
+	if (hasBiomeFiles()) {
+		const biome = await run("Running staged Biome validation", ["bun", "run", "biome", "check", "--staged"]);
+		if (biome !== 0) {
+			process.exitCode = biome;
+			return;
+		}
+	} else {
+		console.log("No Biome-supported staged files; skipping staged Biome validation");
+	}
+
+	process.exitCode = await run("Running workspace typecheck", ["bun", "run", "typecheck"]);
+}
+
+if (import.meta.main) await main();

--- a/web/docs/src/content/docs/contributing.md
+++ b/web/docs/src/content/docs/contributing.md
@@ -27,9 +27,14 @@ Contributor workflow, from source:
 git clone https://github.com/Signet-AI/signetai.git
 cd signetai
 bun install
+bun run hooks:install
 bun run build
 bun test
 ```
+
+`bun install` also installs the tracked Git hooks for the current worktree through
+the `prepare` script. Run `bun run hooks:install` explicitly when re-enabling
+them after changing worktrees or Git configuration.
 
 Before submitting changes, run the full check suite:
 
@@ -38,6 +43,24 @@ bun run typecheck   # Workspace typecheck (includes the daemon backlog tracked i
 bun run lint        # Biome static analysis
 bun run format      # Biome auto-format
 bun test            # All maintained repository tests (excludes vendored references/)
+```
+
+Git hooks
+---
+
+The pre-commit hook runs staged Biome validation and the workspace typecheck.
+The typecheck observes the current working tree rather than reconstructing the
+staged index, so unrelated unstaged changes can affect its result. It also prints
+a documentation reminder when a commit may change user-visible behavior, APIs,
+schemas, configuration, or lifecycle. The documentation step is intentionally
+advisory; it does not run a separate documentation checker.
+
+```bash
+# Reinstall the hooks for this worktree
+bun run hooks:install
+
+# Run the pre-commit checks without creating a commit
+bun run hooks:pre-commit
 ```
 
 Common local loops:


### PR DESCRIPTION
## Summary

Adds repository-managed pre-commit hooks so commits run staged Biome validation and the full workspace typecheck. The hook also prints an advisory documentation reminder without running a separate documentation checker.

## Changes

- Add a worktree-safe `.githooks/pre-commit` entrypoint.
- Install the hook path automatically from Bun's `prepare` script, with an explicit `bun run hooks:install` command.
- Run `biome check --staged` only when non-ignored Biome-supported staged files exist.
- Run `bun run typecheck` for every commit, including empty-index amend operations.
- Document the hook setup and advisory documentation reminder in the root and synced contributor docs.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: <!-- specify -->

## Screenshots

Not applicable. This change has no UI changes.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [ ] Input/config validation and bounds checks added
- [ ] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [ ] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- The documentation step is intentionally a reminder only. It does not invoke `doc-drift.ts` or validate a separate documentation artifact.
- The hook was exercised through a real commit, a real empty-index `git commit --amend`, and a docs-only staged commit path.
- The repository-wide `bun test` run completed with 4,739 passing, 25 skipped, 315 failing, and 35 errors across 5,079 tests. The failures were in existing daemon, CLI, desktop, and integration areas; this PR is opened as a draft until the repository test baseline is clarified.
