### PR TITLE
feat(install): make Windows a first-class install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Read more: [Why Signet](https://docs.signetai.sh/quickstart/#why-signet) · [Arc
 curl -fsSL https://signetai.sh/install.sh | bash                 # recommended
 ```
 
+On Windows x64, run the PowerShell installer:
+
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
+```
+
 Or: `npm install -g signetai` / `bun add -g signetai`
 
 Don't want to handle setup yourself? Paste this to your AI agent:
@@ -47,7 +53,7 @@ Don't want to handle setup yourself? Paste this to your AI agent:
 Install and fully configure Signet AI by following this guide exactly: https://signetai.sh/skill.md
 ```
 
-Covers Linux x64/arm64, macOS x64/arm64, Docker, and Windows x64 (Windows: use `npm install -g signetai` or Docker).
+Covers Linux x64/arm64, macOS x64/arm64, Windows x64, and Docker.
 
 Durable transcript imports require Linux or macOS filesystem safeguards. The
 Windows package remains supported for other Signet features; transcript import

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ iwr -useb https://signetai.sh/install.ps1 | iex
 
 Or: `npm install -g signetai` / `bun add -g signetai`
 
+The npm and Bun wrappers install the same compiled Signet binary through a matching native package.
+
 Don't want to handle setup yourself? Paste this to your AI agent:
 
 ```
@@ -56,7 +58,7 @@ Install and fully configure Signet AI by following this guide exactly: https://s
 Covers Linux x64/arm64, macOS x64/arm64, Windows x64, and Docker.
 
 Durable transcript imports require Linux or macOS filesystem safeguards. The
-Windows package remains supported for other Signet features; transcript import
+Windows install remains supported for other Signet features; transcript import
 mutations and imported-source deletion return a structured `501` platform error.
 
 ### Setup

--- a/dist/signetai/README.md
+++ b/dist/signetai/README.md
@@ -37,7 +37,7 @@ iwr -useb https://signetai.sh/install.ps1 | iex
 The published binary supports Windows, but durable transcript imports use
 descriptor-relative filesystem safeguards available only on Linux and macOS.
 Transcript import mutations and deletion of imported Sources return a structured
-`501` platform error on Windows; other Windows package features remain supported.
+`501` platform error on Windows; other Windows features remain supported.
 
 The Windows PowerShell installer verifies the release manifest, installs the
 native binary and connector assets, and adds Signet to the user PATH.

--- a/dist/signetai/README.md
+++ b/dist/signetai/README.md
@@ -1,7 +1,7 @@
 # Signet
 
 This npm package is a thin wrapper for the same compiled Signet binary used by
-the curl installer and Bun global installs.
+the native installers and Bun global installs.
 
 ```bash
 npm install -g signetai
@@ -22,6 +22,12 @@ Direct curl installs use the same compiled Signet binary:
 curl -fsSL https://signetai.sh/install.sh | bash
 ```
 
+On Windows x64, use the native PowerShell installer:
+
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
+```
+
 ## Requirements
 
 - Node.js for the npm wrapper, or Bun for the Bun wrapper
@@ -33,9 +39,8 @@ descriptor-relative filesystem safeguards available only on Linux and macOS.
 Transcript import mutations and deletion of imported Sources return a structured
 `501` platform error on Windows; other Windows package features remain supported.
 
-Windows direct installs should use the npm wrapper. The old PowerShell
-`install.ps1` path has been removed until a native Windows direct installer
-ships.
+The Windows PowerShell installer verifies the release manifest, installs the
+native binary and connector assets, and adds Signet to the user PATH.
 
 ## Documentation
 

--- a/docs/RELEASE_CHANNELS.md
+++ b/docs/RELEASE_CHANNELS.md
@@ -28,6 +28,12 @@ npm install -g signetai@next
 curl -fsSL https://signetai.sh/install.sh | SIGNET_CHANNEL=nightly bash
 ```
 
+On Windows x64:
+
+```powershell
+$env:SIGNET_CHANNEL = "nightly"; iwr -useb https://signetai.sh/install.ps1 | iex
+```
+
 The npm package is a wrapper around the same compiled Signet binary published
 to the GitHub release for that version.
 
@@ -51,6 +57,12 @@ npm install -g signetai
 
 # Direct native installer (stable is the default)
 curl -fsSL https://signetai.sh/install.sh | bash
+```
+
+On Windows x64, the stable channel is the default:
+
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
 ```
 
 Or switch back from nightly:

--- a/scripts/check-install-guide.ts
+++ b/scripts/check-install-guide.ts
@@ -113,9 +113,15 @@ function main(): void {
 			},
 		]),
 	);
