### PR TITLE
fix(daemon): fence integrity deadline workers

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -96,6 +96,7 @@ import {
 } from "./db-owner-maintenance";
 import { createDeferredRuntimeGate, createDeferredRuntimeScheduler } from "./deferred-runtime-gate";
 import { dbOwnerBatch, dbOwnerQuery, ownerStatement } from "./db-owner-runtime";
+import { ownerReadOne } from "./db-owner-sql";
 import type { QueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
@@ -956,12 +957,12 @@ async function resolveActiveEmbeddingConfigThroughOwner(
 	operation: string,
 ): Promise<ResolvedMemoryConfig["embedding"]> {
 	if (configured.profile) return configured;
-	const row = await ownerQueryOne<EmbeddingIndexStateRow>(
+	// Startup must not wait behind FTS/integrity maintenance work.
+	const row = await ownerReadOne<EmbeddingIndexStateRow>(
 		owner,
-		operation,
 		"SELECT active_profile_json, staging_profile_json, state, last_error FROM embedding_index_state WHERE id = 1",
 		[],
-		{ deadlineMs: 5_000 },
+		{ operation, deadlineMs: 5_000 },
 	);
 	return resolveActiveEmbeddingConfigFromState(configured, parseEmbeddingIndexStateRow(row ?? null));
 }

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -803,6 +803,27 @@ describe("DB owner client", () => {
 		await waitFor(() => client?.health().lanes?.maintenance.activeJobId === null);
 	});
 
+	test("closes the metrics fence when a queued job expires", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		client = createDbOwnerClient({ dbPath: database.path });
+		await client.start();
+		const slow = client.submit(
+			{ kind: "sleep", durationMs: 250 },
+			{ operation: "maintenance.queued-fence-blocker", lane: "maintenance", deadlineMs: 1_000 },
+		);
+		await waitFor(() => client?.health().lanes?.maintenance.activeJobId === slow.job.id);
+		const queued = client.submit(
+			{ kind: "sleep", durationMs: 0 },
+			{ operation: "maintenance.queued-fence-expiry", lane: "maintenance", deadlineMs: 40 },
+		);
+		await expect(queued.result).rejects.toBeInstanceOf(DbOwnerDeadlineError);
+		const queuedMetrics = queued.metrics;
+		if (queuedMetrics === undefined) throw new Error("queued job did not expose a metrics fence");
+		await expect(queuedMetrics).resolves.toBeUndefined();
+		await expect(slow.result).resolves.toEqual({ sleptMs: 250 });
+	});
+
 	test("recovers immediately after a maintenance deadline is abandoned", async () => {
 		const database = makeDb();
 		directory = database.directory;

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -726,6 +726,10 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 				const dispatched = entry.dispatched;
 				settle(job.id, (settledJob) => {
 					if (dispatched) abandonedMetrics.set(job.id, settledJob.resolveMetrics);
+					else {
+						// No owner worker exists for a queued job; close its completion fence.
+						settledJob.resolveMetrics(undefined);
+					}
 					if (!settledJob.settled) {
 						settledJob.settled = true;
 						settledJob.reject(new DbOwnerDeadlineError(job.id));

--- a/platform/daemon/src/db-owner-maintenance.test.ts
+++ b/platform/daemon/src/db-owner-maintenance.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDbOwnerMaintenance, runOwnerMaintenanceWithRetry } from "./db-owner-maintenance";
-import { createDbOwnerClient, DbOwnerDiedError, type DbOwnerClient } from "./db-owner-client";
+import { createDbOwnerClient, DbOwnerDeadlineError, DbOwnerDiedError, type DbOwnerClient } from "./db-owner-client";
 import { isFtsIndexIncomplete, setFtsIndexIncomplete } from "./fts-index-state";
 import { completeFtsStartupRecovery } from "./fts-startup-recovery";
 
@@ -115,6 +115,40 @@ describe("DB owner FTS maintenance", () => {
 		expect(deadlines).toHaveLength(2);
 		expect(deadlines[1]).toBeLessThan(deadlines[0]);
 		expect(Date.now() - startedAt).toBeLessThan(125);
+	});
+
+	test("waits for a deadline-abandoned owner worker when requested", async () => {
+		let releaseMetrics: (() => void) | undefined;
+		let settledNotifications = 0;
+		const owner = {
+			start: async (): Promise<void> => {},
+			submit: () => ({
+				job: { enqueuedAt: 0 } as never,
+				result: Promise.reject(new DbOwnerDeadlineError("test.owner-settlement-fence")),
+				metrics: new Promise<undefined>((resolve) => {
+					releaseMetrics = () => resolve(undefined);
+				}),
+				cancel: (): void => {},
+			}),
+		} as unknown as DbOwnerClient;
+
+		let returned = false;
+		const run = runOwnerMaintenanceWithRetry(owner, { kind: "sleep", durationMs: 0 }, "test.owner-settlement-fence", {
+			deadlineMs: 100,
+			waitForOwnerCompletionOnDeadline: true,
+			onOwnerJobSettled: () => {
+				settledNotifications += 1;
+			},
+		}).catch((error: unknown) => {
+			returned = true;
+			throw error;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(returned).toBe(false);
+
+		releaseMetrics?.();
+		await expect(run).rejects.toBeInstanceOf(DbOwnerDeadlineError);
+		expect(settledNotifications).toBe(1);
 	});
 
 	test("reports queue admission separately from owner execution time", async () => {

--- a/platform/daemon/src/db-owner-maintenance.ts
+++ b/platform/daemon/src/db-owner-maintenance.ts
@@ -41,6 +41,12 @@ export interface DbOwnerMaintenanceOptions {
 	readonly onOwnerMetrics?: (metrics: DbOwnerMaintenanceMetrics) => void | Promise<void>;
 	/** Called when the owner worker has emitted its terminal result. */
 	readonly onOwnerJobSettled?: () => void | Promise<void>;
+	/**
+	 * Keep a deadline-abandoned synchronous job as the caller's completion fence.
+	 * Queued jobs resolve their metrics without running; dispatched jobs resolve
+	 * after the owner emits its terminal result.
+	 */
+	readonly waitForOwnerCompletionOnDeadline?: boolean;
 	/** Called when admission rejects before an owner job is created. */
 	readonly onOwnerJobAdmissionFailure?: (error: unknown) => void;
 }
@@ -106,7 +112,17 @@ async function runOwnerJob<Result>(
 		// synchronous worker; its metrics promise remains the completion fence.
 		if (!(error instanceof DbOwnerDeadlineError)) notifySettled();
 	});
-	const result = await handle.result;
+	let result: Result;
+	try {
+		result = await handle.result;
+	} catch (error) {
+		if (error instanceof DbOwnerDeadlineError && options.waitForOwnerCompletionOnDeadline === true) {
+			await handle.metrics?.catch(() => {
+				// Preserve the original deadline error if owner metrics fail too.
+			});
+		}
+		throw error;
+	}
 	const metrics = await handle.metrics;
 	if (metrics !== undefined) {
 		await options.onOwnerMetrics?.({

--- a/platform/daemon/src/incremental-database-integrity.test.ts
+++ b/platform/daemon/src/incremental-database-integrity.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createDbOwnerClient } from "./db-owner-client";
+import { createDbOwnerClient, DbOwnerDeadlineError, type DbOwnerClient } from "./db-owner-client";
 import {
 	runIncrementalDatabaseIntegrityCheck,
 	readMigrationVerifyCheckpoint,
@@ -203,6 +203,44 @@ describe("incremental database integrity maintenance (#1683)", () => {
 
 		expect(result.checkedObjects).toBe(1);
 		expect(database.owner.health().activeJobId).toBeNull();
+	});
+
+	it("publishes the committed checkpoint without probing after an owner deadline", async () => {
+		const operations: string[] = [];
+		let releaseMetrics: (() => void) | undefined;
+		let metricsSettled = false;
+		const owner = {
+			health: () => ({ state: "ready" }),
+			submit: (_request: unknown, options: { readonly operation: string }) => {
+				operations.push(options.operation);
+				return {
+					job: { enqueuedAt: Date.now() } as never,
+					result: Promise.reject(new DbOwnerDeadlineError("test.integrity.deadline")),
+					metrics: new Promise<undefined>((resolve) => {
+						releaseMetrics = () => {
+							metricsSettled = true;
+							resolve(undefined);
+						};
+					}),
+					cancel: (): void => {},
+				};
+			},
+		} as unknown as DbOwnerClient;
+
+		const resultPromise = runIncrementalDatabaseIntegrityCheck({
+			owner,
+			checkpointKey: "test.integrity.deadline",
+			runBudgetMs: 5_000,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(metricsSettled).toBe(false);
+		releaseMetrics?.();
+
+		const result = await resultPromise;
+		expect(result.phase).toBe("timed_out");
+		expect(result.remainingObjects).toBe(0);
+		expect(metricsSettled).toBe(true);
+		expect(operations).toEqual(["integrity.checkpoint.ensure"]);
 	});
 
 	it("preserves the checkpoint across a hard 100ms run budget and resumes", async () => {

--- a/platform/daemon/src/incremental-database-integrity.ts
+++ b/platform/daemon/src/incremental-database-integrity.ts
@@ -18,6 +18,7 @@ import {
 	ownerTransaction,
 	ownerRunStatement,
 	type DbOwnerMaintenanceMetrics,
+	type DbOwnerMaintenanceOptions,
 } from "./db-owner-maintenance";
 import { updateDatabaseIntegrityStatus, type DatabaseIntegrityProgress } from "./database-integrity";
 
@@ -102,6 +103,21 @@ interface QuickCheckRow {
 
 type OwnerMetricsCallback = (metrics: DbOwnerMaintenanceMetrics) => void | Promise<void>;
 
+function integrityOwnerOptions(
+	deadlineMs: number,
+	onOwnerMetrics?: OwnerMetricsCallback,
+	estimatedWorkUnits?: number,
+): DbOwnerMaintenanceOptions {
+	// A deadline abandons the client result, but a synchronous SQLite worker can
+	// still be running; the integrity scheduler must not admit its next slice.
+	return {
+		deadlineMs,
+		waitForOwnerCompletionOnDeadline: true,
+		...(estimatedWorkUnits === undefined ? {} : { estimatedWorkUnits }),
+		...(onOwnerMetrics === undefined ? {} : { onOwnerMetrics }),
+	};
+}
+
 const TELEMETRY_INTEGRITY_CURSOR = "\uffff:telemetry_integrity";
 
 function checkpointCursorToLastObject(cursor: string): string | null {
@@ -179,7 +195,7 @@ async function ensureCheckpoint(
 					updated_at TEXT NOT NULL
 				)`),
 		],
-		{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics, 1),
 	);
 	// Upgrade the column before any statement references it: on a legacy table
 	// (created before attempt_count existed) the INSERT below would otherwise
@@ -190,7 +206,7 @@ async function ensureCheckpoint(
 		"integrity.checkpoint.columns",
 		`PRAGMA table_info(${CHECKPOINT_TABLE})`,
 		[],
-		{ deadlineMs, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics),
 	);
 	if (!columns.some((column) => column.name === "attempt_count")) {
 		try {
@@ -198,7 +214,7 @@ async function ensureCheckpoint(
 				owner,
 				"integrity.checkpoint.attempt-count-column",
 				[ownerRunStatement(`ALTER TABLE ${CHECKPOINT_TABLE} ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0`)],
-				{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+				integrityOwnerOptions(deadlineMs, onOwnerMetrics, 1),
 			);
 		} catch (error) {
 			if (!isDuplicateColumnError(error)) throw error;
@@ -207,7 +223,7 @@ async function ensureCheckpoint(
 				"integrity.checkpoint.columns.after-race",
 				`PRAGMA table_info(${CHECKPOINT_TABLE})`,
 				[],
-				{ deadlineMs, onOwnerMetrics },
+				integrityOwnerOptions(deadlineMs, onOwnerMetrics),
 			);
 			if (!columnsAfterRace.some((column) => column.name === "attempt_count")) throw error;
 		}
@@ -223,7 +239,7 @@ async function ensureCheckpoint(
 				[key, new Date().toISOString()],
 			),
 		],
-		{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics, 1),
 	);
 }
 
@@ -241,7 +257,7 @@ async function readCheckpoint(
 			attempt_count AS attemptCount, status
 		 FROM ${CHECKPOINT_TABLE} WHERE checkpoint_key = ?`,
 		[key],
-		{ deadlineMs, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics),
 	);
 	if (
 		row === undefined ||
@@ -277,7 +293,7 @@ async function resetCompleteCheckpoint(
 				[new Date().toISOString(), key],
 			),
 		],
-		{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics, 1),
 	);
 }
 
@@ -286,14 +302,20 @@ async function readPageMetrics(
 	deadlineMs: () => number,
 	onOwnerMetrics?: OwnerMetricsCallback,
 ): Promise<{ readonly pages: number; readonly bytes: number }> {
-	const pageCount = await ownerQueryOne<PageCountRow>(owner, "integrity.page-count", "PRAGMA page_count", [], {
-		deadlineMs: deadlineMs(),
-		onOwnerMetrics,
-	});
-	const pageSize = await ownerQueryOne<PageCountRow>(owner, "integrity.page-size", "PRAGMA page_size", [], {
-		deadlineMs: deadlineMs(),
-		onOwnerMetrics,
-	});
+	const pageCount = await ownerQueryOne<PageCountRow>(
+		owner,
+		"integrity.page-count",
+		"PRAGMA page_count",
+		[],
+		integrityOwnerOptions(deadlineMs(), onOwnerMetrics),
+	);
+	const pageSize = await ownerQueryOne<PageCountRow>(
+		owner,
+		"integrity.page-size",
+		"PRAGMA page_size",
+		[],
+		integrityOwnerOptions(deadlineMs(), onOwnerMetrics),
+	);
 	const pages = scalar(pageCount?.page_count);
 	return { pages, bytes: pages * scalar(pageSize?.page_size) };
 }
@@ -313,7 +335,7 @@ async function nextObject(
 		   AND type IN ('table', 'index', 'view', 'trigger')
 		 ORDER BY name, type LIMIT 1`,
 		[CHECKPOINT_TABLE, cursor],
-		{ deadlineMs: deadlineMs(), onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs(), onOwnerMetrics),
 	);
 	if (object !== undefined) return object;
 	if (cursor >= TELEMETRY_INTEGRITY_CURSOR) return undefined;
@@ -322,7 +344,7 @@ async function nextObject(
 		"integrity.telemetry.exists",
 		"SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'telemetry_events'",
 		[],
-		{ deadlineMs: deadlineMs(), onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs(), onOwnerMetrics),
 	);
 	return telemetry === undefined
 		? undefined
@@ -343,7 +365,7 @@ async function remainingObjects(
 		   AND name <> ? AND (name || ':' || type) > ?
 		   AND type IN ('table', 'index', 'view', 'trigger')`,
 		[cursor, TELEMETRY_INTEGRITY_CURSOR, CHECKPOINT_TABLE, cursor],
-		{ deadlineMs, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics),
 	);
 	return scalar(row?.value);
 }
@@ -392,7 +414,7 @@ async function persistTable(
 				],
 			),
 		],
-		{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics, 1),
 	);
 	return next;
 }
@@ -412,7 +434,7 @@ async function markComplete(
 				key,
 			]),
 		],
-		{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics, 1),
 	);
 }
 
@@ -436,7 +458,7 @@ async function markDegraded(
 				[next.cursor, next.status, new Date().toISOString(), key, checkpoint.cursor],
 			),
 		],
-		{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+		integrityOwnerOptions(deadlineMs, onOwnerMetrics, 1),
 	);
 	return next;
 }
@@ -520,13 +542,18 @@ export async function runIncrementalDatabaseIntegrityCheck(
 		if (remaining < 1) throw new IntegrityRunBudgetError();
 		return Math.min(ownerDeadlineMs, Math.floor(remaining));
 	};
-	const emit = async (phase: IncrementalIntegrityPhase, reason: string | null): Promise<void> => {
+	const emit = async (
+		phase: IncrementalIntegrityPhase,
+		reason: string | null,
+		remainingOverride?: number,
+	): Promise<void> => {
 		const remaining =
-			phase === "degraded"
+			remainingOverride ??
+			(phase === "degraded"
 				? 0
 				: await remainingObjects(options.owner, checkpoint.cursor, remainingBudget(), recordOwnerMetrics).catch(
 						() => 0,
-					);
+					));
 		const progress = progressFrom(
 			key,
 			phase,
@@ -542,13 +569,14 @@ export async function runIncrementalDatabaseIntegrityCheck(
 		updateDatabaseIntegrityStatus(progress, errors, options.owner);
 		await options.onProgress?.(progress);
 	};
-	const progressSnapshot = async (): Promise<IncrementalIntegrityProgress> => {
+	const progressSnapshot = async (remainingOverride?: number): Promise<IncrementalIntegrityProgress> => {
 		const remaining =
-			phase === "degraded"
+			remainingOverride ??
+			(phase === "degraded"
 				? 0
 				: await remainingObjects(options.owner, checkpoint.cursor, remainingBudget(), recordOwnerMetrics).catch(
 						() => 0,
-					);
+					));
 		return progressFrom(
 			key,
 			phase,
@@ -631,14 +659,14 @@ export async function runIncrementalDatabaseIntegrityCheck(
 								? `PRAGMA integrity_check(${escapeIdentifier(table.name)})`
 								: `PRAGMA quick_check(${escapeIdentifier(table.name)})`,
 							[],
-							{ deadlineMs: remainingBudget(), estimatedWorkUnits: 1, onOwnerMetrics: recordOwnerMetrics },
+							integrityOwnerOptions(remainingBudget(), recordOwnerMetrics, 1),
 						)
 					: await ownerQueryOne<{ sql?: unknown }>(
 							options.owner,
 							`integrity.${table.type}.check`,
 							"SELECT sql FROM sqlite_schema WHERE type = ? AND name = ?",
 							[table.type, table.name],
-							{ deadlineMs: remainingBudget(), estimatedWorkUnits: 1, onOwnerMetrics: recordOwnerMetrics },
+							integrityOwnerOptions(remainingBudget(), recordOwnerMetrics, 1),
 						);
 			let message =
 				table.type === "table"
@@ -653,25 +681,21 @@ export async function runIncrementalDatabaseIntegrityCheck(
 					"integrity.telemetry.indexes",
 					"SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'telemetry_events' AND sql IS NOT NULL ORDER BY name",
 					[],
-					{ deadlineMs: remainingBudget(), estimatedWorkUnits: 1, onOwnerMetrics: recordOwnerMetrics },
+					integrityOwnerOptions(remainingBudget(), recordOwnerMetrics, 1),
 				);
 				if (failed && indexes.length > 0) {
 					await ownerTransaction(
 						options.owner,
 						"integrity.telemetry.reindex",
 						indexes.map((index) => ownerRunStatement(`REINDEX ${escapeIdentifier(index.name)}`)),
-						{
-							deadlineMs: remainingBudget(),
-							estimatedWorkUnits: Math.min(MAX_WORK_UNITS, indexes.length + 2),
-							onOwnerMetrics: recordOwnerMetrics,
-						},
+						integrityOwnerOptions(remainingBudget(), recordOwnerMetrics, Math.min(MAX_WORK_UNITS, indexes.length + 2)),
 					);
 					const verification = await ownerQueryOne<QuickCheckRow>(
 						options.owner,
 						"integrity.telemetry.verify",
 						`PRAGMA integrity_check(${escapeIdentifier(table.name)})`,
 						[],
-						{ deadlineMs: remainingBudget(), estimatedWorkUnits: 1, onOwnerMetrics: recordOwnerMetrics },
+						integrityOwnerOptions(remainingBudget(), recordOwnerMetrics, 1),
 					);
 					message = text(verification?.integrity_check);
 					failed = message !== "ok";
@@ -708,8 +732,9 @@ export async function runIncrementalDatabaseIntegrityCheck(
 		const reason = error instanceof Error ? error.message : String(error);
 		phase = isDeadline(error) || error instanceof IntegrityRunBudgetError ? "timed_out" : "unavailable";
 		cancellationReason = reason;
+		const remainingOverride = isDeadline(error) ? 0 : undefined;
 		try {
-			await emit(phase, reason);
+			await emit(phase, reason, remainingOverride);
 		} catch {
 			const progress = progressFrom(
 				key,
@@ -726,7 +751,7 @@ export async function runIncrementalDatabaseIntegrityCheck(
 			updateDatabaseIntegrityStatus(progress, [...errors, reason], options.owner);
 			return { ...progress, errors: [...errors, reason] };
 		}
-		return { ...(await progressSnapshot()), errors: [...errors, reason] };
+		return { ...(await progressSnapshot(remainingOverride)), errors: [...errors, reason] };
 	}
 }
 

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -333,168 +333,168 @@
     },
     {
       "path": "daemon.ts",
-      "line": 614,
+      "line": 615,
       "api": "existsSync",
       "source": "if (!existsSync(agentsMdPath)) return;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 631,
+      "line": 632,
       "api": "existsSync",
       "source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 659,
+      "line": 660,
       "api": "existsSync",
       "source": "if (!existsSync(identityPath)) return \"\";",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 689,
+      "line": 690,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 721,
+      "line": 722,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 728,
+      "line": 729,
       "api": "existsSync",
       "source": "if (existsSync(geminiDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 733,
+      "line": 734,
       "api": "existsSync",
       "source": "if (existsSync(settingsPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 734,
+      "line": 735,
       "api": "readFileSync",
       "source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 754,
+      "line": 755,
       "api": "existsSync",
       "source": "if (!existsSync(targetPath)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1319,
+      "line": 1320,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1687,
+      "line": 1688,
       "api": "existsSync",
       "source": "if (!existsSync(p)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1689,
+      "line": 1690,
       "api": "readFileSync",
       "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1733,
+      "line": 1734,
       "api": "existsSync",
       "source": "if (!existsSync(path)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1735,
+      "line": 1736,
       "api": "readFileSync",
       "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2137,
+      "line": 2138,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2139,
+      "line": 2140,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2297,
+      "line": 2298,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2298,
+      "line": 2299,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2299,
+      "line": 2300,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2470,
+      "line": 2471,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2545,
+      "line": 2546,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3285,
+      "line": 3286,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3286,
+      "line": 3287,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3289,
+      "line": 3290,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"
@@ -840,7 +840,7 @@
     },
     {
       "path": "db-owner-client.ts",
-      "line": 839,
+      "line": 843,
       "api": "unlinkSync",
       "source": "unlinkSync(cancellationRegistryPath);",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

Prevent database-integrity maintenance from creating a retry storm after a DB-owner deadline, and keep the pipeline's startup embedding-state read independent from FTS/integrity maintenance.

## Changes

- Make deadline-abandoned owner jobs usable as completion fences for opted-in maintenance callers; queued jobs close their metrics fence immediately because no worker exists.
- Make incremental integrity wait for the physical owner worker before returning, avoid post-deadline remaining-work probes, and resume from the last committed checkpoint.
- Route the startup active-embedding-state read through the independent read lane.
- Add regressions for dispatched and queued deadline settlement, no post-deadline probe, and existing lane behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable: no frontend changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable: no migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- The visible failure was a daemon-side DB-owner deadline during pipeline resume, not evidence of invalid provider credentials.
- Focused daemon matrix: 88 tests passed across six suites after rebasing onto v0.219.7.
- The repository hook initially failed because the fresh worktree lacked optional/generated connector artifacts; the daemon build/typecheck path was then exercised with local-only generated artifacts and cleanup.
- No daemon restart, migration, configuration change, or credential access was performed.
