### PR TITLE
refactor(core): isolate harness integration paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -420,8 +420,11 @@ Signet recognizes these standard identity files at `$SIGNET_WORKSPACE/`:
 | TOOLS.md | no | Tool preferences and notes |
 | BOOTSTRAP.md | no | Setup ritual (typically deleted after first run) |
 
-The `detectExistingSetup()` function in `platform/core/src/identity.ts`
-detects existing setups from OpenClaw, Claude Code, and OpenCode.
+The `detectExistingSetup()` function in `surfaces/cli/src/lib/setup-detection.ts`
+combines shared identity-file checks with harness detection for the setup surface.
+Keep harness-specific installation, managed-file, and configuration policy under
+`integrations/<tool>/`; `platform/core` should expose reusable identity and
+workspace primitives rather than integration-owned setup modules.
 
 Reference Repos
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -420,20 +420,6 @@ Signet recognizes these standard identity files at `$SIGNET_WORKSPACE/`:
 | TOOLS.md | no | Tool preferences and notes |
 | BOOTSTRAP.md | no | Setup ritual (typically deleted after first run) |
 
-The `detectExistingSetup()` function in `surfaces/cli/src/lib/setup-detection.ts`
-combines shared identity-file checks with harness detection for the setup surface.
-Keep harness-specific installation, managed-file, and configuration policy under
-`integrations/<tool>/`; `platform/core` should expose reusable identity and
-workspace primitives rather than integration-owned setup modules.
-
-The harness boundary is also a published API boundary. `@signet/core` no longer
-exports `detectExistingSetup`, `SetupDetection`, or the Oh My Pi/Pi path and
-configuration helpers. Update integration callers to import Oh My Pi helpers from
-`@signet/connector-oh-my-pi`, Pi connector helpers from `@signet/connector-pi`,
-and Pi extension helpers from `@signet/pi-extension-base/agent-dir`. The CLI's
-`surfaces/cli/src/lib/setup-detection.ts` module is an internal CLI composition
-point, not a core API. Compatibility re-exports are intentionally not retained,
-because they would put harness-specific ownership back in `@signet/core`.
 
 Reference Repos
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -426,6 +426,15 @@ Keep harness-specific installation, managed-file, and configuration policy under
 `integrations/<tool>/`; `platform/core` should expose reusable identity and
 workspace primitives rather than integration-owned setup modules.
 
+The harness boundary is also a published API boundary. `@signet/core` no longer
+exports `detectExistingSetup`, `SetupDetection`, or the Oh My Pi/Pi path and
+configuration helpers. Update integration callers to import Oh My Pi helpers from
+`@signet/connector-oh-my-pi`, Pi connector helpers from `@signet/connector-pi`,
+and Pi extension helpers from `@signet/pi-extension-base/agent-dir`. The CLI's
+`surfaces/cli/src/lib/setup-detection.ts` module is an internal CLI composition
+point, not a core API. Compatibility re-exports are intentionally not retained,
+because they would put harness-specific ownership back in `@signet/core`.
+
 Reference Repos
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -246,8 +246,8 @@
         "signet-connector-pi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.217.3",
-        "@signet/core": "0.217.3",
+        "@signet/connector-base": "0.219.6",
+        "@signet/pi-extension-base": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -272,6 +272,7 @@
       "name": "@signet/pi-extension-base",
       "version": "0.219.6",
       "dependencies": {
+        "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
         "@signet/lifecycle-proof": "workspace:*",
       },

--- a/integrations/oh-my-pi/connector/src/agent-dir.ts
+++ b/integrations/oh-my-pi/connector/src/agent-dir.ts
@@ -3,8 +3,6 @@ import { createAgentDir } from "@signet/connector-base/agent-dir";
 const ohMyPiAgentDir = createAgentDir({
 	configFileName: "oh-my-pi.json",
 	defaultAgentDir: ".omp/agent",
-	managedFileNames: ["signet-oh-my-pi.js", "signet-oh-my-pi.mjs"],
-	managedMarker: "SIGNET_MANAGED_OH_MY_PI_EXTENSION",
 });
 
 export const clearConfiguredOhMyPiAgentDir = ohMyPiAgentDir.clearConfiguredAgentDir;

--- a/integrations/oh-my-pi/connector/src/agent-dir.ts
+++ b/integrations/oh-my-pi/connector/src/agent-dir.ts
@@ -1,128 +1,17 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { createAgentDir } from "@signet/connector-base/agent-dir";
 
-const OH_MY_PI_MANAGED_FILENAMES = ["signet-oh-my-pi.js", "signet-oh-my-pi.mjs"] as const;
-const OH_MY_PI_MANAGED_MARKER = "SIGNET_MANAGED_OH_MY_PI_EXTENSION";
+const ohMyPiAgentDir = createAgentDir({
+	configFileName: "oh-my-pi.json",
+	defaultAgentDir: ".omp/agent",
+	managedFileNames: ["signet-oh-my-pi.js", "signet-oh-my-pi.mjs"],
+	managedMarker: "SIGNET_MANAGED_OH_MY_PI_EXTENSION",
+});
 
-interface OhMyPiConfigFile {
-	readonly version: 1;
-	readonly agentDir: string;
-	readonly updatedAt: string;
-}
-
-function readTrimmed(env: NodeJS.ProcessEnv, name: string): string | null {
-	const raw = env[name];
-	if (typeof raw !== "string") return null;
-	const trimmed = raw.trim();
-	return trimmed.length > 0 ? trimmed : null;
-}
-
-function userHome(env: NodeJS.ProcessEnv): string {
-	return env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
-}
-
-function expandUserPath(pathValue: string, env: NodeJS.ProcessEnv): string {
-	const trimmed = pathValue.trim();
-	const home = userHome(env);
-	if (trimmed === "~") return home;
-	if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) return join(home, trimmed.slice(2));
-	return trimmed;
-}
-
-function normalizePath(pathValue: string, env: NodeJS.ProcessEnv): string {
-	return resolve(expandUserPath(pathValue, env));
-}
-
-function readConfigHome(env: NodeJS.ProcessEnv): string {
-	const configured = readTrimmed(env, "XDG_CONFIG_HOME");
-	return configured ? normalizePath(configured, env) : join(userHome(env), ".config");
-}
-
-export function getOhMyPiConfigPath(env: NodeJS.ProcessEnv = process.env): string {
-	return join(readConfigHome(env), "signet", "oh-my-pi.json");
-}
-
-export function readConfiguredOhMyPiAgentDir(env: NodeJS.ProcessEnv = process.env): string | null {
-	const configPath = getOhMyPiConfigPath(env);
-	if (!existsSync(configPath)) return null;
-
-	try {
-		const raw: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
-		if (typeof raw !== "object" || raw === null) return null;
-		const agentDir = Reflect.get(raw, "agentDir");
-		return typeof agentDir === "string" && agentDir.trim().length > 0 ? normalizePath(agentDir, env) : null;
-	} catch {
-		return null;
-	}
-}
-
-/**
- * Resolve the Oh My Pi agent directory.
- *
- * Mirrors the logic of Oh My Pi SDK's `getAgentDir()` (env → default) but
- * adds a persistence layer via `~/.config/signet/oh-my-pi.json` so the CLI
- * remembers the path across sessions even when the env var is unset.
- */
-export function resolveOhMyPiAgentDir(env: NodeJS.ProcessEnv = process.env): string {
-	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) return normalizePath(configured, env);
-	return readConfiguredOhMyPiAgentDir(env) ?? join(userHome(env), ".omp", "agent");
-}
-
-export function resolveOhMyPiExtensionsDir(env: NodeJS.ProcessEnv = process.env): string {
-	return join(resolveOhMyPiAgentDir(env), "extensions");
-}
-
-export function listOhMyPiAgentDirCandidates(env: NodeJS.ProcessEnv = process.env): readonly string[] {
-	const candidates = new Set<string>();
-	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) candidates.add(normalizePath(configured, env));
-	const persisted = readConfiguredOhMyPiAgentDir(env);
-	if (persisted) candidates.add(persisted);
-	candidates.add(join(userHome(env), ".omp", "agent"));
-	return Array.from(candidates);
-}
-
-export function hasOhMyPiSetup(env: NodeJS.ProcessEnv = process.env): boolean {
-	if (existsSync(resolveOhMyPiAgentDir(env))) return true;
-	for (const agentDir of listOhMyPiAgentDirCandidates(env)) {
-		const extensionsDir = join(agentDir, "extensions");
-		for (const filename of OH_MY_PI_MANAGED_FILENAMES) {
-			const extensionPath = join(extensionsDir, filename);
-			if (!existsSync(extensionPath)) continue;
-			try {
-				if (readFileSync(extensionPath, "utf8").includes(OH_MY_PI_MANAGED_MARKER)) return true;
-			} catch {
-				// Ignore unreadable candidate and continue checking others.
-			}
-		}
-	}
-	return false;
-}
-
-export function writeConfiguredOhMyPiAgentDir(pathValue: string, env: NodeJS.ProcessEnv = process.env): string {
-	const agentDir = normalizePath(pathValue, env);
-	const configPath = getOhMyPiConfigPath(env);
-	if (readConfiguredOhMyPiAgentDir(env) === agentDir && existsSync(configPath)) {
-		return configPath;
-	}
-	mkdirSync(dirname(configPath), { recursive: true });
-	const payload: OhMyPiConfigFile = {
-		version: 1,
-		agentDir,
-		updatedAt: new Date().toISOString(),
-	};
-	writeFileSync(configPath, `${JSON.stringify(payload, null, 2)}\n`);
-	return configPath;
-}
-
-export function clearConfiguredOhMyPiAgentDir(env: NodeJS.ProcessEnv = process.env): void {
-	const configPath = getOhMyPiConfigPath(env);
-	if (!existsSync(configPath)) return;
-	try {
-		rmSync(configPath, { force: true });
-	} catch {
-		// best-effort cleanup
-	}
-}
+export const clearConfiguredOhMyPiAgentDir = ohMyPiAgentDir.clearConfiguredAgentDir;
+export const getOhMyPiConfigPath = ohMyPiAgentDir.getConfigPath;
+export const hasOhMyPiSetup = ohMyPiAgentDir.hasSetup;
+export const listOhMyPiAgentDirCandidates = ohMyPiAgentDir.listAgentDirCandidates;
+export const readConfiguredOhMyPiAgentDir = ohMyPiAgentDir.readConfiguredAgentDir;
+export const resolveOhMyPiAgentDir = ohMyPiAgentDir.resolveAgentDir;
+export const resolveOhMyPiExtensionsDir = ohMyPiAgentDir.resolveExtensionsDir;
+export const writeConfiguredOhMyPiAgentDir = ohMyPiAgentDir.writeConfiguredAgentDir;