-	failures.push(...runRules(heroPath, hero, [{ kind: "require", pattern: /OsInstallSelector/, description: "OS install selector" }]));
 	failures.push(
-		...runRules(installCtaPath, installCta, [{ kind: "require", pattern: /OsInstallSelector/, description: "OS install selector" }]),
+		...runRules(heroPath, hero, [
+			{ kind: "require", pattern: /OsInstallSelector/, description: "OS install selector" },
+		]),
+	);
+	failures.push(
+		...runRules(installCtaPath, installCta, [
+			{ kind: "require", pattern: /OsInstallSelector/, description: "OS install selector" },
+		]),
 	);
 
 	if (failures.length > 0) {

--- a/scripts/check-install-guide.ts
+++ b/scripts/check-install-guide.ts
@@ -32,7 +32,8 @@ function main(): void {
 	const skillPath = "web/marketing/public/skill.md";
 	const readmePath = "README.md";
 	const heroPath = "web/marketing/src/components/landing/Hero.astro";
-	const ctaPath = "web/marketing/src/components/landing/Cta.astro";
+	const installCtaPath = "web/marketing/src/components/landing/InstallCta.astro";
+	const selectorPath = "web/marketing/src/components/landing/OsInstallSelector.astro";
 
 	const expectedPrompt =
 		"Install and fully configure Signet AI by following this guide exactly: https://signetai.sh/skill.md";
@@ -40,7 +41,8 @@ function main(): void {
 	const skill = load(skillPath);
 	const readme = load(readmePath);
 	const hero = load(heroPath);
-	const cta = load(ctaPath);
+	const installCta = load(installCtaPath);
+	const selector = load(selectorPath);
 
 	const failures: string[] = [];
 
@@ -89,10 +91,32 @@ function main(): void {
 		pattern: new RegExp(expectedPrompt.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
 		description: `Expected install prompt: ${expectedPrompt}`,
 	};
+	const windowsInstallerRule: Rule = {
+		kind: "require",
+		pattern: /iwr -useb https:\/\/signetai\.sh\/install\.ps1 \| iex/,
+		description: "Windows PowerShell installer",
+	};
 
 	failures.push(...runRules(readmePath, readme, [promptRule]));
-	failures.push(...runRules(heroPath, hero, [promptRule]));
-	failures.push(...runRules(ctaPath, cta, [promptRule]));
+	failures.push(
+		...runRules(selectorPath, selector, [
+			windowsInstallerRule,
+			{
+				kind: "require",
+				pattern: /id: "windows"/,
+				description: "Windows operating-system selector tab",
+			},
+			{
+				kind: "require",
+				pattern: /id: "unix"/,
+				description: "macOS and Linux operating-system selector tab",
+			},
+		]),
+	);
+	failures.push(...runRules(heroPath, hero, [{ kind: "require", pattern: /OsInstallSelector/, description: "OS install selector" }]));
+	failures.push(
+		...runRules(installCtaPath, installCta, [{ kind: "require", pattern: /OsInstallSelector/, description: "OS install selector" }]),
+	);
 
 	if (failures.length > 0) {
 		console.error("Install guide guard failed:\n");

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 const root = join(import.meta.dir, "..");
 const nativeInstallCommand = "curl -fsSL https://signetai.sh/install.sh | bash";
+const windowsInstallCommand = "iwr -useb https://signetai.sh/install.ps1 | iex";
 
 function read(path: string): string {
 	return readFileSync(join(root, path), "utf-8");
@@ -15,8 +16,6 @@ describe("install copy", () => {
 			"README.md",
 			"web/docs/src/content/docs/getting-started/install.md",
 			"web/docs/src/content/docs/cli/getting-started.md",
-			"web/marketing/src/components/landing/Hero.astro",
-			"web/marketing/src/components/landing/InstallCta.astro",
 			"web/marketing/src/components/landing/Quickstart.astro",
 			"web/marketing/public/skill.md",
 		];
@@ -24,6 +23,19 @@ describe("install copy", () => {
 		for (const path of primarySurfaces) {
 			expect(read(path)).toContain(nativeInstallCommand);
 		}
+
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain(windowsInstallCommand);
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain('data-install-os={option.id}');
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain('id: "unix"');
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain("install-os-icon-pair");
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain("macOS and Linux");
+		expect(read("web/marketing/src/components/landing/Hero.astro")).toContain("OsInstallSelector");
+		expect(read("web/marketing/src/components/landing/InstallCta.astro")).toContain("OsInstallSelector");
+		const interactions = read("web/marketing/src/scripts/interactions.ts");
+		expect(interactions).toContain("navigator.userAgent");
+		expect(interactions).toContain("windows nt|win32|win64");
+		expect(interactions).toContain('return "unix"');
+		expect(interactions).toContain("panel.hidden = !active");
 
 		for (const path of [
 			"README.md",
@@ -57,6 +69,19 @@ describe("install copy", () => {
 		expect(installer).not.toContain("bun add -g signetai");
 		expect(installer).not.toContain("npm install -g signetai");
 		expect(installer).not.toContain("better-sqlite3");
+	});
+
+	test("serves a checksum-verifying native Windows installer", () => {
+		const installer = read("web/marketing/public/install.ps1");
+
+		expect(installer).toContain("native-manifest.json");
+		expect(installer).toContain("win32-x64");
+		expect(installer).toContain("signet-win32-x64.exe");
+		expect(installer).toContain("Get-FileHash -Algorithm SHA256");
+		expect(installer).toContain("--connector-assets");
+		expect(installer).toContain("SetEnvironmentVariable(\"Path\", $updatedUserPath, \"User\")");
+		expect(installer).toContain("SIGNET_CHANNEL");
+		expect(installer).not.toContain("npm install -g signetai");
 	});
 
 	test("keeps the npm package as a native binary wrapper", () => {

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -25,10 +25,18 @@ describe("install copy", () => {
 		}
 
 		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain(windowsInstallCommand);
-		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain('data-install-os={option.id}');
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain(
+			"data-install-os={option.id}",
+		);
 		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain('id: "unix"');
 		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain("install-os-icon-pair");
 		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain("macOS and Linux");
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain(
+			'data-analytics-command={option.id === "windows" ? "native_install_windows" : "native_install"}',
+		);
+		expect(read("web/marketing/src/components/landing/OsInstallSelector.astro")).toContain(
+			"data-analytics-placement={placement}",
+		);
 		expect(read("web/marketing/src/components/landing/Hero.astro")).toContain("OsInstallSelector");
 		expect(read("web/marketing/src/components/landing/InstallCta.astro")).toContain("OsInstallSelector");
 		const interactions = read("web/marketing/src/scripts/interactions.ts");
@@ -57,7 +65,7 @@ describe("install copy", () => {
 		expect(installer).toContain("native-manifest.json");
 		expect(installer).toContain("SIGNET_RELEASES_API_BASE");
 		expect(installer).toContain("SIGNET_RELEASE_TAG");
-		expect(installer).toContain("${VERSION:-}");
+		expect(installer).toContain(`\${VERSION:-}`);
 		expect(installer).toContain("SIGNET_CHANNEL");
 		expect(installer).toContain('"$binary_path" install --force "$@"');
 		expect(installer).toContain(
@@ -79,7 +87,7 @@ describe("install copy", () => {
 		expect(installer).toContain("signet-win32-x64.exe");
 		expect(installer).toContain("Get-FileHash -Algorithm SHA256");
 		expect(installer).toContain("--connector-assets");
-		expect(installer).toContain("SetEnvironmentVariable(\"Path\", $updatedUserPath, \"User\")");
+		expect(installer).toContain('SetEnvironmentVariable("Path", $updatedUserPath, "User")');
 		expect(installer).toContain("SIGNET_CHANNEL");
 		expect(installer).not.toContain("npm install -g signetai");
 	});
@@ -129,7 +137,7 @@ describe("install copy", () => {
 		expect(installer).toContain("native-manifest.json");
 		expect(installer).toContain("CONNECTOR_COMPONENT");
 		expect(installer).toContain("verifySha256");
-		expect(installer).toContain("signet-connectors-${manifest.version}.tar.gz");
+		expect(installer).toContain(`signet-connectors-\${manifest.version}.tar.gz`);
 		expect(installer).not.toContain("bun.sh/install");
 		expect(installer).not.toContain("better-sqlite3");
 	});
@@ -178,7 +186,7 @@ describe("install copy", () => {
 
 	test("build-connector-assets stages runtime plugin assets into a tarball", () => {
 		const buildScript = read("scripts/build-connector-assets.ts");
-		expect(buildScript).toContain("signet-connectors-${version}.tar.gz");
+		expect(buildScript).toContain(`signet-connectors-\${version}.tar.gz`);
 		expect(buildScript).toContain("runtime/connectors");
 		// The build script walks every `integrations/*/connector/` and
 		// ships any non-source/asset dir under the runtime tree.

--- a/web/docs/src/content/docs/ai-memory-hermes-openclaw.md
+++ b/web/docs/src/content/docs/ai-memory-hermes-openclaw.md
@@ -143,6 +143,15 @@ signet start
 signet status
 ```
 
+On Windows x64, use the native PowerShell installer instead:
+
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
+signet setup
+signet start
+signet status
+```
+
 During setup, select Hermes Agent and OpenClaw when prompted. For
 non-interactive installs, see the harness-specific options in
 [Harnesses](/harnesses/).

--- a/web/docs/src/content/docs/cli/getting-started.md
+++ b/web/docs/src/content/docs/cli/getting-started.md
@@ -17,7 +17,13 @@ bun add -g signetai
 signet --help
 ```
 
-Use one installation route per machine. See [Install](/getting-started/install/) for platform notes. All three installation paths provide the same compiled Signet binary through the matching native package.
+On Windows x64, use the native PowerShell installer:
+
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
+```
+
+Use one installation route per machine. See [Install](/getting-started/install/) for platform notes. All installation paths provide the same compiled Signet binary through the matching native package.
 
 ## Common commands
 

--- a/web/docs/src/content/docs/cli/getting-started.md
+++ b/web/docs/src/content/docs/cli/getting-started.md
@@ -23,7 +23,7 @@ On Windows x64, use the native PowerShell installer:
 iwr -useb https://signetai.sh/install.ps1 | iex
 ```
 
-Use one installation route per machine. See [Install](/getting-started/install/) for platform notes. All installation paths provide the same compiled Signet binary through the matching native package.
+Use one installation route per machine. Each route installs the same compiled Signet binary; package-manager routes use the matching native package. See [Install](/getting-started/install/) for platform notes.
 
 ## Common commands
 

--- a/web/docs/src/content/docs/getting-started/install.md
+++ b/web/docs/src/content/docs/getting-started/install.md
@@ -11,6 +11,17 @@ For macOS and Linux, the native installer is the recommended route:
 curl -fsSL https://signetai.sh/install.sh | bash
 ```
 
+For Windows x64, run the PowerShell installer:
+
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
+```
+
+The Windows installer verifies the release checksum, installs the native
+binary and connector assets, and adds Signet to the user PATH. Open a new
+PowerShell window after installation. The direct Windows installer currently
+supports x64; Windows ARM64 is not currently covered by the direct installer.
+
 Package-manager wrappers install the same compiled Signet binary as the direct installer through the matching native package:
 
 ```bash
@@ -19,7 +30,7 @@ npm install -g signetai
 bun add -g signetai
 ```
 
-Use one method per machine. The npm and Bun routes require their corresponding runtime; the direct installer does not install Bun or rebuild Signet. Windows currently uses the npm route:
+Use one method per machine. The npm and Bun routes require their corresponding runtime; the direct installers do not install Bun or rebuild Signet.
 
 ```bash
 npm install -g signetai

--- a/web/docs/src/content/docs/getting-started/install.md
+++ b/web/docs/src/content/docs/getting-started/install.md
@@ -32,10 +32,6 @@ bun add -g signetai
 
 Use one method per machine. The npm and Bun routes require their corresponding runtime; the direct installers do not install Bun or rebuild Signet.
 
-```bash
-npm install -g signetai
-```
-
 Confirm that the launcher is available, then start onboarding:
 
 ```bash

--- a/web/docs/src/content/docs/quickstart.md
+++ b/web/docs/src/content/docs/quickstart.md
@@ -14,10 +14,10 @@ curl -fsSL https://signetai.sh/install.sh | bash
 signet --help
 ```
 
-Windows users should install the package wrapper instead:
+On Windows x64, use the PowerShell installer:
 
-```bash
-npm install -g signetai
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
 ```
 
 See [Install](/getting-started/install/) for package-manager alternatives and non-interactive setup.

--- a/web/marketing/public/_headers
+++ b/web/marketing/public/_headers
@@ -13,6 +13,9 @@
 /install.sh
   Content-Type: text/plain; charset=utf-8
 
+/install.ps1
+  Content-Type: text/plain; charset=utf-8
+
 /llms.txt
   Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=3600

--- a/web/marketing/public/install.ps1
+++ b/web/marketing/public/install.ps1
@@ -1,0 +1,259 @@
+& {
+	$ErrorActionPreference = "Stop"
+	Set-StrictMode -Version Latest
+
+	function Get-EnvironmentValue {
+		param(
+			[Parameter(Mandatory = $true)][string]$Name,
+			[string]$Default = ""
+		)
+
+		$value = [Environment]::GetEnvironmentVariable($Name)
+		if ([string]::IsNullOrWhiteSpace($value)) {
+			return $Default
+		}
+		return $value
+	}
+
+	function ConvertTo-ReleaseTag {
+		param([Parameter(Mandatory = $true)][string]$Value)
+
+		$trimmed = $Value.Trim()
+		if ([string]::IsNullOrWhiteSpace($trimmed)) {
+			throw "Signet release version cannot be empty."
+		}
+		if ($trimmed.StartsWith("v", [StringComparison]::OrdinalIgnoreCase)) {
+			return $trimmed
+		}
+		return "v$trimmed"
+	}
+
+	function Join-DownloadUrl {
+		param(
+			[Parameter(Mandatory = $true)][string]$Base,
+			[Parameter(Mandatory = $true)][string]$Asset
+		)
+
+		return "{0}/{1}" -f $Base.TrimEnd("/"), $Asset.TrimStart("/")
+	}
+
+	function Download-File {
+		param(
+			[Parameter(Mandatory = $true)][string]$Url,
+			[Parameter(Mandatory = $true)][string]$Path
+		)
+
+		Write-Host "Downloading $Url"
+		Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $Path
+	}
+
+	function Get-Sha256 {
+		param([Parameter(Mandatory = $true)][string]$Path)
+
+		return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+	}
+
+	function Get-ComparableWindowsPath {
+		param([Parameter(Mandatory = $true)][string]$Path)
+
+		$expanded = [Environment]::ExpandEnvironmentVariables($Path.Trim().Trim('"'))
+		return $expanded.TrimEnd([char[]]"/\").ToLowerInvariant()
+	}
+
+	function Add-UserPathEntry {
+		param([Parameter(Mandatory = $true)][string]$Directory)
+
+		$normalizedDirectory = Get-ComparableWindowsPath $Directory
+		$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+		$userEntries = @()
+		if (-not [string]::IsNullOrWhiteSpace($userPath)) {
+			$userEntries = @($userPath -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+		}
+
+		$alreadyPersisted = $userEntries | Where-Object {
+			(Get-ComparableWindowsPath ([string]$_)) -eq $normalizedDirectory
+		}
+		if ($null -eq $alreadyPersisted) {
+			$updatedUserPath = if ([string]::IsNullOrWhiteSpace($userPath)) {
+				$Directory
+			} else {
+				"$Directory;$userPath"
+			}
+			[Environment]::SetEnvironmentVariable("Path", $updatedUserPath, "User")
+		}
+
+		$currentEntries = @()
+		if (-not [string]::IsNullOrWhiteSpace($env:Path)) {
+			$currentEntries = @($env:Path -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+		}
+		$alreadyCurrent = $currentEntries | Where-Object {
+			(Get-ComparableWindowsPath ([string]$_)) -eq $normalizedDirectory
+		}
+		if ($null -eq $alreadyCurrent) {
+			$env:Path = if ([string]::IsNullOrWhiteSpace($env:Path)) {
+				$Directory
+			} else {
+				"$Directory;$env:Path"
+			}
+		}
+	}
+
+	# Windows PowerShell 5.1 may default to TLS 1.0 on older hosts. GitHub and
+	# signetai.sh require TLS 1.2 or newer.
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+	$repo = Get-EnvironmentValue "SIGNET_RELEASE_REPO" "Signet-AI/signetai"
+	$releasesApiBase = Get-EnvironmentValue "SIGNET_RELEASES_API_BASE" "https://api.github.com/repos/$repo/releases"
+	$releasesDownloadBase = Get-EnvironmentValue "SIGNET_RELEASES_DOWNLOAD_BASE" "https://github.com/$repo/releases/download"
+	$latestReleaseApi = Get-EnvironmentValue "SIGNET_LATEST_RELEASE_API" "$releasesApiBase/latest"
+	$nightlyVersionApi = Get-EnvironmentValue "SIGNET_NIGHTLY_VERSION_API" "https://registry.npmjs.org/signetai/next"
+	$channel = Get-EnvironmentValue "SIGNET_CHANNEL" "stable"
+
+	if ($channel -ne "stable" -and $channel -ne "nightly") {
+		throw "SIGNET_CHANNEL must be stable or nightly."
+	}
+
+	$downloadBase = Get-EnvironmentValue "SIGNET_DOWNLOAD_BASE"
+	if ([string]::IsNullOrWhiteSpace($downloadBase)) {
+		$releaseTag = Get-EnvironmentValue "SIGNET_RELEASE_TAG"
+		if ([string]::IsNullOrWhiteSpace($releaseTag)) {
+			$explicitVersion = Get-EnvironmentValue "SIGNET_VERSION"
+			if ([string]::IsNullOrWhiteSpace($explicitVersion)) {
+				$explicitVersion = Get-EnvironmentValue "VERSION"
+			}
+			if (-not [string]::IsNullOrWhiteSpace($explicitVersion)) {
+				$releaseTag = ConvertTo-ReleaseTag $explicitVersion
+			}
+		}
+		if ([string]::IsNullOrWhiteSpace($releaseTag)) {
+			if ($channel -eq "stable") {
+				$release = Invoke-RestMethod -UseBasicParsing -Uri $latestReleaseApi
+				$releaseTag = [string]$release.tag_name
+			} else {
+				$nightly = Invoke-RestMethod -UseBasicParsing -Uri $nightlyVersionApi
+				$releaseTag = ConvertTo-ReleaseTag ([string]$nightly.version)
+			}
+		}
+		if ([string]::IsNullOrWhiteSpace($releaseTag)) {
+			throw "Could not resolve the latest Signet $channel release."
+		}
+		$downloadBase = Join-DownloadUrl $releasesDownloadBase (ConvertTo-ReleaseTag $releaseTag)
+	}
+
+	$architecture = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITEW6432")
+	if ([string]::IsNullOrWhiteSpace($architecture)) {
+		$architecture = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE")
+	}
+	if ($architecture -notmatch "^(AMD64|x64)$") {
+		throw "Signet's Windows installer currently supports Windows x64 only (detected: $architecture)."
+	}
+
+	$platform = "win32-x64"
+	$expectedAssetName = "signet-win32-x64.exe"
+	$downloadRoot = Get-EnvironmentValue "SIGNET_DOWNLOAD_DIR" (Join-Path (Get-EnvironmentValue "TEMP" ([IO.Path]::GetTempPath())) "signet")
+	$workDir = Join-Path $downloadRoot ("install-" + [Guid]::NewGuid().ToString("N"))
+	$binaryPath = $null
+	$connectorPath = $null
+
+	try {
+		New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+
+		$manifestPath = Join-Path $workDir "native-manifest.json"
+		Download-File (Join-DownloadUrl $downloadBase "native-manifest.json") $manifestPath
+		$manifest = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+
+		$matchingAssets = @($manifest.assets | Where-Object { $_.platform -eq $platform })
+		if ($matchingAssets.Count -ne 1) {
+			throw "No unique Signet native binary was found for $platform in native-manifest.json."
+		}
+		$asset = $matchingAssets[0]
+		$assetName = [string]$asset.name
+		$expectedSha256 = ([string]$asset.sha256).ToLowerInvariant()
+		if ($assetName -ne $expectedAssetName -or $expectedSha256 -notmatch "^[a-f0-9]{64}$") {
+			throw "The Signet Windows release manifest contains an invalid native asset."
+		}
+		$assetPropertyNames = @($asset.PSObject.Properties | ForEach-Object { $_.Name })
+		if ($assetPropertyNames -notcontains "size" -or [int64]$asset.size -le 0) {
+			throw "The Signet Windows release manifest is missing the native asset size."
+		}
+
+		$binaryPath = Join-Path $workDir $assetName
+		Download-File (Join-DownloadUrl $downloadBase $assetName) $binaryPath
+		$binaryInfo = Get-Item -LiteralPath $binaryPath
+		if ([int64]$binaryInfo.Length -ne [int64]$asset.size) {
+			throw "Signet native binary size verification failed."
+		}
+		if ((Get-Sha256 $binaryPath) -ne $expectedSha256) {
+			throw "Signet native binary SHA-256 verification failed."
+		}
+
+		$connector = $null
+		$manifestPropertyNames = @($manifest.PSObject.Properties | ForEach-Object { $_.Name })
+		$componentPropertyNames = @()
+		if ($manifestPropertyNames -contains "components" -and $null -ne $manifest.components) {
+			$componentPropertyNames = @($manifest.components.PSObject.Properties | ForEach-Object { $_.Name })
+		}
+		if ($componentPropertyNames -contains "connectors") {
+			$connector = $manifest.components.connectors
+		}
+		if ($null -ne $connector) {
+			$connectorUrl = [string]$connector.url
+			$connectorSha256 = ([string]$connector.sha256).ToLowerInvariant()
+			if ([string]::IsNullOrWhiteSpace($connectorUrl) -or $connectorSha256 -notmatch "^[a-f0-9]{64}$") {
+				throw "The Signet connector asset entry is invalid."
+			}
+
+			if ($connectorUrl -match "^https?://") {
+				$connectorDownloadUrl = $connectorUrl
+				$connectorName = [IO.Path]::GetFileName(([Uri]$connectorUrl).AbsolutePath)
+			} else {
+				if ($connectorUrl -match "\.\.") {
+					throw "The Signet connector asset path is invalid."
+				}
+				$connectorDownloadUrl = Join-DownloadUrl $downloadBase $connectorUrl
+				$connectorName = [IO.Path]::GetFileName(($connectorUrl -split "\?")[0])
+			}
+			if ($connectorName -notmatch "^[A-Za-z0-9._-]+$") {
+				throw "The Signet connector asset name is invalid."
+			}
+			$connectorPath = Join-Path $workDir $connectorName
+			Download-File $connectorDownloadUrl $connectorPath
+			$connectorInfo = Get-Item -LiteralPath $connectorPath
+			$connectorPropertyNames = @($connector.PSObject.Properties | ForEach-Object { $_.Name })
+			if ($connectorPropertyNames -notcontains "size" -or [int64]$connectorInfo.Length -ne [int64]$connector.size) {
+				throw "Signet connector asset size verification failed."
+			}
+			if ((Get-Sha256 $connectorPath) -ne $connectorSha256) {
+				throw "Signet connector asset SHA-256 verification failed."
+			}
+		}
+
+		$localAppData = Get-EnvironmentValue "LOCALAPPDATA" (Join-Path (Get-EnvironmentValue "USERPROFILE" $HOME) "AppData\Local")
+		$installDir = Get-EnvironmentValue "SIGNET_BIN_DIR" (Join-Path $localAppData "Programs\Signet")
+		$installArguments = @("install", "--bin-dir", $installDir, "--force")
+		if ($null -ne $connectorPath) {
+			$installArguments += @("--connector-assets", $connectorPath)
+		}
+
+		Write-Host "Installing Signet to $installDir"
+		& $binaryPath @installArguments
+		if ($LASTEXITCODE -ne 0) {
+			throw "Signet installation failed with exit code $LASTEXITCODE."
+		}
+
+		if ((Get-EnvironmentValue "SIGNET_PERSIST_PATH" "1") -ne "0") {
+			try {
+				Add-UserPathEntry $installDir
+				Write-Host "Added $installDir to the user PATH."
+			} catch {
+				Write-Warning "Signet was installed, but the user PATH could not be updated. Add this directory manually: $installDir"
+			}
+		}
+
+		Write-Host "Signet is installed. Open a new PowerShell window, then run: signet setup"
+	} finally {
+		if ($null -ne $workDir -and (Test-Path -LiteralPath $workDir)) {
+			Remove-Item -LiteralPath $workDir -Recurse -Force -ErrorAction SilentlyContinue
+		}
+	}
+}

--- a/web/marketing/public/install.ps1
+++ b/web/marketing/public/install.ps1
@@ -216,11 +216,14 @@
 			if ($connectorName -notmatch "^[A-Za-z0-9._-]+$") {
 				throw "The Signet connector asset name is invalid."
 			}
+			$connectorPropertyNames = @($connector.PSObject.Properties | ForEach-Object { $_.Name })
+			if ($connectorPropertyNames -notcontains "size" -or [int64]$connector.size -le 0) {
+				throw "The Signet connector asset entry is missing a valid size."
+			}
 			$connectorPath = Join-Path $workDir $connectorName
 			Download-File $connectorDownloadUrl $connectorPath
 			$connectorInfo = Get-Item -LiteralPath $connectorPath
-			$connectorPropertyNames = @($connector.PSObject.Properties | ForEach-Object { $_.Name })
-			if ($connectorPropertyNames -notcontains "size" -or [int64]$connectorInfo.Length -ne [int64]$connector.size) {
+			if ([int64]$connectorInfo.Length -ne [int64]$connector.size) {
 				throw "Signet connector asset size verification failed."
 			}
 			if ((Get-Sha256 $connectorPath) -ne $connectorSha256) {

--- a/web/marketing/public/skill.md
+++ b/web/marketing/public/skill.md
@@ -277,13 +277,18 @@ https://nodejs.org
 Check the operating system:
 - **macOS**: Fully supported
 - **Linux**: Fully supported
-- **Windows**: Supported via WSL (Windows Subsystem for Linux) only
+- **Windows**: Native Windows x64 is supported through the PowerShell installer
 
 ### Step 2: Install Signet
 
 Using the direct native binary installer:
 ```bash
 curl -fsSL https://signetai.sh/install.sh | bash
+```
+
+On Windows x64, use the native PowerShell installer:
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
 ```
 
 Using Bun's package-manager wrapper for the same compiled Signet binary:
@@ -718,8 +723,11 @@ curl --version                 # Required for direct native binary install
 bun --version                  # Only needed for Bun package install
 node --version                 # Only needed for npm package install
 
-# Install
+# Install on macOS/Linux
 curl -fsSL https://signetai.sh/install.sh | bash
+
+# Install on Windows x64
+iwr -useb https://signetai.sh/install.ps1 | iex
 
 # Setup
 signet                       # Show command help

--- a/web/marketing/public/skill.md
+++ b/web/marketing/public/skill.md
@@ -219,7 +219,7 @@ in user space by default.
 
 ### What Signet writes to disk
 
-Signet only writes to these locations inside the home directory:
+Signet's application data is written only to these locations inside the home directory:
 
 | Path | When | What |
 |------|------|------|
@@ -228,11 +228,14 @@ Signet only writes to these locations inside the home directory:
 | `~/.config/opencode/` | OpenCode users | Plugin bundle (signet.mjs), generated AGENTS.md, skills symlink |
 | `~/.openclaw/` or `~/.clawdbot/` or `~/.moltbot/` | OpenClaw users | Config patch only |
 
+The Windows direct installer also adds its user-level install directory to the
+current user's PATH; it does not require administrator permissions.
+
 ### What Signet NEVER does
 
 - Requires or uses sudo
-- Modifies system settings, OS preferences, or system files
-- Writes anything outside the home directory
+- Modifies system-wide settings, OS preferences, or system files
+- Writes application data outside the home directory
 - Installs system services (launchd/systemd) automatically
 - Sends data to external servers (everything is local)
 - Deletes or overwrites existing files without the setup wizard
@@ -253,10 +256,16 @@ Signet only writes to these locations inside the home directory:
 
 ### Step 1: Check prerequisites
 
-Check whether the native installer prerequisites are available:
+Check whether the native installer prerequisites are available on macOS or Linux:
 
 ```bash
 curl --version
+```
+
+On Windows x64, use PowerShell 5.1 or newer for the native installer:
+
+```powershell
+$PSVersionTable.PSVersion
 ```
 
 If you choose the Bun package-manager path instead, verify Bun first:
@@ -718,17 +727,22 @@ signet setup
 ## Quick Reference
 
 ```bash
-# Prereqs
+# Prereqs on macOS/Linux
 curl --version                 # Required for direct native binary install
 bun --version                  # Only needed for Bun package install
 node --version                 # Only needed for npm package install
 
 # Install on macOS/Linux
 curl -fsSL https://signetai.sh/install.sh | bash
+```
 
-# Install on Windows x64
+```powershell
+# Prereqs and install on Windows x64
+$PSVersionTable.PSVersion
 iwr -useb https://signetai.sh/install.ps1 | iex
+```
 
+```bash
 # Setup
 signet                       # Show command help
 signet setup                 # Explicit setup command

--- a/web/marketing/public/skill.md
+++ b/web/marketing/public/skill.md
@@ -235,7 +235,7 @@ current user's PATH; it does not require administrator permissions.
 
 - Requires or uses sudo
 - Modifies system-wide settings, OS preferences, or system files
-- Writes application data outside the home directory
+- Writes application data to system directories without an explicit configured path
 - Installs system services (launchd/systemd) automatically
 - Sends data to external servers (everything is local)
 - Deletes or overwrites existing files without the setup wizard
@@ -248,9 +248,10 @@ current user's PATH; it does not require administrator permissions.
 > GATE: Before proceeding, tell your user:
 > "I'm going to install Signet, which will give me persistent memory
 > and a secrets vault. The installer uses the compiled
-> Signet binary and runs a small background daemon on port 3850. It only
-> writes to directories inside your home folder — never system files,
-> never with sudo. Ready to proceed?"
+> Signet binary and runs a small background daemon on port 3850. It writes
+> application data in your home folder; the Windows installer also uses a
+> temporary working directory and may update your user PATH. It never writes
+> system files or uses sudo. Ready to proceed?"
 >
 > WAIT for the user to confirm before continuing.
 

--- a/web/marketing/src/components/landing/Hero.astro
+++ b/web/marketing/src/components/landing/Hero.astro
@@ -1,4 +1,5 @@
 ---
+import OsInstallSelector from "./OsInstallSelector.astro";
 ---
 
 <section class="hero">
@@ -16,16 +17,7 @@
       </p>
 
       <div class="hero-install">
-        <div class="install-box">
-          <span class="install-prompt">$</span>
-          <span class="install-cmd">curl -fsSL https://signetai.sh/install.sh | bash</span>
-          <button class="copy-btn push-right" data-copy="curl -fsSL https://signetai.sh/install.sh | bash" data-analytics-command="native_install" aria-label="Copy command">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-            </svg>
-          </button>
-        </div>
+        <OsInstallSelector placement="hero" />
         <div class="hero-cta-row">
           <a href="/join" class="btn hero-discord-btn" data-analytics-cta="join_community" data-analytics-placement="hero">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>

--- a/web/marketing/src/components/landing/InstallCta.astro
+++ b/web/marketing/src/components/landing/InstallCta.astro
@@ -1,4 +1,6 @@
 ---
+import OsInstallSelector from "./OsInstallSelector.astro";
+
 const tabs = [
 	{
 		id: "install",
@@ -43,6 +45,8 @@ const tabs = [
   <div class="install-final reveal">
     <h2 class="install-final-title">Persistent memory in five minutes.</h2>
     <p class="install-final-sub">Install the binary, run the wizard, start working. No cloud account, no migration.</p>
+
+    <OsInstallSelector placement="install_cta" />
 
     <div class="install-terminal">
       <div class="install-terminal-tabs" role="tablist" aria-label="Getting started steps">

--- a/web/marketing/src/components/landing/OsInstallSelector.astro
+++ b/web/marketing/src/components/landing/OsInstallSelector.astro
@@ -1,0 +1,86 @@
+---
+const options = [
+	{
+		id: "windows",
+		label: "Windows",
+		prompt: "PS>",
+		command: "iwr -useb https://signetai.sh/install.ps1 | iex",
+	},
+	{
+		id: "unix",
+		label: "macOS and Linux",
+		prompt: "$",
+		command: "curl -fsSL https://signetai.sh/install.sh | bash",
+	},
+];
+
+const placement = Astro.props.placement ?? "install_selector";
+---
+
+<div class="install-os-selector" data-install-os-selector>
+  <div class="install-os-label">Install for your operating system</div>
+  <div class="install-os-tabs" role="tablist" aria-label="Choose your operating system">
+    {options.map((option, index) => (
+      <button
+        type="button"
+        class:list={["install-os-tab", { active: index === 1 }]}
+        role="tab"
+        aria-label={option.label}
+        title={option.label}
+        aria-selected={index === 1 ? "true" : "false"}
+        aria-controls={`install-os-panel-${placement}-${option.id}`}
+        data-install-os={option.id}
+        data-analytics-install-surface={placement}
+        data-analytics-install-option={option.id}
+      >
+        {option.id === "windows" ? (
+          <svg class="install-os-tab-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M3 5.2 11 4.1v7.45H3V5.2Zm9.5-1.33L21 2.7v8.85h-8.5V3.87ZM3 12.95H11v7.45L3 19.3v-6.35Zm9.5 0H21v8.85l-8.5-1.2v-7.65Z" />
+          </svg>
+        ) : (
+          <span class="install-os-icon-pair" aria-hidden="true">
+            <svg class="install-os-tab-icon" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 14.25 3.51 4.59 9.05 4.24c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.1 1.87-2.37 5.98.48 7.12-.57 1.5-1.31 2.99-2.53 4.18ZM12.03 4.1C11.87 1.77 13.77-.1 16.04 0c.31 2.7-2.46 4.66-4.01 4.1Z" />
+            </svg>
+            <svg class="install-os-tab-icon" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2.75c-2.08 0-3.45 1.93-3.45 4.64 0 1.11-.33 2.08-1.16 3.18-.64.85-1.42 1.91-1.42 3.53 0 2.64 2.1 4.92 6.03 4.92s6.03-2.28 6.03-4.92c0-1.62-.78-2.68-1.42-3.53-.83-1.1-1.16-2.07-1.16-3.18 0-2.71-1.37-4.64-3.45-4.64Z" />
+              <circle cx="10.15" cy="7.8" r=".72" fill="var(--color-bg)" />
+              <circle cx="13.85" cy="7.8" r=".72" fill="var(--color-bg)" />
+              <path d="M10.4 10.1c.55.42 1.45.42 2 0l-.45 1.1h-1.1l-.45-1.1ZM8.5 15.05c.82.75 1.99 1.15 3.5 1.15s2.68-.4 3.5-1.15" fill="none" stroke="var(--color-bg)" stroke-width=".9" stroke-linecap="round" />
+            </svg>
+          </span>
+        )}
+      </button>
+    ))}
+  </div>
+
+  <div class="install-os-panels">
+    {options.map((option, index) => (
+      <div
+        id={`install-os-panel-${placement}-${option.id}`}
+        class:list={["install-os-panel", { active: index === 1 }]}
+        role="tabpanel"
+        aria-label={`${option.label} install command`}
+        data-install-os-panel={option.id}
+        hidden={index !== 1}
+      >
+        <div class="install-box">
+          <span class="install-prompt">{option.prompt}</span>
+          <code class="install-cmd">{option.command}</code>
+          <button
+            type="button"
+            class="copy-btn push-right"
+            data-copy={option.command}
+            data-analytics-command="native_install"
+            aria-label={`Copy ${option.label} install command`}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="9" y="9" width="13" height="13" rx="2"></rect>
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+          </button>
+        </div>
+      </div>
+    ))}
+  </div>
+</div>

--- a/web/marketing/src/components/landing/OsInstallSelector.astro
+++ b/web/marketing/src/components/landing/OsInstallSelector.astro
@@ -71,7 +71,8 @@ const placement = Astro.props.placement ?? "install_selector";
             type="button"
             class="copy-btn push-right"
             data-copy={option.command}
-            data-analytics-command="native_install"
+            data-analytics-command={option.id === "windows" ? "native_install_windows" : "native_install"}
+            data-analytics-placement={placement}
             aria-label={`Copy ${option.label} install command`}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/web/marketing/src/content/blog/self-hosted-ai-memory-hermes-openclaw.mdx
+++ b/web/marketing/src/content/blog/self-hosted-ai-memory-hermes-openclaw.mdx
@@ -150,6 +150,15 @@ signet start
 signet status
 ```
 
+On Windows x64, use the native PowerShell installer instead:
+
+```powershell
+iwr -useb https://signetai.sh/install.ps1 | iex
+signet setup
+signet start
+signet status
+```
+
 Select Hermes Agent and OpenClaw during setup. Then read
 [AI Memory for Hermes Agent and OpenClaw](https://docs.signetai.sh/ai-memory-hermes-openclaw/)
 for the focused guide, [Harnesses](https://docs.signetai.sh/harnesses/) for integration details,

--- a/web/marketing/src/integrations/graph-index.ts
+++ b/web/marketing/src/integrations/graph-index.ts
@@ -2,6 +2,7 @@
 
 import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AstroIntegration } from "astro";
 import { buildContentIndex } from "../lib/content-graph";
 
@@ -10,7 +11,7 @@ export default function graphIndex(): AstroIntegration {
 		name: "graph-index",
 		hooks: {
 			"astro:config:setup"({ config, logger }) {
-				const root = config.root ? new URL(config.root).pathname : process.cwd();
+				const root = config.root ? fileURLToPath(config.root) : process.cwd();
 				const blog = resolve(root, "src", "content", "blog");
 				const output = resolve(root, "public", "contentIndex.json");
 				const index = buildContentIndex(blog);

--- a/web/marketing/src/pages/index.astro
+++ b/web/marketing/src/pages/index.astro
@@ -31,7 +31,7 @@ const siteUrl = Astro.site?.toString().replace(/\/$/, "") ?? "https://signetai.s
     url: siteUrl,
     description: "Portable, source-backed memory and secrets across Claude Code, OpenCode, OpenClaw, Codex, Gemini CLI, Pi, Oh My Pi, and Hermes Agent.",
     applicationCategory: 'DeveloperApplication',
-    operatingSystem: 'Linux, macOS',
+    operatingSystem: 'Linux, macOS, Windows',
     offers: {
       '@type': 'Offer',
       price: '0',

--- a/web/marketing/src/scripts/interactions.ts
+++ b/web/marketing/src/scripts/interactions.ts
@@ -7,6 +7,7 @@ let hasBoundScroll = false;
 let lastScrollY = -1;
 
 function commandKind(command: string): string {
+	if (command.startsWith("iwr ")) return "native_install_windows";
 	if (command.startsWith("curl ")) return "native_install";
 	if (command.startsWith("npm install")) return "npm_install";
 	if (command.startsWith("bun add")) return "bun_install";
@@ -16,6 +17,44 @@ function commandKind(command: string): string {
 	if (command.startsWith("signet remember")) return "remember";
 	if (command.startsWith("signet recall")) return "recall";
 	return "other";
+}
+
+function detectInstallOs(userAgent: string): "windows" | "unix" {
+	if (/windows nt|win32|win64/i.test(userAgent)) return "windows";
+	return "unix";
+}
+
+function activateInstallOs(selector: Element, os: "windows" | "unix"): void {
+	for (const tab of selector.querySelectorAll<HTMLElement>("[data-install-os]")) {
+		const active = tab.dataset.installOs === os;
+		tab.classList.toggle("active", active);
+		tab.setAttribute("aria-selected", active ? "true" : "false");
+	}
+	for (const panel of selector.querySelectorAll<HTMLElement>("[data-install-os-panel]")) {
+		const active = panel.dataset.installOsPanel === os;
+		panel.classList.toggle("active", active);
+		panel.hidden = !active;
+	}
+}
+
+function initOsInstallSelectors(): void {
+	const detectedOs = detectInstallOs(navigator.userAgent);
+	for (const selector of document.querySelectorAll("[data-install-os-selector]")) {
+		const selectorEl = selector as HTMLElement;
+		if (selectorEl.dataset.bound === "true") continue;
+		selectorEl.dataset.bound = "true";
+
+		activateInstallOs(selector, detectedOs);
+		for (const tab of selector.querySelectorAll<HTMLElement>("[data-install-os]")) {
+				tab.addEventListener("click", () => {
+					const os = tab.dataset.installOs;
+					if (os !== "windows" && os !== "unix") return;
+					for (const otherSelector of document.querySelectorAll("[data-install-os-selector]")) {
+						activateInstallOs(otherSelector, os);
+					}
+				});
+		}
+	}
 }
 
 function initCopyButtons() {
@@ -163,6 +202,7 @@ function bindScrollParallax() {
 
 function initInteractions() {
 	initCopyButtons();
+	initOsInstallSelectors();
 	initInstallTabs();
 	initCodeTabs();
 	initQuickstartTabs();

--- a/web/marketing/src/scripts/interactions.ts
+++ b/web/marketing/src/scripts/interactions.ts
@@ -46,13 +46,13 @@ function initOsInstallSelectors(): void {
 
 		activateInstallOs(selector, detectedOs);
 		for (const tab of selector.querySelectorAll<HTMLElement>("[data-install-os]")) {
-				tab.addEventListener("click", () => {
-					const os = tab.dataset.installOs;
-					if (os !== "windows" && os !== "unix") return;
-					for (const otherSelector of document.querySelectorAll("[data-install-os-selector]")) {
-						activateInstallOs(otherSelector, os);
-					}
-				});
+			tab.addEventListener("click", () => {
+				const os = tab.dataset.installOs;
+				if (os !== "windows" && os !== "unix") return;
+				for (const otherSelector of document.querySelectorAll("[data-install-os-selector]")) {
+					activateInstallOs(otherSelector, os);
+				}
+			});
 		}
 	}
 }
@@ -76,7 +76,7 @@ function initCopyButtons() {
 					new CustomEvent("signet:command-copied", {
 						detail: {
 							commandKind: el.dataset.analyticsCommand ?? commandKind(installCmd),
-							placement: button.closest(".hero-install") ? "hero" : "quickstart",
+							placement: el.dataset.analyticsPlacement ?? (button.closest(".hero-install") ? "hero" : "quickstart"),
 						},
 					}),
 				);

--- a/web/marketing/src/styles/landing.css
+++ b/web/marketing/src/styles/landing.css
@@ -208,6 +208,94 @@
 	color: var(--color-success);
 }
 
+.install-os-selector {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	max-width: 760px;
+}
+.install-os-label {
+	font-family: var(--font-mono);
+	font-size: 0.6875rem;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: var(--color-text-muted);
+}
+.install-os-tabs {
+	display: flex;
+	align-items: stretch;
+	justify-content: center;
+	max-width: 100%;
+}
+.install-os-tab {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	min-width: 58px;
+	background: none;
+	border: 1px solid var(--color-border);
+	padding: 9px 14px;
+	font-family: var(--font-mono);
+	color: var(--color-text-muted);
+	cursor: pointer;
+	transition: color var(--dur) var(--ease), background var(--dur) var(--ease), border-color var(--dur) var(--ease);
+}
+.install-os-tab-icon {
+	display: block;
+	width: 18px;
+	height: 18px;
+	flex: 0 0 auto;
+}
+.install-os-icon-pair {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+.install-os-icon-pair .install-os-tab-icon {
+	width: 17px;
+	height: 17px;
+}
+.install-os-tab + .install-os-tab {
+	margin-left: -1px;
+}
+.install-os-tab:first-child {
+	border-radius: 4px 0 0 4px;
+}
+.install-os-tab:last-child {
+	border-radius: 0 4px 4px 0;
+}
+.install-os-tab:hover,
+.install-os-tab.active {
+	color: var(--color-text-bright);
+	background: var(--color-surface);
+	border-color: var(--color-border-strong);
+}
+.install-os-tab:focus-visible {
+	position: relative;
+	z-index: 1;
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+.install-os-panels {
+	width: 100%;
+}
+.install-os-panel {
+	display: none;
+	width: 100%;
+}
+.install-os-panel.active {
+	display: block;
+}
+.install-os-panel .install-box {
+	width: 100%;
+}
+.install-os-panel .install-cmd {
+	min-width: 0;
+}
+
 /* Install method tabs */
 .install-tabs {
 	display: flex;


### PR DESCRIPTION
## Summary

Make Windows x64 a first-class Signet install target with a canonical PowerShell installer and an OS-aware website selector.

## Changes

- Add a checksum-verifying native Windows installer at https://signetai.sh/install.ps1.
- Make the PowerShell installer command the documented Windows path across the README, docs, release-channel guide, package README, and agent skill.
- Add icon-only Windows and combined macOS/Linux install controls to the landing page.
- Detect Windows from the user agent, default other supported desktop platforms to the shared macOS/Linux control, and keep both selector locations synchronized.
- Add regression guards and fix the Windows path handling needed by the marketing-site build.

## Type

- [x] feat — new user-facing feature (bumps minor)

## Packages affected

- [x] @signet/web
- [x] Other: native installer, CLI distribution docs, and release documentation

## PR Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added to the installer
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [ ] PowerShell script parsing and local HTTP installer smoke test
- [x] Marketing-site Astro build
- [x] Targeted TypeScript check for the selector interactions
- [x] Install-guide guard
- [ ] Full Bun test/typecheck/lint suite

## AI disclosure

- [x] AI tools were used (see Assisted-by: Codex: GPT-5 in the commit)

## Notes

The direct Windows installer supports Windows x64 and installs the native binary plus connector assets, then persists the user PATH. Linux and macOS continue to use the existing curl installer.

Local verification on the takeover branch: targeted installer tests (7 passing), install-guide guard, full workspace build, workspace typecheck, repository lint, format check, marketing-site build, docs check, and content validation passed. The full workspace test command was attempted but timed out after unrelated native-memory/SQLite failures; the targeted installer regression suite passed. PowerShell execution was not available in this Linux environment, so the installer itself remains for CI/Windows validation.

## Screenshots

Windows auto-detected on the Windows user agent:
<img width="1405" height="631" alt="clipboard" src="https://github.com/user-attachments/assets/9182d77f-49df-4a18-93d5-014c11a00b26" />

macOS and Linux share the curl installer:
<img width="1405" height="631" alt="clipboard" src="https://github.com/user-attachments/assets/ece063dc-f263-4ddc-8cc9-fb56674971c3" />