--- a/integrations/oh-my-pi/connector/src/agent-dir.ts
+++ b/integrations/oh-my-pi/connector/src/agent-dir.ts
@@ -1,7 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { expandHome } from "./constants.js";
+
+const OH_MY_PI_MANAGED_FILENAMES = ["signet-oh-my-pi.js", "signet-oh-my-pi.mjs"] as const;
+const OH_MY_PI_MANAGED_MARKER = "SIGNET_MANAGED_OH_MY_PI_EXTENSION";
 
 interface OhMyPiConfigFile {
 	readonly version: 1;
@@ -16,13 +18,25 @@ function readTrimmed(env: NodeJS.ProcessEnv, name: string): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
-function normalizePath(pathValue: string): string {
-	return resolve(expandHome(pathValue.trim()));
+function userHome(env: NodeJS.ProcessEnv): string {
+	return env.HOME?.trim() || homedir();
+}
+
+function expandUserPath(pathValue: string, env: NodeJS.ProcessEnv): string {
+	const trimmed = pathValue.trim();
+	const home = userHome(env);
+	if (trimmed === "~") return home;
+	if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) return join(home, trimmed.slice(2));
+	return trimmed;
+}
+
+function normalizePath(pathValue: string, env: NodeJS.ProcessEnv): string {
+	return resolve(expandUserPath(pathValue, env));
 }
 
 function readConfigHome(env: NodeJS.ProcessEnv): string {
 	const configured = readTrimmed(env, "XDG_CONFIG_HOME");
-	return configured ? normalizePath(configured) : join(homedir(), ".config");
+	return configured ? normalizePath(configured, env) : join(userHome(env), ".config");
 }
 
 export function getOhMyPiConfigPath(env: NodeJS.ProcessEnv = process.env): string {
@@ -37,7 +51,7 @@ export function readConfiguredOhMyPiAgentDir(env: NodeJS.ProcessEnv = process.en
 		const raw: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
 		if (typeof raw !== "object" || raw === null) return null;
 		const agentDir = Reflect.get(raw, "agentDir");
-		return typeof agentDir === "string" && agentDir.trim().length > 0 ? normalizePath(agentDir) : null;
+		return typeof agentDir === "string" && agentDir.trim().length > 0 ? normalizePath(agentDir, env) : null;
 	} catch {
 		return null;
 	}
@@ -52,8 +66,8 @@ export function readConfiguredOhMyPiAgentDir(env: NodeJS.ProcessEnv = process.en
  */
 export function resolveOhMyPiAgentDir(env: NodeJS.ProcessEnv = process.env): string {
 	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) return normalizePath(configured);
-	return readConfiguredOhMyPiAgentDir(env) ?? join(homedir(), ".omp", "agent");
+	if (configured) return normalizePath(configured, env);
+	return readConfiguredOhMyPiAgentDir(env) ?? join(userHome(env), ".omp", "agent");
 }
 
 export function resolveOhMyPiExtensionsDir(env: NodeJS.ProcessEnv = process.env): string {
@@ -63,15 +77,32 @@ export function resolveOhMyPiExtensionsDir(env: NodeJS.ProcessEnv = process.env)
 export function listOhMyPiAgentDirCandidates(env: NodeJS.ProcessEnv = process.env): readonly string[] {
 	const candidates = new Set<string>();
 	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) candidates.add(normalizePath(configured));
+	if (configured) candidates.add(normalizePath(configured, env));
 	const persisted = readConfiguredOhMyPiAgentDir(env);
 	if (persisted) candidates.add(persisted);
-	candidates.add(join(homedir(), ".omp", "agent"));
+	candidates.add(join(userHome(env), ".omp", "agent"));
 	return Array.from(candidates);
 }
 
+export function hasOhMyPiSetup(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (existsSync(resolveOhMyPiAgentDir(env))) return true;
+	for (const agentDir of listOhMyPiAgentDirCandidates(env)) {
+		const extensionsDir = join(agentDir, "extensions");
+		for (const filename of OH_MY_PI_MANAGED_FILENAMES) {
+			const extensionPath = join(extensionsDir, filename);
+			if (!existsSync(extensionPath)) continue;
+			try {
+				if (readFileSync(extensionPath, "utf8").includes(OH_MY_PI_MANAGED_MARKER)) return true;
+			} catch {
+				// Ignore unreadable candidate and continue checking others.
+			}
+		}
+	}
+	return false;
+}
+
 export function writeConfiguredOhMyPiAgentDir(pathValue: string, env: NodeJS.ProcessEnv = process.env): string {
-	const agentDir = normalizePath(pathValue);
+	const agentDir = normalizePath(pathValue, env);
 	const configPath = getOhMyPiConfigPath(env);
 	if (readConfiguredOhMyPiAgentDir(env) === agentDir && existsSync(configPath)) {
 		return configPath;

--- a/integrations/oh-my-pi/connector/src/agent-dir.ts
+++ b/integrations/oh-my-pi/connector/src/agent-dir.ts
@@ -19,7 +19,7 @@ function readTrimmed(env: NodeJS.ProcessEnv, name: string): string | null {
 }
 
 function userHome(env: NodeJS.ProcessEnv): string {
-	return env.HOME?.trim() || homedir();
+	return env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
 }
 
 function expandUserPath(pathValue: string, env: NodeJS.ProcessEnv): string {

--- a/integrations/oh-my-pi/connector/src/index.ts
+++ b/integrations/oh-my-pi/connector/src/index.ts
@@ -3,7 +3,6 @@ import { dirname, join } from "node:path";
 import {
 	BaseConnector,
 	type InstallResult,
-	MANAGED_AGENT_ID_DEFAULT,
 	MANAGED_DAEMON_URL_DEFAULT,
 	type UninstallResult,
 	buildManagedExtensionContent,
@@ -17,14 +16,25 @@ import {
 } from "@signet/connector-base";
 import {
 	clearConfiguredOhMyPiAgentDir,
-	expandHome,
 	getOhMyPiConfigPath,
 	listOhMyPiAgentDirCandidates,
 	resolveOhMyPiAgentDir,
 	resolveOhMyPiExtensionsDir,
 	writeConfiguredOhMyPiAgentDir,
-} from "@signet/core";
+} from "./agent-dir.js";
+import { expandHome } from "@signet/core";
 import { EXTENSION_BUNDLE } from "./extension-bundle.js";
+
+export {
+	clearConfiguredOhMyPiAgentDir,
+	getOhMyPiConfigPath,
+	hasOhMyPiSetup,
+	listOhMyPiAgentDirCandidates,
+	readConfiguredOhMyPiAgentDir,
+	resolveOhMyPiAgentDir,
+	resolveOhMyPiExtensionsDir,
+	writeConfiguredOhMyPiAgentDir,
+} from "./agent-dir.js";
 
 const OH_MY_PI_EXTENSION_PACKAGE = "@signet/oh-my-pi-extension";
 const OH_MY_PI_EXTENSION_ENTRY = "dist/signet-oh-my-pi.mjs";
@@ -53,10 +63,6 @@ export class OhMyPiConnector extends BaseConnector {
 
 	private getManagedExtensionPath(): string {
 		return join(resolveOhMyPiExtensionsDir(), OH_MY_PI_MANAGED_FILENAME);
-	}
-
-	private getLegacyManagedExtensionPath(): string {
-		return join(resolveOhMyPiExtensionsDir(), OH_MY_PI_LEGACY_MANAGED_FILENAME);
 	}
 
 	private getManagedCandidatePaths(filename: string): readonly string[] {

--- a/integrations/pi/connector/index.test.ts
+++ b/integrations/pi/connector/index.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolvePiAgentDir } from "@signet/pi-extension-base/agent-dir";
 import { EXTENSION_BUNDLE } from "./src/extension-bundle.js";
 import { PiConnector } from "./src/index.js";
 
@@ -35,8 +36,7 @@ beforeEach(() => {
 	process.env.SIGNET_AGENT_ID = "agent-from-env";
 	process.env.SIGNET_DAEMON_URL = "http://127.0.0.1:4123";
 	process.env.SIGNET_API_KEY = "sig_sk_test_connector";
-	// biome-ignore lint/performance/noDelete: assigning undefined to process.env stores the string "undefined"
-	delete process.env.SIGNET_PATH;
+	Reflect.deleteProperty(process.env, "SIGNET_PATH");
 });
 
 afterEach(() => {
@@ -53,6 +53,12 @@ afterEach(() => {
 });
 
 describe("PiConnector", () => {
+	it("preserves Pi's legacy expansion for any tilde-prefixed agent dir", () => {
+		process.env.PI_CODING_AGENT_DIR = "~foo";
+
+		expect(resolvePiAgentDir()).toBe(join(tmpRoot, "foo"));
+	});
+
 	it("installs a bundled managed extension without external package resolution", async () => {
 		const connector = new PiConnector();
 		const result = await connector.install(tmpRoot);

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@signet/connector-base": "0.219.6",
-		"@signet/core": "0.219.6"
+		"@signet/pi-extension-base": "workspace:*"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/integrations/pi/connector/src/index.ts
+++ b/integrations/pi/connector/src/index.ts
@@ -3,7 +3,6 @@ import { dirname, join } from "node:path";
 import {
 	BaseConnector,
 	type InstallResult,
-	MANAGED_AGENT_ID_DEFAULT,
 	MANAGED_DAEMON_URL_DEFAULT,
 	type UninstallResult,
 	buildManagedExtensionContent,
@@ -22,8 +21,19 @@ import {
 	resolvePiAgentDir,
 	resolvePiExtensionsDir,
 	writeConfiguredPiAgentDir,
-} from "@signet/core";
+} from "@signet/pi-extension-base/agent-dir";
 import { EXTENSION_BUNDLE } from "./extension-bundle.js";
+
+export {
+	clearConfiguredPiAgentDir,
+	getPiConfigPath,
+	hasPiSetup,
+	listPiAgentDirCandidates,
+	readConfiguredPiAgentDir,
+	resolvePiAgentDir,
+	resolvePiExtensionsDir,
+	writeConfiguredPiAgentDir,
+} from "@signet/pi-extension-base/agent-dir";
 
 const PI_EXTENSION_PACKAGE = "@signet/pi-extension";
 const PI_EXTENSION_ENTRY = "dist/signet-pi.mjs";

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -6,7 +6,8 @@
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./agent-dir": "./src/agent-dir.ts"
 	},
 	"dependencies": {
 		"@signet/core": "workspace:*",

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -10,6 +10,7 @@
 		"./agent-dir": "./src/agent-dir.ts"
 	},
 	"dependencies": {
+		"@signet/connector-base": "workspace:*",
 		"@signet/core": "workspace:*",
 		"@signet/lifecycle-proof": "workspace:*"
 	},

--- a/integrations/pi/extension-base/src/agent-dir.ts
+++ b/integrations/pi/extension-base/src/agent-dir.ts
@@ -2,6 +2,9 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
+const PI_MANAGED_FILENAMES = ["signet-pi.js", "signet-pi.mjs"] as const;
+const PI_MANAGED_MARKER = "SIGNET_MANAGED_PI_EXTENSION";
+
 interface PiConfigFile {
 	readonly version: 1;
 	readonly agentDir: string;
@@ -15,21 +18,26 @@ function readTrimmed(env: NodeJS.ProcessEnv, name: string): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
-function expandUserPath(pathValue: string): string {
+function userHome(env: NodeJS.ProcessEnv): string {
+	return env.HOME?.trim() || homedir();
+}
+
+function expandUserPath(pathValue: string, env: NodeJS.ProcessEnv): string {
 	const trimmed = pathValue.trim();
-	if (trimmed === "~") return homedir();
-	if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
-	if (trimmed.startsWith("~")) return join(homedir(), trimmed.slice(1));
+	const home = userHome(env);
+	if (trimmed === "~") return home;
+	if (trimmed.startsWith("~/")) return join(home, trimmed.slice(2));
+	if (trimmed.startsWith("~")) return join(home, trimmed.slice(1));
 	return trimmed;
 }
 
-function normalizePath(pathValue: string): string {
-	return resolve(expandUserPath(pathValue));
+function normalizePath(pathValue: string, env: NodeJS.ProcessEnv): string {
+	return resolve(expandUserPath(pathValue, env));
 }
 
 function readConfigHome(env: NodeJS.ProcessEnv): string {
 	const configured = readTrimmed(env, "XDG_CONFIG_HOME");
-	return configured ? normalizePath(configured) : join(homedir(), ".config");
+	return configured ? normalizePath(configured, env) : join(userHome(env), ".config");
 }
 
 export function getPiConfigPath(env: NodeJS.ProcessEnv = process.env): string {
@@ -44,7 +52,7 @@ export function readConfiguredPiAgentDir(env: NodeJS.ProcessEnv = process.env): 
 		const raw: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
 		if (typeof raw !== "object" || raw === null) return null;
 		const agentDir = Reflect.get(raw, "agentDir");
-		return typeof agentDir === "string" && agentDir.trim().length > 0 ? normalizePath(agentDir) : null;
+		return typeof agentDir === "string" && agentDir.trim().length > 0 ? normalizePath(agentDir, env) : null;
 	} catch {
 		return null;
 	}
@@ -59,8 +67,8 @@ export function readConfiguredPiAgentDir(env: NodeJS.ProcessEnv = process.env): 
  */
 export function resolvePiAgentDir(env: NodeJS.ProcessEnv = process.env): string {
 	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) return normalizePath(configured);
-	return readConfiguredPiAgentDir(env) ?? join(homedir(), ".pi", "agent");
+	if (configured) return normalizePath(configured, env);
+	return readConfiguredPiAgentDir(env) ?? join(userHome(env), ".pi", "agent");
 }
 
 export function resolvePiExtensionsDir(env: NodeJS.ProcessEnv = process.env): string {
@@ -70,15 +78,32 @@ export function resolvePiExtensionsDir(env: NodeJS.ProcessEnv = process.env): st
 export function listPiAgentDirCandidates(env: NodeJS.ProcessEnv = process.env): readonly string[] {
 	const candidates = new Set<string>();
 	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) candidates.add(normalizePath(configured));
+	if (configured) candidates.add(normalizePath(configured, env));
 	const persisted = readConfiguredPiAgentDir(env);
 	if (persisted) candidates.add(persisted);
-	candidates.add(join(homedir(), ".pi", "agent"));
+	candidates.add(join(userHome(env), ".pi", "agent"));
 	return Array.from(candidates);
 }
 
+export function hasPiSetup(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (existsSync(resolvePiAgentDir(env))) return true;
+	for (const agentDir of listPiAgentDirCandidates(env)) {
+		const extensionsDir = join(agentDir, "extensions");
+		for (const filename of PI_MANAGED_FILENAMES) {
+			const extensionPath = join(extensionsDir, filename);
+			if (!existsSync(extensionPath)) continue;
+			try {
+				if (readFileSync(extensionPath, "utf8").includes(PI_MANAGED_MARKER)) return true;
+			} catch {
+				// Ignore unreadable candidate and continue checking others.
+			}
+		}
+	}
+	return false;
+}
+
 export function writeConfiguredPiAgentDir(pathValue: string, env: NodeJS.ProcessEnv = process.env): string {
-	const agentDir = normalizePath(pathValue);
+	const agentDir = normalizePath(pathValue, env);
 	const configPath = getPiConfigPath(env);
 	if (readConfiguredPiAgentDir(env) === agentDir && existsSync(configPath)) {
 		return configPath;

--- a/integrations/pi/extension-base/src/agent-dir.ts
+++ b/integrations/pi/extension-base/src/agent-dir.ts
@@ -3,8 +3,6 @@ import { createAgentDir } from "@signet/connector-base/agent-dir";
 const piAgentDir = createAgentDir({
 	configFileName: "pi.json",
 	defaultAgentDir: ".pi/agent",
-	managedFileNames: ["signet-pi.js", "signet-pi.mjs"],
-	managedMarker: "SIGNET_MANAGED_PI_EXTENSION",
 });
 
 export const clearConfiguredPiAgentDir = piAgentDir.clearConfiguredAgentDir;

--- a/integrations/pi/extension-base/src/agent-dir.ts
+++ b/integrations/pi/extension-base/src/agent-dir.ts
@@ -1,129 +1,17 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { createAgentDir } from "@signet/connector-base/agent-dir";
 
-const PI_MANAGED_FILENAMES = ["signet-pi.js", "signet-pi.mjs"] as const;
-const PI_MANAGED_MARKER = "SIGNET_MANAGED_PI_EXTENSION";
+const piAgentDir = createAgentDir({
+	configFileName: "pi.json",
+	defaultAgentDir: ".pi/agent",
+	managedFileNames: ["signet-pi.js", "signet-pi.mjs"],
+	managedMarker: "SIGNET_MANAGED_PI_EXTENSION",
+});
 
-interface PiConfigFile {
-	readonly version: 1;
-	readonly agentDir: string;
-	readonly updatedAt: string;
-}
-
-function readTrimmed(env: NodeJS.ProcessEnv, name: string): string | null {
-	const raw = env[name];
-	if (typeof raw !== "string") return null;
-	const trimmed = raw.trim();
-	return trimmed.length > 0 ? trimmed : null;
-}
-
-function userHome(env: NodeJS.ProcessEnv): string {
-	return env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
-}
-
-function expandUserPath(pathValue: string, env: NodeJS.ProcessEnv): string {
-	const trimmed = pathValue.trim();
-	const home = userHome(env);
-	if (trimmed === "~") return home;
-	if (trimmed.startsWith("~/")) return join(home, trimmed.slice(2));
-	if (trimmed.startsWith("~")) return join(home, trimmed.slice(1));
-	return trimmed;
-}
-
-function normalizePath(pathValue: string, env: NodeJS.ProcessEnv): string {
-	return resolve(expandUserPath(pathValue, env));
-}
-
-function readConfigHome(env: NodeJS.ProcessEnv): string {
-	const configured = readTrimmed(env, "XDG_CONFIG_HOME");
-	return configured ? normalizePath(configured, env) : join(userHome(env), ".config");
-}
-
-export function getPiConfigPath(env: NodeJS.ProcessEnv = process.env): string {
-	return join(readConfigHome(env), "signet", "pi.json");
-}
-
-export function readConfiguredPiAgentDir(env: NodeJS.ProcessEnv = process.env): string | null {
-	const configPath = getPiConfigPath(env);
-	if (!existsSync(configPath)) return null;
-
-	try {
-		const raw: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
-		if (typeof raw !== "object" || raw === null) return null;
-		const agentDir = Reflect.get(raw, "agentDir");
-		return typeof agentDir === "string" && agentDir.trim().length > 0 ? normalizePath(agentDir, env) : null;
-	} catch {
-		return null;
-	}
-}
-
-/**
- * Resolve the Pi agent directory.
- *
- * Mirrors the logic of Pi SDK's `getAgentDir()` (env → default) but adds
- * a persistence layer via `~/.config/signet/pi.json` so the CLI remembers
- * the path across sessions even when the env var is unset.
- */
-export function resolvePiAgentDir(env: NodeJS.ProcessEnv = process.env): string {
-	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) return normalizePath(configured, env);
-	return readConfiguredPiAgentDir(env) ?? join(userHome(env), ".pi", "agent");
-}
-
-export function resolvePiExtensionsDir(env: NodeJS.ProcessEnv = process.env): string {
-	return join(resolvePiAgentDir(env), "extensions");
-}
-
-export function listPiAgentDirCandidates(env: NodeJS.ProcessEnv = process.env): readonly string[] {
-	const candidates = new Set<string>();
-	const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-	if (configured) candidates.add(normalizePath(configured, env));
-	const persisted = readConfiguredPiAgentDir(env);
-	if (persisted) candidates.add(persisted);
-	candidates.add(join(userHome(env), ".pi", "agent"));
-	return Array.from(candidates);
-}
-
-export function hasPiSetup(env: NodeJS.ProcessEnv = process.env): boolean {
-	if (existsSync(resolvePiAgentDir(env))) return true;
-	for (const agentDir of listPiAgentDirCandidates(env)) {
-		const extensionsDir = join(agentDir, "extensions");
-		for (const filename of PI_MANAGED_FILENAMES) {
-			const extensionPath = join(extensionsDir, filename);
-			if (!existsSync(extensionPath)) continue;
-			try {
-				if (readFileSync(extensionPath, "utf8").includes(PI_MANAGED_MARKER)) return true;
-			} catch {
-				// Ignore unreadable candidate and continue checking others.
-			}
-		}
-	}
-	return false;
-}
-
-export function writeConfiguredPiAgentDir(pathValue: string, env: NodeJS.ProcessEnv = process.env): string {
-	const agentDir = normalizePath(pathValue, env);
-	const configPath = getPiConfigPath(env);
-	if (readConfiguredPiAgentDir(env) === agentDir && existsSync(configPath)) {
-		return configPath;
-	}
-	mkdirSync(dirname(configPath), { recursive: true });
-	const payload: PiConfigFile = {
-		version: 1,
-		agentDir,
-		updatedAt: new Date().toISOString(),
-	};
-	writeFileSync(configPath, `${JSON.stringify(payload, null, 2)}\n`);
-	return configPath;
-}
-
-export function clearConfiguredPiAgentDir(env: NodeJS.ProcessEnv = process.env): void {
-	const configPath = getPiConfigPath(env);
-	if (!existsSync(configPath)) return;
-	try {
-		rmSync(configPath, { force: true });
-	} catch {
-		// best-effort cleanup
-	}
-}
+export const clearConfiguredPiAgentDir = piAgentDir.clearConfiguredAgentDir;
+export const getPiConfigPath = piAgentDir.getConfigPath;
+export const hasPiSetup = piAgentDir.hasSetup;
+export const listPiAgentDirCandidates = piAgentDir.listAgentDirCandidates;
+export const readConfiguredPiAgentDir = piAgentDir.readConfiguredAgentDir;
+export const resolvePiAgentDir = piAgentDir.resolveAgentDir;
+export const resolvePiExtensionsDir = piAgentDir.resolveExtensionsDir;
+export const writeConfiguredPiAgentDir = piAgentDir.writeConfiguredAgentDir;

--- a/integrations/pi/extension-base/src/agent-dir.ts
+++ b/integrations/pi/extension-base/src/agent-dir.ts
@@ -19,7 +19,7 @@ function readTrimmed(env: NodeJS.ProcessEnv, name: string): string | null {
 }
 
 function userHome(env: NodeJS.ProcessEnv): string {
-	return env.HOME?.trim() || homedir();
+	return env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
 }
 
 function expandUserPath(pathValue: string, env: NodeJS.ProcessEnv): string {

--- a/integrations/pi/extension-base/src/agent-dir.ts
+++ b/integrations/pi/extension-base/src/agent-dir.ts
@@ -3,6 +3,7 @@ import { createAgentDir } from "@signet/connector-base/agent-dir";
 const piAgentDir = createAgentDir({
 	configFileName: "pi.json",
 	defaultAgentDir: ".pi/agent",
+	legacyTildeExpansion: true,
 });
 
 export const clearConfiguredPiAgentDir = piAgentDir.clearConfiguredAgentDir;

--- a/integrations/pi/extension-base/src/index.ts
+++ b/integrations/pi/extension-base/src/index.ts
@@ -5,6 +5,17 @@ export {
 	readTrimmedRuntimeEnv,
 } from "./helpers.js";
 
+export {
+	clearConfiguredPiAgentDir,
+	getPiConfigPath,
+	hasPiSetup,
+	listPiAgentDirCandidates,
+	readConfiguredPiAgentDir,
+	resolvePiAgentDir,
+	resolvePiExtensionsDir,
+	writeConfiguredPiAgentDir,
+} from "./agent-dir.js";
+
 export type {
 	BaseAgentMessage,
 	BaseExtensionContext,

--- a/integrations/pi/extension/src/index.ts
+++ b/integrations/pi/extension/src/index.ts
@@ -1,13 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-	buildRecallRequestBody,
-	buildRememberRequestBody,
-	formatRecallText,
-	parseRecallPayload,
-	resolvePiAgentDir,
-} from "@signet/core";
+import { buildRecallRequestBody, buildRememberRequestBody, formatRecallText, parseRecallPayload } from "@signet/core";
 import type { RecallPayload } from "@signet/core";
+import { resolvePiAgentDir } from "@signet/pi-extension-base/agent-dir";
 import { readRuntimeEnv, readTrimmedRuntimeEnv, readTrimmedString } from "@signet/pi-extension-base";
 import { Type } from "@sinclair/typebox";
 import { createDaemonClient } from "./daemon-client.js";

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -10,6 +10,10 @@
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		},
+		"./agent-dir": {
+			"import": "./dist/agent-dir.js",
+			"types": "./dist/agent-dir.d.ts"
+		},
 		"./lenient-json": {
 			"import": "./dist/lenient-json.js",
 			"types": "./dist/lenient-json.d.ts"
@@ -21,7 +25,7 @@
 		"!dist/**/__tests__/**"
 	],
 	"scripts": {
-		"build": "bun build ./src/index.ts ./src/lenient-json.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
+		"build": "bun build ./src/index.ts ./src/agent-dir.ts ./src/lenient-json.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
 		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
 		"typecheck": "tsc --noEmit"
 	},

--- a/libs/connector-base/src/agent-dir.ts
+++ b/libs/connector-base/src/agent-dir.ts
@@ -6,6 +6,7 @@ import { expandHome } from "@signet/core";
 export interface AgentDirConfig {
 	readonly configFileName: string;
 	readonly defaultAgentDir: string;
+	readonly legacyTildeExpansion?: boolean;
 }
 
 export interface AgentDir {
@@ -30,18 +31,22 @@ function userHome(env: NodeJS.ProcessEnv): string {
 	return env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
 }
 
-function normalizePath(pathValue: string, env: NodeJS.ProcessEnv): string {
-	return resolve(expandHome(pathValue.trim(), userHome(env)));
+function normalizePath(pathValue: string, env: NodeJS.ProcessEnv, legacyTildeExpansion = false): string {
+	const trimmed = pathValue.trim();
+	const home = userHome(env);
+	const expanded =
+		legacyTildeExpansion && trimmed.startsWith("~") ? join(home, trimmed.slice(1)) : expandHome(trimmed, home);
+	return resolve(expanded);
 }
 
-function readConfigHome(env: NodeJS.ProcessEnv): string {
+function readConfigHome(env: NodeJS.ProcessEnv, legacyTildeExpansion = false): string {
 	const configured = readTrimmed(env, "XDG_CONFIG_HOME");
-	return configured === null ? join(userHome(env), ".config") : normalizePath(configured, env);
+	return configured === null ? join(userHome(env), ".config") : normalizePath(configured, env, legacyTildeExpansion);
 }
 
 export function createAgentDir(config: AgentDirConfig): AgentDir {
 	const getConfigPath = (env: NodeJS.ProcessEnv = process.env): string =>
-		join(readConfigHome(env), "signet", config.configFileName);
+		join(readConfigHome(env, config.legacyTildeExpansion), "signet", config.configFileName);
 
 	const readConfiguredAgentDir = (env: NodeJS.ProcessEnv = process.env): string | null => {
 		try {
@@ -49,7 +54,7 @@ export function createAgentDir(config: AgentDirConfig): AgentDir {
 			if (typeof raw !== "object" || raw === null) return null;
 			const agentDir = Reflect.get(raw, "agentDir");
 			if (typeof agentDir !== "string" || agentDir.trim().length === 0) return null;
-			return normalizePath(agentDir, env);
+			return normalizePath(agentDir, env, config.legacyTildeExpansion);
 		} catch {
 			return null;
 		}
@@ -57,7 +62,7 @@ export function createAgentDir(config: AgentDirConfig): AgentDir {
 
 	const resolveAgentDir = (env: NodeJS.ProcessEnv = process.env): string => {
 		const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-		if (configured !== null) return normalizePath(configured, env);
+		if (configured !== null) return normalizePath(configured, env, config.legacyTildeExpansion);
 		return readConfiguredAgentDir(env) ?? join(userHome(env), config.defaultAgentDir);
 	};
 
@@ -67,7 +72,7 @@ export function createAgentDir(config: AgentDirConfig): AgentDir {
 	const listAgentDirCandidates = (env: NodeJS.ProcessEnv = process.env): readonly string[] => {
 		const candidates = new Set<string>();
 		const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
-		if (configured !== null) candidates.add(normalizePath(configured, env));
+		if (configured !== null) candidates.add(normalizePath(configured, env, config.legacyTildeExpansion));
 		const persisted = readConfiguredAgentDir(env);
 		if (persisted !== null) candidates.add(persisted);
 		candidates.add(join(userHome(env), config.defaultAgentDir));
@@ -78,7 +83,7 @@ export function createAgentDir(config: AgentDirConfig): AgentDir {
 		listAgentDirCandidates(env).some((agentDir) => existsSync(agentDir));
 
 	const writeConfiguredAgentDir = (pathValue: string, env: NodeJS.ProcessEnv = process.env): string => {
-		const agentDir = normalizePath(pathValue, env);
+		const agentDir = normalizePath(pathValue, env, config.legacyTildeExpansion);
 		const configPath = getConfigPath(env);
 		if (readConfiguredAgentDir(env) === agentDir) return configPath;
 		mkdirSync(dirname(configPath), { recursive: true });

--- a/libs/connector-base/src/agent-dir.ts
+++ b/libs/connector-base/src/agent-dir.ts
@@ -6,8 +6,6 @@ import { expandHome } from "@signet/core";
 export interface AgentDirConfig {
 	readonly configFileName: string;
 	readonly defaultAgentDir: string;
-	readonly managedFileNames: readonly string[];
-	readonly managedMarker: string;
 }
 
 export interface AgentDir {
@@ -76,19 +74,8 @@ export function createAgentDir(config: AgentDirConfig): AgentDir {
 		return Array.from(candidates);
 	};
 
-	const hasSetup = (env: NodeJS.ProcessEnv = process.env): boolean => {
-		for (const agentDir of listAgentDirCandidates(env)) {
-			if (existsSync(agentDir)) return true;
-			for (const filename of config.managedFileNames) {
-				try {
-					if (readFileSync(join(agentDir, "extensions", filename), "utf8").includes(config.managedMarker)) return true;
-				} catch {
-					// Ignore unreadable candidates and continue checking others.
-				}
-			}
-		}
-		return false;
-	};
+	const hasSetup = (env: NodeJS.ProcessEnv = process.env): boolean =>
+		listAgentDirCandidates(env).some((agentDir) => existsSync(agentDir));
 
 	const writeConfiguredAgentDir = (pathValue: string, env: NodeJS.ProcessEnv = process.env): string => {
 		const agentDir = normalizePath(pathValue, env);

--- a/libs/connector-base/src/agent-dir.ts
+++ b/libs/connector-base/src/agent-dir.ts
@@ -1,0 +1,123 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { expandHome } from "@signet/core";
+
+export interface AgentDirConfig {
+	readonly configFileName: string;
+	readonly defaultAgentDir: string;
+	readonly managedFileNames: readonly string[];
+	readonly managedMarker: string;
+}
+
+export interface AgentDir {
+	readonly getConfigPath: (env?: NodeJS.ProcessEnv) => string;
+	readonly readConfiguredAgentDir: (env?: NodeJS.ProcessEnv) => string | null;
+	readonly resolveAgentDir: (env?: NodeJS.ProcessEnv) => string;
+	readonly resolveExtensionsDir: (env?: NodeJS.ProcessEnv) => string;
+	readonly listAgentDirCandidates: (env?: NodeJS.ProcessEnv) => readonly string[];
+	readonly hasSetup: (env?: NodeJS.ProcessEnv) => boolean;
+	readonly writeConfiguredAgentDir: (pathValue: string, env?: NodeJS.ProcessEnv) => string;
+	readonly clearConfiguredAgentDir: (env?: NodeJS.ProcessEnv) => void;
+}
+
+function readTrimmed(env: NodeJS.ProcessEnv, name: string): string | null {
+	const raw = env[name];
+	if (typeof raw !== "string") return null;
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function userHome(env: NodeJS.ProcessEnv): string {
+	return env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
+}
+
+function normalizePath(pathValue: string, env: NodeJS.ProcessEnv): string {
+	return resolve(expandHome(pathValue.trim(), userHome(env)));
+}
+
+function readConfigHome(env: NodeJS.ProcessEnv): string {
+	const configured = readTrimmed(env, "XDG_CONFIG_HOME");
+	return configured === null ? join(userHome(env), ".config") : normalizePath(configured, env);
+}
+
+export function createAgentDir(config: AgentDirConfig): AgentDir {
+	const getConfigPath = (env: NodeJS.ProcessEnv = process.env): string =>
+		join(readConfigHome(env), "signet", config.configFileName);
+
+	const readConfiguredAgentDir = (env: NodeJS.ProcessEnv = process.env): string | null => {
+		try {
+			const raw: unknown = JSON.parse(readFileSync(getConfigPath(env), "utf8"));
+			if (typeof raw !== "object" || raw === null) return null;
+			const agentDir = Reflect.get(raw, "agentDir");
+			if (typeof agentDir !== "string" || agentDir.trim().length === 0) return null;
+			return normalizePath(agentDir, env);
+		} catch {
+			return null;
+		}
+	};
+
+	const resolveAgentDir = (env: NodeJS.ProcessEnv = process.env): string => {
+		const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
+		if (configured !== null) return normalizePath(configured, env);
+		return readConfiguredAgentDir(env) ?? join(userHome(env), config.defaultAgentDir);
+	};
+
+	const resolveExtensionsDir = (env: NodeJS.ProcessEnv = process.env): string =>
+		join(resolveAgentDir(env), "extensions");
+
+	const listAgentDirCandidates = (env: NodeJS.ProcessEnv = process.env): readonly string[] => {
+		const candidates = new Set<string>();
+		const configured = readTrimmed(env, "PI_CODING_AGENT_DIR");
+		if (configured !== null) candidates.add(normalizePath(configured, env));
+		const persisted = readConfiguredAgentDir(env);
+		if (persisted !== null) candidates.add(persisted);
+		candidates.add(join(userHome(env), config.defaultAgentDir));
+		return Array.from(candidates);
+	};
+
+	const hasSetup = (env: NodeJS.ProcessEnv = process.env): boolean => {
+		for (const agentDir of listAgentDirCandidates(env)) {
+			if (existsSync(agentDir)) return true;
+			for (const filename of config.managedFileNames) {
+				try {
+					if (readFileSync(join(agentDir, "extensions", filename), "utf8").includes(config.managedMarker)) return true;
+				} catch {
+					// Ignore unreadable candidates and continue checking others.
+				}
+			}
+		}
+		return false;
+	};
+
+	const writeConfiguredAgentDir = (pathValue: string, env: NodeJS.ProcessEnv = process.env): string => {
+		const agentDir = normalizePath(pathValue, env);
+		const configPath = getConfigPath(env);
+		if (readConfiguredAgentDir(env) === agentDir) return configPath;
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(
+			configPath,
+			`${JSON.stringify({ version: 1, agentDir, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+		);
+		return configPath;
+	};
+
+	const clearConfiguredAgentDir = (env: NodeJS.ProcessEnv = process.env): void => {
+		try {
+			rmSync(getConfigPath(env), { force: true });
+		} catch {
+			// Best-effort cleanup.
+		}
+	};
+
+	return {
+		getConfigPath,
+		readConfiguredAgentDir,
+		resolveAgentDir,
+		resolveExtensionsDir,
+		listAgentDirCandidates,
+		hasSetup,
+		writeConfiguredAgentDir,
+		clearConfiguredAgentDir,
+	};
+}

--- a/platform/core/src/__tests__/identity.test.ts
+++ b/platform/core/src/__tests__/identity.test.ts
@@ -6,7 +6,6 @@ import { join } from "node:path";
 import { buildAgentMemoryConfig, getAgentIdentityFiles, normalizeAgentRosterEntry, scaffoldAgent } from "../agents";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
-	detectExistingSetup,
 	getMissingIdentityFiles,
 	hasValidIdentity,
 	loadIdentityMode,
@@ -23,44 +22,32 @@ const TMP = join(tmpdir(), `signet-identity-test-${Date.now()}`);
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_HERMES_REPO = process.env.HERMES_REPO;
 const ORIGINAL_HERMES_HOME = process.env.HERMES_HOME;
-const ORIGINAL_FORGE_CONFIG = process.env.FORGE_CONFIG;
 const ORIGINAL_KIMI_SHARE_DIR = process.env.KIMI_SHARE_DIR;
 const ORIGINAL_KIMI_CODE_HOME = process.env.KIMI_CODE_HOME;
 
 beforeEach(() => mkdirSync(TMP, { recursive: true }));
 afterEach(() => {
 	if (ORIGINAL_HOME === undefined) {
-		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 		delete process.env.HOME;
 	} else {
 		process.env.HOME = ORIGINAL_HOME;
 	}
 	if (ORIGINAL_HERMES_REPO === undefined) {
-		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 		delete process.env.HERMES_REPO;
 	} else {
 		process.env.HERMES_REPO = ORIGINAL_HERMES_REPO;
 	}
 	if (ORIGINAL_HERMES_HOME === undefined) {
-		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 		delete process.env.HERMES_HOME;
 	} else {
 		process.env.HERMES_HOME = ORIGINAL_HERMES_HOME;
 	}
-	if (ORIGINAL_FORGE_CONFIG === undefined) {
-		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
-		delete process.env.FORGE_CONFIG;
-	} else {
-		process.env.FORGE_CONFIG = ORIGINAL_FORGE_CONFIG;
-	}
 	if (ORIGINAL_KIMI_SHARE_DIR === undefined) {
-		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 		delete process.env.KIMI_SHARE_DIR;
 	} else {
 		process.env.KIMI_SHARE_DIR = ORIGINAL_KIMI_SHARE_DIR;
 	}
 	if (ORIGINAL_KIMI_CODE_HOME === undefined) {
-		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 		delete process.env.KIMI_CODE_HOME;
 	} else {
 		process.env.KIMI_CODE_HOME = ORIGINAL_KIMI_CODE_HOME;
@@ -280,87 +267,6 @@ describe("parseRuntimeYaml", () => {
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe("");
 		expect(result.stderr).not.toContain(secret);
-	});
-});
-
-describe("detectExistingSetup", () => {
-	test("detects Hermes Agent in the default ~/.hermes install path", () => {
-		process.env.HOME = TMP;
-		mkdirSync(join(TMP, ".hermes", "plugins", "memory"), { recursive: true });
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects Hermes Agent from HERMES_HOME without HERMES_REPO", () => {
-		const hermesHome = join(TMP, "custom-hermes-home");
-		process.env.HERMES_HOME = hermesHome;
-		mkdirSync(join(hermesHome, "plugins", "memory"), { recursive: true });
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects Hermes Agent in the managed ~/.hermes/hermes-agent checkout", () => {
-		process.env.HOME = TMP;
-		mkdirSync(join(TMP, ".hermes", "hermes-agent", "plugins", "memory"), { recursive: true });
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects Hermes Agent before the Signet memory plugin is installed", () => {
-		const hermesRepo = join(TMP, "hermes-agent");
-		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
-		process.env.HERMES_REPO = hermesRepo;
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects ForgeCode from the default ~/.forge config path", () => {
-		process.env.HOME = TMP;
-		mkdirSync(join(TMP, ".forge"), { recursive: true });
-		writeFileSync(join(TMP, ".forge", ".mcp.json"), "{}\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.forge).toBe(true);
-	});
-
-	test("detects ForgeCode from the legacy ~/forge config path", () => {
-		process.env.HOME = TMP;
-		mkdirSync(join(TMP, "forge"), { recursive: true });
-		writeFileSync(join(TMP, "forge", ".forge.toml"), "# config\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.forge).toBe(true);
-	});
-
-	test("detects Kimi from the current ~/.kimi config home", () => {
-		process.env.HOME = TMP;
-		mkdirSync(join(TMP, ".kimi"), { recursive: true });
-		writeFileSync(join(TMP, ".kimi", "config.toml"), "[loop_control]\nmax_steps = 10\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.kimi).toBe(true);
-	});
-
-	test("detects Kimi from the legacy KIMI_CODE_HOME override", () => {
-		const legacyHome = join(TMP, "legacy-kimi");
-		process.env.KIMI_CODE_HOME = legacyHome;
-		mkdirSync(legacyHome, { recursive: true });
-		writeFileSync(join(legacyHome, "config.toml"), "[loop_control]\nmax_steps = 10\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.kimi).toBe(true);
 	});
 });
 

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -6,20 +6,11 @@
  * that form the cross-harness identity standard.
  */
 
-import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { execFileSyncHidden } from "./child-process";
-import { listOhMyPiAgentDirCandidates, resolveOhMyPiAgentDir } from "./oh-my-pi";
-import { listPiAgentDirCandidates, resolvePiAgentDir } from "./pi";
 import { parseSimpleYaml } from "./yaml";
-
-const OH_MY_PI_MANAGED_EXTENSION_FILENAME = "signet-oh-my-pi.js";
-const OH_MY_PI_LEGACY_MANAGED_EXTENSION_FILENAME = "signet-oh-my-pi.mjs";
-const OH_MY_PI_MANAGED_MARKER = "SIGNET_MANAGED_OH_MY_PI_EXTENSION";
-const PI_MANAGED_EXTENSION_FILENAME = "signet-pi.js";
-const PI_LEGACY_MANAGED_EXTENSION_FILENAME = "signet-pi.mjs";
-const PI_MANAGED_MARKER = "SIGNET_MANAGED_PI_EXTENSION";
 
 /**
  * Returns the base path for agent-specific files.
@@ -219,81 +210,6 @@ export const OPTIONAL_IDENTITY_KEYS = Object.entries(IDENTITY_FILES)
 	.filter(([, spec]) => spec.optional)
 	.map(([key]) => key);
 
-/**
- * Detection result for existing setup
- */
-export interface SetupDetection {
-	/** Base path checked */
-	basePath: string;
-	/** Whether the base directory exists */
-	agentsDir: boolean;
-	/** Whether agent.yaml exists */
-	agentYaml: boolean;
-	/** Whether AGENTS.md exists */
-	agentsMd: boolean;
-	/** Whether config.yaml exists */
-	configYaml: boolean;
-	/** Whether memories.db exists */
-	memoryDb: boolean;
-	/** Found identity files */
-	identityFiles: string[];
-	/** Whether memory directory exists with logs */
-	hasMemoryDir: boolean;
-	/** Number of memory log files */
-	memoryLogCount: number;
-	/** Whether .clawdhub/lock.json exists (OpenClaw skills registry) */
-	hasClawdhub: boolean;
-	/** Whether ~/.claude/skills/ exists */
-	hasClaudeSkills: boolean;
-	/** Detected installed harnesses */
-	harnesses: {
-		claudeCode: boolean;
-		openclaw: boolean;
-		opencode: boolean;
-		forge: boolean;
-		codex: boolean;
-		kimi: boolean;
-		ohMyPi: boolean;
-		pi: boolean;
-		hermesAgent: boolean;
-		gemini: boolean;
-	};
-}
-
-function isSignetManagedOhMyPiInstall(): boolean {
-	for (const agentDir of listOhMyPiAgentDirCandidates()) {
-		const extensionsDir = join(agentDir, "extensions");
-		for (const filename of [OH_MY_PI_MANAGED_EXTENSION_FILENAME, OH_MY_PI_LEGACY_MANAGED_EXTENSION_FILENAME]) {
-			const extensionPath = join(extensionsDir, filename);
-			if (!existsSync(extensionPath)) continue;
-			try {
-				const content = readFileSync(extensionPath, "utf8");
-				if (content.includes(OH_MY_PI_MANAGED_MARKER)) return true;
-			} catch {
-				// ignore unreadable candidate and continue checking others
-			}
-		}
-	}
-	return false;
-}
-
-function isSignetManagedPiInstall(): boolean {
-	for (const agentDir of listPiAgentDirCandidates()) {
-		const extensionsDir = join(agentDir, "extensions");
-		for (const filename of [PI_MANAGED_EXTENSION_FILENAME, PI_LEGACY_MANAGED_EXTENSION_FILENAME]) {
-			const extensionPath = join(extensionsDir, filename);
-			if (!existsSync(extensionPath)) continue;
-			try {
-				const content = readFileSync(extensionPath, "utf8");
-				if (content.includes(PI_MANAGED_MARKER)) return true;
-			} catch {
-				// ignore unreadable candidate and continue checking others
-			}
-		}
-	}
-	return false;
-}
-
 function userHome(): string {
 	return process.env.HOME?.trim() || homedir();
 }
@@ -309,13 +225,6 @@ export function resolveKimiHomePath(): string {
 	if (existsSync(currentHome)) return currentHome;
 	if (existsSync(legacyHome)) return legacyHome;
 	return currentHome;
-}
-
-function isBinaryOnPath(bin: string): boolean {
-	const separator = process.platform === "win32" ? ";" : ":";
-	return (process.env.PATH ?? "")
-		.split(separator)
-		.some((directory) => directory.length > 0 && existsSync(join(directory, bin)));
 }
 
 export interface HermesTarget {
@@ -428,71 +337,6 @@ export function resolveHermesRepoPluginPath(): string | null {
 	}
 
 	return null;
-}
-
-/**
- * Detect existing identity setup at a given path
- */
-export function detectExistingSetup(basePath: string): SetupDetection {
-	const identityFileNames = Object.values(IDENTITY_FILES).map((spec) => spec.path);
-
-	// Check for identity files
-	const foundFiles: string[] = [];
-	for (const fileName of identityFileNames) {
-		if (existsSync(join(basePath, fileName))) {
-			foundFiles.push(fileName);
-		}
-	}
-
-	// Check memory directory
-	const memoryDir = join(basePath, "memory");
-	let memoryLogCount = 0;
-	if (existsSync(memoryDir)) {
-		try {
-			const files = readdirSync(memoryDir);
-			memoryLogCount = files.filter((f: string) => f.endsWith(".md") && !f.startsWith("TEMPLATE")).length;
-		} catch {
-			// Ignore errors
-		}
-	}
-
-	// Detect harnesses
-	const home = homedir();
-
-	return {
-		basePath,
-		agentsDir: existsSync(basePath),
-		agentYaml: existsSync(join(basePath, "agent.yaml")),
-		agentsMd: existsSync(join(basePath, "AGENTS.md")),
-		configYaml: existsSync(join(basePath, "config.yaml")),
-		memoryDb: existsSync(join(basePath, "memory", "memories.db")),
-		identityFiles: foundFiles,
-		hasMemoryDir: existsSync(memoryDir),
-		memoryLogCount,
-		hasClawdhub: existsSync(join(basePath, ".clawdhub", "lock.json")),
-		hasClaudeSkills: existsSync(join(home, ".claude", "skills")),
-		harnesses: {
-			claudeCode: existsSync(join(home, ".claude", "settings.json")),
-			openclaw:
-				existsSync(join(home, ".openclaw", "openclaw.json")) || existsSync(join(home, ".clawdbot", "clawdbot.json")),
-			opencode: existsSync(join(home, ".config", "opencode", "config.json")),
-			forge:
-				existsSync(join(home, ".forge", ".mcp.json")) ||
-				existsSync(join(home, "forge", ".mcp.json")) ||
-				existsSync(join(home, ".forge", ".forge.toml")) ||
-				existsSync(join(home, "forge", ".forge.toml")),
-			codex:
-				existsSync(join(home, ".codex", "config.toml")) || existsSync(join(home, ".config", "signet", "bin", "codex")),
-			kimi:
-				existsSync(join(resolveKimiHomePath(), "config.toml")) ||
-				existsSync(join(home, ".kimi-code", "config.toml")) ||
-				isBinaryOnPath("kimi"),
-			ohMyPi: isSignetManagedOhMyPiInstall() || existsSync(resolveOhMyPiAgentDir()),
-			pi: isSignetManagedPiInstall() || existsSync(resolvePiAgentDir()),
-			hermesAgent: resolveHermesRepoPath() !== null,
-			gemini: existsSync(join(home, ".gemini", "settings.json")),
-		},
-	};
 }
 
 /**

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -451,7 +451,6 @@ export {
 	IDENTITY_MODES,
 	REQUIRED_IDENTITY_KEYS,
 	OPTIONAL_IDENTITY_KEYS,
-	detectExistingSetup,
 	loadIdentityFiles,
 	loadIdentityFilesSync,
 	hasValidIdentity,
@@ -488,29 +487,8 @@ export type {
 	IdentityPresetSpec,
 	IdentityFile,
 	IdentityMap,
-	SetupDetection,
 	HermesTarget,
 } from "./identity";
-
-export {
-	clearConfiguredOhMyPiAgentDir,
-	getOhMyPiConfigPath,
-	listOhMyPiAgentDirCandidates,
-	readConfiguredOhMyPiAgentDir,
-	resolveOhMyPiAgentDir,
-	resolveOhMyPiExtensionsDir,
-	writeConfiguredOhMyPiAgentDir,
-} from "./oh-my-pi";
-
-export {
-	clearConfiguredPiAgentDir,
-	getPiConfigPath,
-	listPiAgentDirCandidates,
-	readConfiguredPiAgentDir,
-	resolvePiAgentDir,
-	resolvePiExtensionsDir,
-	writeConfiguredPiAgentDir,
-} from "./pi";
 
 // Multi-agent support
 export {

--- a/platform/core/src/sqlite-journal.ts
+++ b/platform/core/src/sqlite-journal.ts
@@ -54,7 +54,8 @@ export function detectFilesystemType(
 
 	try {
 		const output =
-			opts?.statCommand?.(path) ?? (execFileSyncHidden("/usr/bin/stat", ["-f", "%T", path], { encoding: "utf8" }) as string);
+			opts?.statCommand?.(path) ??
+			(execFileSyncHidden("/usr/bin/stat", ["-f", "%T", path], { encoding: "utf8" }) as string);
 		const filesystemType = output.trim();
 		return filesystemType.length > 0 ? filesystemType : null;
 	} catch {

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -29,8 +29,6 @@ import { OpenClawConnector } from "@signet/connector-openclaw";
 import { OpenCodeConnector } from "@signet/connector-opencode";
 import { PiConnector } from "@signet/connector-pi";
 import {
-	type SetupDetection,
-	detectExistingSetup as detectExistingSetupCore,
 	expandHome,
 	getGlobalInstallCommand,
 	loadConfiguredHarnesses,
@@ -41,6 +39,7 @@ import {
 	syncWorkspaceSourceRepo,
 	syncWorkspaceSourceRepoAsync,
 } from "@signet/core";
+import { detectExistingSetup } from "./lib/setup-detection.js";
 import chalk from "chalk";
 import { Command } from "commander";
 
@@ -364,11 +363,6 @@ function signetLogo() {
   ${chalk.hex("#C9A227")("◈")} ${chalk.bold("signet")} ${chalk.dim(`v${VERSION}`)}
   ${chalk.dim("own your agent. bring it anywhere.")}
 `;
-}
-
-function detectExistingSetup(basePath: string): SetupDetection {
-	// Use the enhanced detection from @signet/core
-	return detectExistingSetupCore(basePath);
 }
 
 function collectListOption(value: string, previous: string[]): string[] {

--- a/surfaces/cli/src/features/setup-embedding-validation.test.ts
+++ b/surfaces/cli/src/features/setup-embedding-validation.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SetupDetection } from "@signet/core";
+import type { SetupDetection } from "../lib/setup-detection.js";
 import { validateOllamaModelNonInteractive } from "./setup-providers.js";
 import type { SetupDeps } from "./setup-types.js";
 import { setupWizard } from "./setup.js";

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -6,7 +6,6 @@ import {
 	Database as CoreDatabase,
 	type IdentityMode,
 	type ImportResult,
-	type SetupDetection,
 	type SkillsResult,
 	disableGraphiqState,
 	ensureUnifiedSchema,
@@ -20,6 +19,7 @@ import { readNetworkMode } from "@signet/core";
 import chalk from "chalk";
 import ora from "ora";
 import { daemonAccessLines } from "../lib/network.js";
+import type { SetupDetection } from "../lib/setup-detection.js";
 import { openUrlWithFallback } from "../lib/open-url.js";
 import Database from "../sqlite.js";
 import { installGraphiqPlugin } from "./graphiq.js";

--- a/surfaces/cli/src/features/setup-shared.ts
+++ b/surfaces/cli/src/features/setup-shared.ts
@@ -1,5 +1,5 @@
 import { OpenClawConnector } from "@signet/connector-openclaw";
-import type { SetupDetection } from "@signet/core";
+import type { SetupDetection } from "../lib/setup-detection.js";
 import chalk from "chalk";
 
 export type HarnessChoice =

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -1,4 +1,4 @@
-import type { SetupDetection } from "@signet/core";
+import type { SetupDetection } from "../lib/setup-detection.js";
 import type { OpenClawRuntimeChoice } from "./setup-shared.js";
 
 export interface SetupWizardOptions {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -2,16 +2,10 @@ import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-	SIGNET_SECRETS_PLUGIN_ID,
-	type SetupDetection,
-	detectExistingSetup,
-	readGraphiqState,
-	updateGraphiqActiveProject,
-} from "@signet/core";
+import { SIGNET_SECRETS_PLUGIN_ID, readGraphiqState, updateGraphiqActiveProject } from "@signet/core";
+import { detectExistingSetup, type SetupDetection } from "../lib/setup-detection.js";
 import * as openUrl from "../lib/open-url.js";
 import { detectedHarnessesForExistingSetup, runExistingSetupWizard } from "./setup-migrate.js";
-import { parseSetupPlan } from "./setup-plan.js";
 import type { SetupDeps } from "./setup-types.js";
 import { setupWizard } from "./setup.js";
 
@@ -21,6 +15,7 @@ const NO_HARNESSES = {
 	opencode: false,
 	forge: false,
 	codex: false,
+	kimi: false,
 	ohMyPi: false,
 	pi: false,
 	hermesAgent: false,
@@ -102,19 +97,16 @@ describe("setupWizard non-interactive harness hooks", () => {
 
 	afterEach(() => {
 		if (ORIGINAL_HOME === undefined) {
-			// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 			delete process.env.HOME;
 		} else {
 			process.env.HOME = ORIGINAL_HOME;
 		}
 		if (ORIGINAL_HERMES_REPO === undefined) {
-			// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 			delete process.env.HERMES_REPO;
 		} else {
 			process.env.HERMES_REPO = ORIGINAL_HERMES_REPO;
 		}
 		if (ORIGINAL_HERMES_HOME === undefined) {
-			// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 			delete process.env.HERMES_HOME;
 		} else {
 			process.env.HERMES_HOME = ORIGINAL_HERMES_HOME;
@@ -508,9 +500,7 @@ describe("setupWizard non-interactive harness hooks", () => {
 		mkdirSync(basePath, { recursive: true });
 		mkdirSync(join(root, ".hermes", "plugins", "memory"), { recursive: true });
 		process.env.HOME = root;
-		// biome-ignore lint/performance/noDelete: default ~/.hermes must be enough
 		delete process.env.HERMES_REPO;
-		// biome-ignore lint/performance/noDelete: default ~/.hermes must be enough
 		delete process.env.HERMES_HOME;
 
 		const detection = detectExistingSetup(basePath);

--- a/surfaces/cli/src/features/sync.ts
+++ b/surfaces/cli/src/features/sync.ts
@@ -2,10 +2,10 @@ import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSy
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { OpenClawConnector } from "@signet/connector-openclaw";
+import { getOhMyPiConfigPath } from "@signet/connector-oh-my-pi";
+import { getPiConfigPath } from "@signet/connector-pi";
 import {
 	type WorkspaceSourceRepoSyncResult,
-	getOhMyPiConfigPath,
-	getPiConfigPath,
 	loadConfiguredHarnesses,
 	resolveHermesRepoPath,
 	resolveKimiHomePath,

--- a/surfaces/cli/src/features/workspace.ts
+++ b/surfaces/cli/src/features/workspace.ts
@@ -2,7 +2,8 @@ import { createHash } from "node:crypto";
 import { closeSync, copyFileSync, existsSync, lstatSync, mkdirSync, openSync, readSync, readdirSync } from "node:fs";
 import { dirname, join, sep } from "node:path";
 import { OpenClawConnector } from "@signet/connector-openclaw";
-import { detectExistingSetup, preflightWorkspace } from "@signet/core";
+import { preflightWorkspace } from "@signet/core";
+import { detectExistingSetup } from "../lib/setup-detection.js";
 import { normalizeWorkspacePath, resolveAgentsDir, writeConfiguredWorkspacePath } from "../lib/workspace.js";
 
 export interface WorkspaceCandidate {

--- a/surfaces/cli/src/lib/setup-detection.test.ts
+++ b/surfaces/cli/src/lib/setup-detection.test.ts
@@ -7,6 +7,7 @@ import { detectExistingSetup } from "./setup-detection.js";
 const TMP = join(tmpdir(), `signet-setup-detection-test-${Date.now()}`);
 const ENVIRONMENT_KEYS = [
 	"HOME",
+	"USERPROFILE",
 	"HERMES_HOME",
 	"HERMES_REPO",
 	"KIMI_CODE_HOME",
@@ -138,6 +139,19 @@ describe("detectExistingSetup", () => {
 
 		const detection = detectExistingSetup(TMP);
 
+		expect(detection.harnesses.pi).toBe(true);
+	});
+
+	test("uses USERPROFILE when HOME is unavailable", () => {
+		const userProfile = join(TMP, "user-profile");
+		Reflect.deleteProperty(process.env, "HOME");
+		process.env.USERPROFILE = userProfile;
+		mkdirSync(join(userProfile, ".omp", "agent"), { recursive: true });
+		mkdirSync(join(userProfile, ".pi", "agent"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.ohMyPi).toBe(true);
 		expect(detection.harnesses.pi).toBe(true);
 	});
 

--- a/surfaces/cli/src/lib/setup-detection.test.ts
+++ b/surfaces/cli/src/lib/setup-detection.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { detectExistingSetup } from "./setup-detection.js";
+import { detectExistingSetup, type SetupDetection } from "./setup-detection.js";
 
 const TMP = join(tmpdir(), `signet-setup-detection-test-${Date.now()}`);
 const ENVIRONMENT_KEYS = [
@@ -19,28 +19,29 @@ const ENVIRONMENT_KEYS = [
 const ORIGINAL_ENVIRONMENT = new Map<string, string | undefined>(
 	ENVIRONMENT_KEYS.map((key) => [key, process.env[key]]),
 );
+type Harness = keyof SetupDetection["harnesses"];
+
+afterEach(() => {
+	for (const key of ENVIRONMENT_KEYS) {
+		const value = ORIGINAL_ENVIRONMENT.get(key);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	rmSync(TMP, { recursive: true, force: true });
+});
 
 beforeEach(() => {
 	mkdirSync(TMP, { recursive: true });
 	process.env.HOME = TMP;
 	process.env.PATH = join(TMP, "bin");
 	for (const key of ENVIRONMENT_KEYS) {
-		if (key === "HOME" || key === "PATH") continue;
-		delete process.env[key];
+		if (key !== "HOME" && key !== "PATH") delete process.env[key];
 	}
 });
 
-afterEach(() => {
-	for (const key of ENVIRONMENT_KEYS) {
-		const value = ORIGINAL_ENVIRONMENT.get(key);
-		if (value === undefined) {
-			delete process.env[key];
-			continue;
-		}
-		process.env[key] = value;
-	}
-	rmSync(TMP, { recursive: true, force: true });
-});
+function expectDetected(harness: Harness): void {
+	expect(detectExistingSetup(TMP).harnesses[harness]).toBe(true);
+}
 
 describe("detectExistingSetup", () => {
 	test("detects identity files without requiring a harness", () => {
@@ -52,107 +53,101 @@ describe("detectExistingSetup", () => {
 		expect(Object.values(detection.harnesses).every((value) => value === false)).toBe(true);
 	});
 
-	test("detects Hermes Agent in the default ~/.hermes install path", () => {
-		mkdirSync(join(TMP, ".hermes", "plugins", "memory"), { recursive: true });
+	const detectedHarnesses: readonly {
+		readonly name: string;
+		readonly harness: Harness;
+		readonly setup: () => void;
+	}[] = [
+		{
+			name: "detects Hermes Agent in the default ~/.hermes install path",
+			harness: "hermesAgent",
+			setup: () => mkdirSync(join(TMP, ".hermes", "plugins", "memory"), { recursive: true }),
+		},
+		{
+			name: "detects Hermes Agent from HERMES_HOME without HERMES_REPO",
+			harness: "hermesAgent",
+			setup: () => {
+				const hermesHome = join(TMP, "custom-hermes-home");
+				process.env.HERMES_HOME = hermesHome;
+				mkdirSync(join(hermesHome, "plugins", "memory"), { recursive: true });
+			},
+		},
+		{
+			name: "detects Hermes Agent in the managed ~/.hermes/hermes-agent checkout",
+			harness: "hermesAgent",
+			setup: () => mkdirSync(join(TMP, ".hermes", "hermes-agent", "plugins", "memory"), { recursive: true }),
+		},
+		{
+			name: "detects Hermes Agent before the Signet memory plugin is installed",
+			harness: "hermesAgent",
+			setup: () => {
+				const hermesRepo = join(TMP, "hermes-agent");
+				process.env.HERMES_REPO = hermesRepo;
+				mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+			},
+		},
+		{
+			name: "detects ForgeCode from the default ~/.forge config path",
+			harness: "forge",
+			setup: () => {
+				mkdirSync(join(TMP, ".forge"), { recursive: true });
+				writeFileSync(join(TMP, ".forge", ".mcp.json"), "{}\n");
+			},
+		},
+		{
+			name: "detects ForgeCode from the legacy ~/forge config path",
+			harness: "forge",
+			setup: () => {
+				mkdirSync(join(TMP, "forge"), { recursive: true });
+				writeFileSync(join(TMP, "forge", ".forge.toml"), "# config\n");
+			},
+		},
+		{
+			name: "detects Kimi from the current ~/.kimi config home",
+			harness: "kimi",
+			setup: () => {
+				mkdirSync(join(TMP, ".kimi"), { recursive: true });
+				writeFileSync(join(TMP, ".kimi", "config.toml"), "[loop_control]\nmax_steps = 10\n");
+			},
+		},
+		{
+			name: "detects Kimi from the legacy KIMI_CODE_HOME override",
+			harness: "kimi",
+			setup: () => {
+				const legacyHome = join(TMP, "legacy-kimi");
+				process.env.KIMI_CODE_HOME = legacyHome;
+				mkdirSync(legacyHome, { recursive: true });
+				writeFileSync(join(legacyHome, "config.toml"), "[loop_control]\nmax_steps = 10\n");
+			},
+		},
+		{
+			name: "detects an Oh My Pi agent directory through the integration detector",
+			harness: "ohMyPi",
+			setup: () => mkdirSync(join(TMP, ".omp", "agent"), { recursive: true }),
+		},
+		{
+			name: "detects a Pi agent directory through the integration detector",
+			harness: "pi",
+			setup: () => mkdirSync(join(TMP, ".pi", "agent"), { recursive: true }),
+		},
+	];
 
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects Hermes Agent from HERMES_HOME without HERMES_REPO", () => {
-		const hermesHome = join(TMP, "custom-hermes-home");
-		process.env.HERMES_HOME = hermesHome;
-		mkdirSync(join(hermesHome, "plugins", "memory"), { recursive: true });
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects Hermes Agent in the managed ~/.hermes/hermes-agent checkout", () => {
-		mkdirSync(join(TMP, ".hermes", "hermes-agent", "plugins", "memory"), { recursive: true });
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects Hermes Agent before the Signet memory plugin is installed", () => {
-		const hermesRepo = join(TMP, "hermes-agent");
-		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
-		process.env.HERMES_REPO = hermesRepo;
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.hermesAgent).toBe(true);
-	});
-
-	test("detects ForgeCode from the default ~/.forge config path", () => {
-		mkdirSync(join(TMP, ".forge"), { recursive: true });
-		writeFileSync(join(TMP, ".forge", ".mcp.json"), "{}\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.forge).toBe(true);
-	});
-
-	test("detects ForgeCode from the legacy ~/forge config path", () => {
-		mkdirSync(join(TMP, "forge"), { recursive: true });
-		writeFileSync(join(TMP, "forge", ".forge.toml"), "# config\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.forge).toBe(true);
-	});
-
-	test("detects Kimi from the current ~/.kimi config home", () => {
-		mkdirSync(join(TMP, ".kimi"), { recursive: true });
-		writeFileSync(join(TMP, ".kimi", "config.toml"), "[loop_control]\nmax_steps = 10\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.kimi).toBe(true);
-	});
-
-	test("detects Kimi from the legacy KIMI_CODE_HOME override", () => {
-		const legacyHome = join(TMP, "legacy-kimi");
-		process.env.KIMI_CODE_HOME = legacyHome;
-		mkdirSync(legacyHome, { recursive: true });
-		writeFileSync(join(legacyHome, "config.toml"), "[loop_control]\nmax_steps = 10\n");
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.kimi).toBe(true);
-	});
-
-	test("detects an Oh My Pi agent directory through the integration detector", () => {
-		mkdirSync(join(TMP, ".omp", "agent"), { recursive: true });
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.ohMyPi).toBe(true);
-	});
-
-	test("detects a Pi agent directory through the integration detector", () => {
-		mkdirSync(join(TMP, ".pi", "agent"), { recursive: true });
-
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.pi).toBe(true);
-	});
+	for (const { name, harness, setup } of detectedHarnesses) {
+		test(name, () => {
+			setup();
+			expectDetected(harness);
+		});
+	}
 
 	test("uses USERPROFILE when HOME is unavailable", () => {
 		const userProfile = join(TMP, "user-profile");
-		Reflect.deleteProperty(process.env, "HOME");
+		delete process.env.HOME;
 		process.env.USERPROFILE = userProfile;
 		mkdirSync(join(userProfile, ".omp", "agent"), { recursive: true });
 		mkdirSync(join(userProfile, ".pi", "agent"), { recursive: true });
 
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.ohMyPi).toBe(true);
-		expect(detection.harnesses.pi).toBe(true);
+		expectDetected("ohMyPi");
+		expectDetected("pi");
 	});
 
 	test("detects configured Oh My Pi and Pi directories", () => {
@@ -160,18 +155,14 @@ describe("detectExistingSetup", () => {
 		process.env.PI_CODING_AGENT_DIR = agentDir;
 		mkdirSync(agentDir, { recursive: true });
 
-		const detection = detectExistingSetup(TMP);
-
-		expect(detection.harnesses.ohMyPi).toBe(true);
-		expect(detection.harnesses.pi).toBe(true);
+		expectDetected("ohMyPi");
+		expectDetected("pi");
 	});
 
 	test("does not report a missing Oh My Pi or Pi directory", () => {
 		expect(existsSync(join(TMP, ".omp", "agent"))).toBe(false);
 		expect(existsSync(join(TMP, ".pi", "agent"))).toBe(false);
-
 		const detection = detectExistingSetup(TMP);
-
 		expect(detection.harnesses.ohMyPi).toBe(false);
 		expect(detection.harnesses.pi).toBe(false);
 	});

--- a/surfaces/cli/src/lib/setup-detection.test.ts
+++ b/surfaces/cli/src/lib/setup-detection.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectExistingSetup } from "./setup-detection.js";
+
+const TMP = join(tmpdir(), `signet-setup-detection-test-${Date.now()}`);
+const ENVIRONMENT_KEYS = [
+	"HOME",
+	"HERMES_HOME",
+	"HERMES_REPO",
+	"KIMI_CODE_HOME",
+	"KIMI_SHARE_DIR",
+	"PATH",
+	"PI_CODING_AGENT_DIR",
+	"XDG_CONFIG_HOME",
+] as const;
+const ORIGINAL_ENVIRONMENT = new Map<string, string | undefined>(
+	ENVIRONMENT_KEYS.map((key) => [key, process.env[key]]),
+);
+
+beforeEach(() => {
+	mkdirSync(TMP, { recursive: true });
+	process.env.HOME = TMP;
+	process.env.PATH = join(TMP, "bin");
+	for (const key of ENVIRONMENT_KEYS) {
+		if (key === "HOME" || key === "PATH") continue;
+		delete process.env[key];
+	}
+});
+
+afterEach(() => {
+	for (const key of ENVIRONMENT_KEYS) {
+		const value = ORIGINAL_ENVIRONMENT.get(key);
+		if (value === undefined) {
+			delete process.env[key];
+			continue;
+		}
+		process.env[key] = value;
+	}
+	rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("detectExistingSetup", () => {
+	test("detects identity files without requiring a harness", () => {
+		writeFileSync(join(TMP, "AGENTS.md"), "agent rules\n");
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.identityFiles).toEqual(["AGENTS.md"]);
+		expect(Object.values(detection.harnesses).every((value) => value === false)).toBe(true);
+	});
+
+	test("detects Hermes Agent in the default ~/.hermes install path", () => {
+		mkdirSync(join(TMP, ".hermes", "plugins", "memory"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
+	});
+
+	test("detects Hermes Agent from HERMES_HOME without HERMES_REPO", () => {
+		const hermesHome = join(TMP, "custom-hermes-home");
+		process.env.HERMES_HOME = hermesHome;
+		mkdirSync(join(hermesHome, "plugins", "memory"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
+	});
+
+	test("detects Hermes Agent in the managed ~/.hermes/hermes-agent checkout", () => {
+		mkdirSync(join(TMP, ".hermes", "hermes-agent", "plugins", "memory"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
+	});
+
+	test("detects Hermes Agent before the Signet memory plugin is installed", () => {
+		const hermesRepo = join(TMP, "hermes-agent");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_REPO = hermesRepo;
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
+	});
+
+	test("detects ForgeCode from the default ~/.forge config path", () => {
+		mkdirSync(join(TMP, ".forge"), { recursive: true });
+		writeFileSync(join(TMP, ".forge", ".mcp.json"), "{}\n");
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.forge).toBe(true);
+	});
+
+	test("detects ForgeCode from the legacy ~/forge config path", () => {
+		mkdirSync(join(TMP, "forge"), { recursive: true });
+		writeFileSync(join(TMP, "forge", ".forge.toml"), "# config\n");
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.forge).toBe(true);
+	});
+
+	test("detects Kimi from the current ~/.kimi config home", () => {
+		mkdirSync(join(TMP, ".kimi"), { recursive: true });
+		writeFileSync(join(TMP, ".kimi", "config.toml"), "[loop_control]\nmax_steps = 10\n");
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.kimi).toBe(true);
+	});
+
+	test("detects Kimi from the legacy KIMI_CODE_HOME override", () => {
+		const legacyHome = join(TMP, "legacy-kimi");
+		process.env.KIMI_CODE_HOME = legacyHome;
+		mkdirSync(legacyHome, { recursive: true });
+		writeFileSync(join(legacyHome, "config.toml"), "[loop_control]\nmax_steps = 10\n");
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.kimi).toBe(true);
+	});
+
+	test("detects an Oh My Pi agent directory through the integration detector", () => {
+		mkdirSync(join(TMP, ".omp", "agent"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.ohMyPi).toBe(true);
+	});
+
+	test("detects a Pi agent directory through the integration detector", () => {
+		mkdirSync(join(TMP, ".pi", "agent"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.pi).toBe(true);
+	});
+
+	test("detects configured Oh My Pi and Pi directories", () => {
+		const agentDir = join(TMP, "shared-agent");
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		mkdirSync(agentDir, { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.ohMyPi).toBe(true);
+		expect(detection.harnesses.pi).toBe(true);
+	});
+
+	test("does not report a missing Oh My Pi or Pi directory", () => {
+		expect(existsSync(join(TMP, ".omp", "agent"))).toBe(false);
+		expect(existsSync(join(TMP, ".pi", "agent"))).toBe(false);
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.ohMyPi).toBe(false);
+		expect(detection.harnesses.pi).toBe(false);
+	});
+});

--- a/surfaces/cli/src/lib/setup-detection.ts
+++ b/surfaces/cli/src/lib/setup-detection.ts
@@ -86,7 +86,7 @@ export function detectExistingSetup(basePath: string): SetupDetection {
 		}
 	}
 
-	const home = process.env.HOME?.trim() || homedir();
+	const home = process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || homedir();
 	return {
 		basePath,
 		agentsDir: existsSync(basePath),

--- a/surfaces/cli/src/lib/setup-detection.ts
+++ b/surfaces/cli/src/lib/setup-detection.ts
@@ -1,0 +1,124 @@
+/**
+ * Detect existing Signet workspaces and installed harnesses.
+ *
+ * Workspace identity files are shared core data. Harness installation paths are
+ * integration policy, so their detection stays at the CLI boundary.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { hasOhMyPiSetup } from "@signet/connector-oh-my-pi";
+import { hasPiSetup } from "@signet/connector-pi";
+import { IDENTITY_FILES, resolveHermesRepoPath, resolveKimiHomePath } from "@signet/core";
+
+export interface SetupDetection {
+	/** Base path checked */
+	basePath: string;
+	/** Whether the base directory exists */
+	agentsDir: boolean;
+	/** Whether agent.yaml exists */
+	agentYaml: boolean;
+	/** Whether AGENTS.md exists */
+	agentsMd: boolean;
+	/** Whether config.yaml exists */
+	configYaml: boolean;
+	/** Whether memories.db exists */
+	memoryDb: boolean;
+	/** Found identity files */
+	identityFiles: string[];
+	/** Whether memory directory exists with logs */
+	hasMemoryDir: boolean;
+	/** Number of memory log files */
+	memoryLogCount: number;
+	/** Whether .clawdhub/lock.json exists (OpenClaw skills registry) */
+	hasClawdhub: boolean;
+	/** Whether ~/.claude/skills/ exists */
+	hasClaudeSkills: boolean;
+	/** Detected installed harnesses */
+	harnesses: {
+		claudeCode: boolean;
+		openclaw: boolean;
+		opencode: boolean;
+		forge: boolean;
+		codex: boolean;
+		kimi: boolean;
+		ohMyPi: boolean;
+		pi: boolean;
+		hermesAgent: boolean;
+		gemini: boolean;
+	};
+}
+
+function isBinaryOnPath(bin: string): boolean {
+	const separator = process.platform === "win32" ? ";" : ":";
+	return (process.env.PATH ?? "")
+		.split(separator)
+		.some((directory) => directory.length > 0 && existsSync(join(directory, bin)));
+}
+
+/**
+ * Detect existing identity setup at a given path.
+ *
+ * This is a CLI/setup concern: the core package owns identity data and
+ * primitives, while this boundary composes integration-specific detectors.
+ */
+export function detectExistingSetup(basePath: string): SetupDetection {
+	const identityFileNames = Object.values(IDENTITY_FILES).map((spec) => spec.path);
+
+	const foundFiles: string[] = [];
+	for (const fileName of identityFileNames) {
+		if (existsSync(join(basePath, fileName))) {
+			foundFiles.push(fileName);
+		}
+	}
+
+	const memoryDir = join(basePath, "memory");
+	let memoryLogCount = 0;
+	if (existsSync(memoryDir)) {
+		try {
+			const files = readdirSync(memoryDir);
+			memoryLogCount = files.filter(
+				(fileName: string) => fileName.endsWith(".md") && !fileName.startsWith("TEMPLATE"),
+			).length;
+		} catch {
+			// Ignore errors.
+		}
+	}
+
+	const home = process.env.HOME?.trim() || homedir();
+	return {
+		basePath,
+		agentsDir: existsSync(basePath),
+		agentYaml: existsSync(join(basePath, "agent.yaml")),
+		agentsMd: existsSync(join(basePath, "AGENTS.md")),
+		configYaml: existsSync(join(basePath, "config.yaml")),
+		memoryDb: existsSync(join(basePath, "memory", "memories.db")),
+		identityFiles: foundFiles,
+		hasMemoryDir: existsSync(memoryDir),
+		memoryLogCount,
+		hasClawdhub: existsSync(join(basePath, ".clawdhub", "lock.json")),
+		hasClaudeSkills: existsSync(join(home, ".claude", "skills")),
+		harnesses: {
+			claudeCode: existsSync(join(home, ".claude", "settings.json")),
+			openclaw:
+				existsSync(join(home, ".openclaw", "openclaw.json")) || existsSync(join(home, ".clawdbot", "clawdbot.json")),
+			opencode: existsSync(join(home, ".config", "opencode", "config.json")),
+			forge:
+				existsSync(join(home, ".forge", ".mcp.json")) ||
+				existsSync(join(home, "forge", ".mcp.json")) ||
+				existsSync(join(home, ".forge", ".forge.toml")) ||
+				existsSync(join(home, "forge", ".forge.toml")),
+			codex:
+				existsSync(join(home, ".codex", "config.toml")) || existsSync(join(home, ".config", "signet", "bin", "codex")),
+			kimi:
+				existsSync(join(resolveKimiHomePath(), "config.toml")) ||
+				existsSync(join(home, ".kimi-code", "config.toml")) ||
+				isBinaryOnPath("kimi"),
+			ohMyPi: hasOhMyPiSetup(),
+			pi: hasPiSetup(),
+			hermesAgent: resolveHermesRepoPath() !== null,
+			gemini: existsSync(join(home, ".gemini", "settings.json")),
+		},
+	};
+}

--- a/web/docs/src/content/docs/contributing.md
+++ b/web/docs/src/content/docs/contributing.md
@@ -427,8 +427,11 @@ Signet recognizes these standard identity files at `$SIGNET_WORKSPACE/`:
 | TOOLS.md | no | Tool preferences and notes |
 | BOOTSTRAP.md | no | Setup ritual (typically deleted after first run) |
 
-The `detectExistingSetup()` function in `platform/core/src/identity.ts`
-detects existing setups from OpenClaw, Claude Code, and OpenCode.
+The `detectExistingSetup()` function in `surfaces/cli/src/lib/setup-detection.ts`
+combines shared identity-file checks with harness detection for the setup surface.
+Keep harness-specific installation, managed-file, and configuration policy under
+`integrations/<tool>/`; `platform/core` should expose reusable identity and
+workspace primitives rather than integration-owned setup modules.
 
 Reference Repos
 ---

--- a/web/docs/src/content/docs/contributing.md
+++ b/web/docs/src/content/docs/contributing.md
@@ -427,20 +427,6 @@ Signet recognizes these standard identity files at `$SIGNET_WORKSPACE/`:
 | TOOLS.md | no | Tool preferences and notes |
 | BOOTSTRAP.md | no | Setup ritual (typically deleted after first run) |
 
-The `detectExistingSetup()` function in `surfaces/cli/src/lib/setup-detection.ts`
-combines shared identity-file checks with harness detection for the setup surface.
-Keep harness-specific installation, managed-file, and configuration policy under
-`integrations/<tool>/`; `platform/core` should expose reusable identity and
-workspace primitives rather than integration-owned setup modules.
-
-The harness boundary is also a published API boundary. `@signet/core` no longer
-exports `detectExistingSetup`, `SetupDetection`, or the Oh My Pi/Pi path and
-configuration helpers. Update integration callers to import Oh My Pi helpers from
-`@signet/connector-oh-my-pi`, Pi connector helpers from `@signet/connector-pi`,
-and Pi extension helpers from `@signet/pi-extension-base/agent-dir`. The CLI's
-`surfaces/cli/src/lib/setup-detection.ts` module is an internal CLI composition
-point, not a core API. Compatibility re-exports are intentionally not retained,
-because they would put harness-specific ownership back in `@signet/core`.
 
 Reference Repos
 ---

--- a/web/docs/src/content/docs/contributing.md
+++ b/web/docs/src/content/docs/contributing.md
@@ -433,6 +433,15 @@ Keep harness-specific installation, managed-file, and configuration policy under
 `integrations/<tool>/`; `platform/core` should expose reusable identity and
 workspace primitives rather than integration-owned setup modules.
 
+The harness boundary is also a published API boundary. `@signet/core` no longer
+exports `detectExistingSetup`, `SetupDetection`, or the Oh My Pi/Pi path and
+configuration helpers. Update integration callers to import Oh My Pi helpers from
+`@signet/connector-oh-my-pi`, Pi connector helpers from `@signet/connector-pi`,
+and Pi extension helpers from `@signet/pi-extension-base/agent-dir`. The CLI's
+`surfaces/cli/src/lib/setup-detection.ts` module is an internal CLI composition
+point, not a core API. Compatibility re-exports are intentionally not retained,
+because they would put harness-specific ownership back in `@signet/core`.
+
 Reference Repos
 ---
 


### PR DESCRIPTION
## Summary

Keep harness-owned installation and configuration policy out of `@signet/core`. This moves the Oh My Pi and Pi agent-directory helpers back into their integrations and keeps CLI setup detection at the CLI boundary.

## Changes

- Remove Oh My Pi and Pi setup/path modules and exports from `@signet/core`.
- Move Oh My Pi agent-directory/configuration helpers into its connector package.
- Move Pi agent-directory/configuration helpers into `@signet/pi-extension-base`.
- Compose harness detection in `surfaces/cli/src/lib/setup-detection.ts`.
- Update connector, extension, CLI, package dependency, lockfile, and generated documentation references.
- Add regression coverage for setup detection and moved integration exports.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/pi-extension-base`, `@signet/pi-extension`, `@signet/oh-my-pi-extension`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable: no database or schema migrations were touched.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The core package still intentionally owns shared Hermes/Kimi identity and path resolvers. This refactor specifically removes integration-owned Oh My Pi and Pi installation/configuration/detection policy from core. Targeted verification ran 176 tests across 12 files; the full workspace build and typecheck passed. `bun run lint` passes with pre-existing warnings.

Breaking API note: `@signet/core` no longer exports `detectExistingSetup`, `SetupDetection`, or the Oh My Pi/Pi path and configuration helpers. In-repo consumers now import those helpers from their integration packages; compatibility re-exports are intentionally not retained because they would restore harness-specific ownership in core. The migration details are documented in `CONTRIBUTING.md`.
