### PR TITLE
fix(desktop): harden cross-platform installs

### DIFF
--- a/docs/TRAY.md
+++ b/docs/TRAY.md
@@ -77,6 +77,10 @@ The desktop build stages:
 3. a platform Bun runtime
 4. Electron packaging artifacts
 
+Runtime staging requires a runner whose OS and architecture match the target
+artifact. Release jobs build each platform on its matching native runner rather
+than cross-compiling the bundled Bun runtime.
+
 Generated desktop resources live under `surfaces/desktop/resources/` and are
 not committed.
 

--- a/platform/daemon/src/harness-python.test.ts
+++ b/platform/daemon/src/harness-python.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { resolveHarnessPythonCommand } from "./harness-python";
+
+function resolver(...available: string[]): (name: string) => string | null {
+	return (name) => (available.includes(name) ? `/mock/${name}` : null);
+}
+
+describe("resolveHarnessPythonCommand", () => {
+	test("uses the launchd-resolved Python 3 executable on macOS", () => {
+		expect(resolveHarnessPythonCommand("darwin", resolver(), "/opt/homebrew/bin/python3")).toEqual({
+			executable: "/opt/homebrew/bin/python3",
+			args: [],
+		});
+	});
+
+	test("prefers python.exe on Windows", () => {
+		expect(resolveHarnessPythonCommand("win32", resolver("python", "py"))).toEqual({
+			executable: "/mock/python",
+			args: [],
+		});
+	});
+
+	test("uses the Windows py launcher with an explicit Python 3 selector", () => {
+		expect(resolveHarnessPythonCommand("win32", resolver("py"))).toEqual({
+			executable: "/mock/py",
+			args: ["-3"],
+		});
+	});
+
+	test("prefers python3 on Unix and falls back to python", () => {
+		expect(resolveHarnessPythonCommand("linux", resolver("python3", "python"))).toEqual({
+			executable: "/mock/python3",
+			args: [],
+		});
+		expect(resolveHarnessPythonCommand("linux", resolver("python"))).toEqual({
+			executable: "/mock/python",
+			args: [],
+		});
+	});
+
+	test("reports when no Python executable is available", () => {
+		expect(resolveHarnessPythonCommand("win32", resolver())).toBeNull();
+	});
+});

--- a/platform/daemon/src/harness-python.ts
+++ b/platform/daemon/src/harness-python.ts
@@ -1,0 +1,38 @@
+export interface HarnessPythonCommand {
+	readonly executable: string;
+	readonly args: readonly string[];
+}
+
+interface PythonCandidate {
+	readonly name: string;
+	readonly args: readonly string[];
+}
+
+export function resolveHarnessPythonCommand(
+	platform: NodeJS.Platform,
+	resolveExecutable: (name: string) => string | null,
+	launchdExecutable?: string,
+): HarnessPythonCommand | null {
+	if (platform === "darwin") {
+		return launchdExecutable ? { executable: launchdExecutable, args: [] } : null;
+	}
+
+	const candidates: readonly PythonCandidate[] =
+		platform === "win32"
+			? [
+					{ name: "python", args: [] },
+					{ name: "py", args: ["-3"] },
+					{ name: "python3", args: [] },
+				]
+			: [
+					{ name: "python3", args: [] },
+					{ name: "python", args: [] },
+				];
+
+	for (const candidate of candidates) {
+		const executable = resolveExecutable(candidate.name);
+		if (executable) return { executable, args: candidate.args };
+	}
+
+	return null;
+}

--- a/platform/daemon/src/routes/connectors-routes.ts
+++ b/platform/daemon/src/routes/connectors-routes.ts
@@ -22,7 +22,9 @@ import {
 	updateCursor,
 } from "../connectors/registry.js";
 import { getDbAccessor } from "../db-accessor.js";
+import { resolveHarnessPythonCommand } from "../harness-python.js";
 import { logger } from "../logger.js";
+import { which } from "../which.js";
 import { AGENTS_DIR, SCRIPTS_DIR, authConfig, harnessLastSeen } from "./state.js";
 
 type ConnectorSyncStartOutcome =
@@ -443,8 +445,16 @@ export function registerConnectorRoutes(app: Hono): void {
 				return;
 			}
 
-			const python = process.platform === "darwin" ? resolveLaunchdExecutable("python3") : "python3";
-			const proc = spawn(python, [script], {
+			const python = resolveHarnessPythonCommand(
+				process.platform,
+				which,
+				process.platform === "darwin" ? resolveLaunchdExecutable("python3") : undefined,
+			);
+			if (python === null) {
+				resolve(c.json({ success: false, error: "Python 3 executable not found" }, 500));
+				return;
+			}
+			const proc = spawn(python.executable, [...python.args, script], {
 				timeout: 10000,
 				cwd: AGENTS_DIR,
 			});

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -3128,7 +3128,7 @@
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 284,
+      "line": 286,
       "api": "withReadDb",
       "source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path",
@@ -3136,7 +3136,7 @@
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 295,
+      "line": 297,
       "api": "withWriteTx",
       "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
       "category": "hot-path",
@@ -3144,7 +3144,7 @@
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 326,
+      "line": 328,
       "api": "withReadDb",
       "source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path",
@@ -3152,77 +3152,77 @@
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 362,
+      "line": 364,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".codex\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 368,
+      "line": 370,
       "api": "existsSync",
       "source": "exists: existsSync(resolveHermesHomePath()),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 374,
+      "line": 376,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".claude\", \"settings.json\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 380,
+      "line": 382,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".config\", \"opencode\", \"AGENTS.md\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 386,
+      "line": 388,
       "api": "existsSync",
       "source": "exists: existsSync(join(AGENTS_DIR, \"AGENTS.md\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 392,
+      "line": 394,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".gemini\", \"settings.json\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 398,
+      "line": 400,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".pi\", \"agent\", \"settings.json\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 404,
+      "line": 406,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".omp\", \"agent\", \"settings.json\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 410,
+      "line": 412,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".kimi\", \"config.toml\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 416,
+      "line": 418,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".forge\", \"config.yaml\")),",
       "category": "hot-path"
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 441,
+      "line": 443,
       "api": "existsSync",
       "source": "if (!existsSync(script)) {",
       "category": "hot-path"

--- a/surfaces/cli/src/features/desktop.test.ts
+++ b/surfaces/cli/src/features/desktop.test.ts
@@ -435,6 +435,35 @@ function makeMacAppBundle(dir: string, arch: "x64" | "arm64", executable = "sign
 	return app;
 }
 
+function makeUniversalMacAppBundle(
+	dir: string,
+	architectures: readonly ("x64" | "arm64")[],
+	executable = "signet",
+): string {
+	const app = join(dir, "Signet.app");
+	mkdirSync(join(app, "Contents", "MacOS"), { recursive: true });
+	writeFileSync(
+		join(app, "Contents", "Info.plist"),
+		`<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict><key>CFBundleExecutable</key><string>${executable}</string><key>CFBundleIdentifier</key><string>ai.signet.app</string></dict></plist>\n`,
+	);
+	const entrySize = 20;
+	const tableSize = 8 + architectures.length * entrySize;
+	const header = Buffer.alloc(tableSize + architectures.length * 8);
+	header.writeUInt32BE(0xcafebabe, 0);
+	header.writeUInt32BE(architectures.length, 4);
+	for (const [index, architecture] of architectures.entries()) {
+		const entry = 8 + index * entrySize;
+		const sliceOffset = tableSize + index * 8;
+		header.writeUInt32BE(architecture === "arm64" ? 0x0100000c : 0x01000007, entry);
+		header.writeUInt32BE(0, entry + 4);
+		header.writeUInt32BE(sliceOffset, entry + 8);
+		header.writeUInt32BE(8, entry + 12);
+		header.writeUInt32BE(2, entry + 16);
+	}
+	writeFileSync(join(app, "Contents", "MacOS", executable), header);
+	return app;
+}
+
 function hostDesktopArch(): "x64" | "arm64" {
 	return process.arch === "arm64" ? "arm64" : "x64";
 }
@@ -476,6 +505,23 @@ describe("mac desktop install", () => {
 				existsSync(join(home, "Applications", ".Signet.app.")) ||
 					readdirSync(join(home, "Applications")).some((name) => name.startsWith(".Signet.app.")),
 			).toBe(false);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("accepts a universal bundle containing the host architecture", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		try {
+			const release = join(root, "surfaces", "desktop", "release", "mac");
+			mkdirSync(release, { recursive: true });
+			makeUniversalMacAppBundle(release, ["x64", "arm64"]);
+
+			const result = installMacDesktopApp(root, home, join(home, "workspace"));
+
+			expect(existsSync(result.appBundle)).toBe(true);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 			rmSync(home, { recursive: true, force: true });

--- a/surfaces/cli/src/features/desktop.ts
+++ b/surfaces/cli/src/features/desktop.ts
@@ -387,14 +387,35 @@ function macAppBundleMatchesArch(path: string, arch: string): boolean {
 	}
 	try {
 		const header = Buffer.alloc(8);
-		if (readSync(handle, header, 0, 8, 0) !== 8) return false;
+		if (readSync(handle, header, 0, header.length, 0) !== header.length) return false;
 		const magicLE = header.readUInt32LE(0);
 		const magicBE = header.readUInt32BE(0);
 		const CPU_TYPE_X64 = 0x01000007;
 		const CPU_TYPE_ARM64 = 0x0100000c;
+		const FAT_MAGIC = 0xcafebabe;
+		const FAT_MAGIC_64 = 0xcafebabf;
 		const expected = arch === "arm64" ? CPU_TYPE_ARM64 : CPU_TYPE_X64;
 		if (magicLE === 0xfeedfacf) return header.readUInt32LE(4) === expected;
 		if (magicBE === 0xfeedfacf) return header.readUInt32BE(4) === expected;
+
+		const fatEndian: "be" | "le" | null =
+			magicBE === FAT_MAGIC || magicBE === FAT_MAGIC_64
+				? "be"
+				: magicLE === FAT_MAGIC || magicLE === FAT_MAGIC_64
+					? "le"
+					: null;
+		if (fatEndian === null) return false;
+		const fatMagic = fatEndian === "be" ? magicBE : magicLE;
+		const architectureCount = fatEndian === "be" ? header.readUInt32BE(4) : header.readUInt32LE(4);
+		if (architectureCount === 0 || architectureCount > 128) return false;
+		const entrySize = fatMagic === FAT_MAGIC_64 ? 32 : 20;
+		const table = Buffer.alloc(8 + architectureCount * entrySize);
+		if (readSync(handle, table, 0, table.length, 0) !== table.length) return false;
+		for (let index = 0; index < architectureCount; index += 1) {
+			const entry = 8 + index * entrySize;
+			const cputype = fatEndian === "be" ? table.readUInt32BE(entry) : table.readUInt32LE(entry);
+			if (cputype === expected) return true;
+		}
 		return false;
 	} finally {
 		closeSync(handle);

--- a/surfaces/desktop/scripts/stage-runtime.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.mjs
@@ -138,6 +138,15 @@ function removeBackup(backupParent, backup, remove = rmSync) {
 	}
 }
 
+export function removeStaging(stagedResources, remove = rmSync) {
+	try {
+		remove(stagedResources, { recursive: true, force: true });
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`Unable to remove temporary desktop resources ${stagedResources}: ${detail}`, { cause: error });
+	}
+}
+
 export function replaceResources(target, staged, rename = renameSync, remove = rmSync) {
 	const hadTarget = existsSync(target);
 	const backupParent = mkdtempSync(join(dirname(target), ".resources-backup-"));
@@ -259,7 +268,13 @@ export function stageRuntime() {
 		replaceResources(resources, stagedResources);
 		console.log(`Staged Electron desktop resources in ${resources}`);
 	} catch (error) {
-		rmSync(stagedResources, { recursive: true, force: true });
+		try {
+			removeStaging(stagedResources);
+		} catch (cleanupError) {
+			const original = error instanceof Error ? error.message : String(error);
+			const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+			throw new Error(`${original}; ${detail}`, { cause: error });
+		}
 		throw error;
 	}
 }

--- a/surfaces/desktop/scripts/stage-runtime.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.mjs
@@ -6,9 +6,11 @@ import {
 	cpSync,
 	existsSync,
 	mkdirSync,
+	mkdtempSync,
 	readdirSync,
 	readFileSync,
 	rmSync,
+	renameSync,
 	statSync,
 	writeFileSync,
 } from "node:fs";
@@ -20,8 +22,6 @@ const here = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(here, "..");
 const repoRoot = resolve(desktopRoot, "../..");
 const resources = resolve(desktopRoot, "resources");
-const daemonOut = resolve(resources, "daemon");
-const runtimeOut = resolve(resources, "runtime");
 const daemonPkgPath = resolve(repoRoot, "platform/daemon/package.json");
 const corePkgPath = resolve(repoRoot, "platform/core/package.json");
 
@@ -129,6 +129,28 @@ function pkgVersion(pkg, name) {
 	return pkg.dependencies?.[name] ?? pkg.optionalDependencies?.[name] ?? pkg.devDependencies?.[name] ?? null;
 }
 
+export function replaceResources(target, staged, rename = renameSync) {
+	const hadTarget = existsSync(target);
+	const backupParent = mkdtempSync(join(dirname(target), ".resources-backup-"));
+	const backup = join(backupParent, basename(target));
+	let moved = false;
+	try {
+		if (hadTarget) {
+			rename(target, backup);
+			moved = true;
+		}
+		rename(staged, target);
+	} catch (error) {
+		if (moved) {
+			if (existsSync(target)) rmSync(target, { recursive: true, force: true });
+			rename(backup, target);
+		}
+		throw error;
+	} finally {
+		rmSync(backupParent, { recursive: true, force: true });
+	}
+}
+
 export function stageRuntime() {
 	const bunArch = targetArch();
 	const target = targetPlatform();
@@ -143,75 +165,83 @@ export function stageRuntime() {
 	const bunSrc = bunRuntime();
 	assertBunRuntime(bunSrc, bunArch, target);
 
-	rmSync(resources, { recursive: true, force: true });
-	mkdirSync(daemonOut, { recursive: true });
-	mkdirSync(runtimeOut, { recursive: true });
+	const stagedResources = mkdtempSync(join(desktopRoot, ".resources-stage-"));
+	try {
+		const daemonOut = resolve(stagedResources, "daemon");
+		const runtimeOut = resolve(stagedResources, "runtime");
+		mkdirSync(daemonOut, { recursive: true });
+		mkdirSync(runtimeOut, { recursive: true });
 
-	const bunDest = resolve(runtimeOut, target === "win32" ? "bun.exe" : "bun");
-	cpSync(bunSrc, bunDest);
-	if (target !== "win32") chmodSync(bunDest, 0o755);
+		const bunDest = resolve(runtimeOut, target === "win32" ? "bun.exe" : "bun");
+		cpSync(bunSrc, bunDest);
+		if (target !== "win32") chmodSync(bunDest, 0o755);
 
-	// Stage every built daemon entrypoint and native asset rather than a
-	// hardcoded subset. The daemon resolves its workers (db-owner, harness
-	// install, dreaming tokens, transcript recovery, ...) as siblings of
-	// daemon.js at runtime; missing files here break the packaged app at boot.
-	mkdirSync(resolve(daemonOut, "dist"), { recursive: true });
-	const daemonDist = resolve(repoRoot, "platform/daemon/dist");
-	for (const entry of readdirSync(daemonDist)) {
-		if (/\.(js|node|wasm)$/.test(entry)) {
-			cpSync(join(daemonDist, entry), resolve(daemonOut, "dist", entry));
+		// Stage every built daemon entrypoint and native asset rather than a
+		// hardcoded subset. The daemon resolves its workers (db-owner, harness
+		// install, dreaming tokens, transcript recovery, ...) as siblings of
+		// daemon.js at runtime; missing files here break the packaged app at boot.
+		mkdirSync(resolve(daemonOut, "dist"), { recursive: true });
+		const daemonDist = resolve(repoRoot, "platform/daemon/dist");
+		for (const entry of readdirSync(daemonDist)) {
+			if (/\.(js|node|wasm)$/.test(entry)) {
+				cpSync(join(daemonDist, entry), resolve(daemonOut, "dist", entry));
+			}
 		}
-	}
-	cpSync(resolve(repoRoot, "platform/daemon/dashboard"), resolve(daemonOut, "dashboard"), { recursive: true });
-	cpSync(resolve(repoRoot, "platform/daemon/skills"), resolve(daemonOut, "skills"), { recursive: true });
+		cpSync(resolve(repoRoot, "platform/daemon/dashboard"), resolve(daemonOut, "dashboard"), { recursive: true });
+		cpSync(resolve(repoRoot, "platform/daemon/skills"), resolve(daemonOut, "skills"), { recursive: true });
 
-	// Connector assets that live on disk in the connector package (not bundled
-	// into dist JS). The hermes-agent connector copies its Python plugin from
-	// here during harness install; the desktop daemon points
-	// SIGNET_CONNECTOR_ASSETS_DIR at this tree.
-	const connectorsOut = resolve(daemonOut, "connectors");
-	const hermesPluginSrc = resolve(repoRoot, "integrations/hermes-agent/connector/hermes-plugin");
-	if (existsSync(hermesPluginSrc)) {
-		cpSync(hermesPluginSrc, resolve(connectorsOut, "hermes-agent", "hermes-plugin"), { recursive: true });
-	} else {
-		throw new Error(`Hermes connector plugin source not found: ${hermesPluginSrc}`);
-	}
+		// Connector assets that live on disk in the connector package (not bundled
+		// into dist JS). The hermes-agent connector copies its Python plugin from
+		// here during harness install; the desktop daemon points
+		// SIGNET_CONNECTOR_ASSETS_DIR at this tree.
+		const connectorsOut = resolve(daemonOut, "connectors");
+		const hermesPluginSrc = resolve(repoRoot, "integrations/hermes-agent/connector/hermes-plugin");
+		if (existsSync(hermesPluginSrc)) {
+			cpSync(hermesPluginSrc, resolve(connectorsOut, "hermes-agent", "hermes-plugin"), { recursive: true });
+		} else {
+			throw new Error(`Hermes connector plugin source not found: ${hermesPluginSrc}`);
+		}
 
-	const daemonPkg = readJson(daemonPkgPath);
-	const corePkg = readJson(corePkgPath);
-	const vecPkg = platformVecPackage(target, bunArch);
-	const vecVersion = pkgVersion(corePkg, vecPkg);
-	if (vecVersion === null) {
-		throw new Error(`No sqlite-vec binary package is available for ${target}/${bunArch}`);
-	}
-	const dependencies = {};
-	for (const name of [
-		"@1password/sdk",
-		"@firecrawl/anydoc",
-		"@huggingface/transformers",
-		"onnxruntime-node",
-		"tiktoken",
-	]) {
-		const version = pkgVersion(daemonPkg, name);
-		if (version) dependencies[name] = version;
-	}
-	for (const name of ["sqlite-vec", vecPkg]) {
-		const version = pkgVersion(corePkg, name);
-		if (version) dependencies[name] = version;
-	}
+		const daemonPkg = readJson(daemonPkgPath);
+		const corePkg = readJson(corePkgPath);
+		const vecPkg = platformVecPackage(target, bunArch);
+		const vecVersion = pkgVersion(corePkg, vecPkg);
+		if (vecVersion === null) {
+			throw new Error(`No sqlite-vec binary package is available for ${target}/${bunArch}`);
+		}
+		const dependencies = {};
+		for (const name of [
+			"@1password/sdk",
+			"@firecrawl/anydoc",
+			"@huggingface/transformers",
+			"onnxruntime-node",
+			"tiktoken",
+		]) {
+			const version = pkgVersion(daemonPkg, name);
+			if (version) dependencies[name] = version;
+		}
+		for (const name of ["sqlite-vec", vecPkg]) {
+			const version = pkgVersion(corePkg, name);
+			if (version) dependencies[name] = version;
+		}
 
-	writeFileSync(
-		resolve(daemonOut, "package.json"),
-		`${JSON.stringify({ private: true, type: "module", dependencies }, null, "	")}\n`,
-	);
+		writeFileSync(
+			resolve(daemonOut, "package.json"),
+			`${JSON.stringify({ private: true, type: "module", dependencies }, null, "	")}\n`,
+		);
 
-	execFileSync(bunSrc, ["install", "--production"], {
-		cwd: daemonOut,
-		stdio: "inherit",
-		env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false" },
-	});
+		execFileSync(bunSrc, ["install", "--production"], {
+			cwd: daemonOut,
+			stdio: "inherit",
+			env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false" },
+		});
 
-	console.log(`Staged Electron desktop resources in ${resources}`);
+		replaceResources(resources, stagedResources);
+		console.log(`Staged Electron desktop resources in ${resources}`);
+	} catch (error) {
+		rmSync(stagedResources, { recursive: true, force: true });
+		throw error;
+	}
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) stageRuntime();

--- a/surfaces/desktop/scripts/stage-runtime.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.mjs
@@ -129,12 +129,20 @@ function pkgVersion(pkg, name) {
 	return pkg.dependencies?.[name] ?? pkg.optionalDependencies?.[name] ?? pkg.devDependencies?.[name] ?? null;
 }
 
-export function replaceResources(target, staged, rename = renameSync) {
+function removeBackup(backupParent, backup, remove = rmSync) {
+	try {
+		remove(backupParent, { recursive: true, force: true });
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`Unable to remove desktop resource backup ${backup}: ${detail}`, { cause: error });
+	}
+}
+
+export function replaceResources(target, staged, rename = renameSync, remove = rmSync) {
 	const hadTarget = existsSync(target);
 	const backupParent = mkdtempSync(join(dirname(target), ".resources-backup-"));
 	const backup = join(backupParent, basename(target));
 	let moved = false;
-	let preserveBackup = false;
 	try {
 		if (hadTarget) {
 			rename(target, backup);
@@ -147,15 +155,20 @@ export function replaceResources(target, staged, rename = renameSync) {
 				if (existsSync(target)) rmSync(target, { recursive: true, force: true });
 				rename(backup, target);
 			} catch (restoreError) {
-				preserveBackup = true;
 				const detail = restoreError instanceof Error ? restoreError.message : String(restoreError);
 				throw new Error(`Unable to restore previous desktop resources from ${backup}: ${detail}`, { cause: error });
 			}
 		}
+		try {
+			removeBackup(backupParent, backup, remove);
+		} catch (cleanupError) {
+			const original = error instanceof Error ? error.message : String(error);
+			const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+			throw new Error(`${original}; ${detail}`, { cause: error });
+		}
 		throw error;
-	} finally {
-		if (!preserveBackup) rmSync(backupParent, { recursive: true, force: true });
 	}
+	removeBackup(backupParent, backup, remove);
 }
 
 export function stageRuntime() {

--- a/surfaces/desktop/scripts/stage-runtime.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.mjs
@@ -15,7 +15,7 @@ import {
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const win = process.platform === "win32";
+const hostWin = process.platform === "win32";
 const here = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(here, "..");
 const repoRoot = resolve(desktopRoot, "../..");
@@ -31,7 +31,10 @@ function readJson(path) {
 
 function pathLookup(cmd) {
 	try {
-		const out = execFileSync(win ? "where" : "which", [cmd], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+		const out = execFileSync(hostWin ? "where" : "which", [cmd], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
 		return out.trim().split(/\r?\n/)[0] || null;
 	} catch {
 		return null;
@@ -92,10 +95,12 @@ export function assertBunRuntime(
 	expectedPlatform = process.platform,
 	probe = probeBunRuntime,
 ) {
+	const arch = normalizeArch(expectedArch);
+	const platform = normalizePlatform(expectedPlatform);
 	if (!existsSync(runtimePath) || !statSync(runtimePath).isFile()) {
 		throw new Error(`Bun runtime is not a regular file: ${runtimePath}`);
 	}
-	if (process.platform !== "win32" && (statSync(runtimePath).mode & 0o111) === 0) {
+	if (platform !== "win32" && (statSync(runtimePath).mode & 0o111) === 0) {
 		throw new Error(`Bun runtime is not executable: ${runtimePath}`);
 	}
 
@@ -107,8 +112,6 @@ export function assertBunRuntime(
 		throw new Error(`Unable to execute Bun runtime at ${runtimePath}: ${detail}`);
 	}
 
-	const arch = normalizeArch(expectedArch);
-	const platform = normalizePlatform(expectedPlatform);
 	if (runtime.platform !== platform) {
 		throw new Error(`Bun runtime platform mismatch: expected ${platform}, got ${runtime.platform} (${runtimePath})`);
 	}
@@ -127,18 +130,26 @@ function pkgVersion(pkg, name) {
 }
 
 export function stageRuntime() {
-	const bunSrc = bunRuntime();
 	const bunArch = targetArch();
 	const target = targetPlatform();
+	const hostPlatform = normalizePlatform(process.platform);
+	const hostArch = normalizeArch(process.arch);
+	if (target !== hostPlatform || bunArch !== hostArch) {
+		throw new Error(
+			`Desktop runtime staging requires a native ${target}/${bunArch} build runner; host is ${hostPlatform}/${hostArch}.`,
+		);
+	}
+
+	const bunSrc = bunRuntime();
 	assertBunRuntime(bunSrc, bunArch, target);
 
 	rmSync(resources, { recursive: true, force: true });
 	mkdirSync(daemonOut, { recursive: true });
 	mkdirSync(runtimeOut, { recursive: true });
 
-	const bunDest = resolve(runtimeOut, win ? "bun.exe" : "bun");
+	const bunDest = resolve(runtimeOut, target === "win32" ? "bun.exe" : "bun");
 	cpSync(bunSrc, bunDest);
-	if (!win) chmodSync(bunDest, 0o755);
+	if (target !== "win32") chmodSync(bunDest, 0o755);
 
 	// Stage every built daemon entrypoint and native asset rather than a
 	// hardcoded subset. The daemon resolves its workers (db-owner, harness

--- a/surfaces/desktop/scripts/stage-runtime.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.mjs
@@ -134,6 +134,7 @@ export function replaceResources(target, staged, rename = renameSync) {
 	const backupParent = mkdtempSync(join(dirname(target), ".resources-backup-"));
 	const backup = join(backupParent, basename(target));
 	let moved = false;
+	let preserveBackup = false;
 	try {
 		if (hadTarget) {
 			rename(target, backup);
@@ -142,12 +143,18 @@ export function replaceResources(target, staged, rename = renameSync) {
 		rename(staged, target);
 	} catch (error) {
 		if (moved) {
-			if (existsSync(target)) rmSync(target, { recursive: true, force: true });
-			rename(backup, target);
+			try {
+				if (existsSync(target)) rmSync(target, { recursive: true, force: true });
+				rename(backup, target);
+			} catch (restoreError) {
+				preserveBackup = true;
+				const detail = restoreError instanceof Error ? restoreError.message : String(restoreError);
+				throw new Error(`Unable to restore previous desktop resources from ${backup}: ${detail}`, { cause: error });
+			}
 		}
 		throw error;
 	} finally {
-		rmSync(backupParent, { recursive: true, force: true });
+		if (!preserveBackup) rmSync(backupParent, { recursive: true, force: true });
 	}
 }
 

--- a/surfaces/desktop/scripts/stage-runtime.test.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	chmodSync,
+	existsSync,
 	mkdtempSync,
 	mkdirSync,
 	readFileSync,
@@ -11,7 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assertBunRuntime, replaceResources, stageRuntime } from "./stage-runtime.mjs";
+import { assertBunRuntime, removeStaging, replaceResources, stageRuntime } from "./stage-runtime.mjs";
 
 describe("stage-runtime Bun validation", () => {
 	it("rejects an architecture-mismatched staged runtime", () => {
@@ -132,6 +133,20 @@ describe("stage-runtime Bun validation", () => {
 			const backups = readdirSync(directory).filter((entry) => entry.startsWith(".resources-backup-"));
 			expect(backups).toHaveLength(1);
 			expect(readFileSync(join(directory, backups[0], "resources", "marker"), "utf8")).toBe("old\n");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("reports temporary cleanup failures without hiding the staged tree", () => {
+		const directory = mkdtempSync(join(tmpdir(), "signet-stage-runtime-"));
+		const failCleanup = () => {
+			throw new Error("injected staging cleanup failure");
+		};
+
+		try {
+			expect(() => removeStaging(directory, failCleanup)).toThrow("Unable to remove temporary desktop resources");
+			expect(existsSync(directory)).toBe(true);
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}

--- a/surfaces/desktop/scripts/stage-runtime.test.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.test.mjs
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assertBunRuntime, stageRuntime } from "./stage-runtime.mjs";
+import { assertBunRuntime, replaceResources, stageRuntime } from "./stage-runtime.mjs";
 
 describe("stage-runtime Bun validation", () => {
 	it("rejects an architecture-mismatched staged runtime", () => {
@@ -49,6 +49,30 @@ describe("stage-runtime Bun validation", () => {
 			else process.env.ELECTRON_BUILDER_PLATFORM = previousPlatform;
 			if (previousArch === undefined) delete process.env.ELECTRON_BUILDER_ARCH;
 			else process.env.ELECTRON_BUILDER_ARCH = previousArch;
+		}
+	});
+
+	it("restores the existing resources when the final swap fails", () => {
+		const directory = mkdtempSync(join(tmpdir(), "signet-stage-runtime-"));
+		const target = join(directory, "resources");
+		const staged = join(directory, "staged");
+		mkdirSync(target);
+		mkdirSync(staged);
+		writeFileSync(join(target, "marker"), "old\n");
+		writeFileSync(join(staged, "marker"), "new\n");
+		let renameCalls = 0;
+		const failFinalSwap = (source, destination) => {
+			renameCalls += 1;
+			if (renameCalls === 2) throw new Error("injected final swap failure");
+			renameSync(source, destination);
+		};
+
+		try {
+			expect(() => replaceResources(target, staged, failFinalSwap)).toThrow("injected final swap failure");
+			expect(readFileSync(join(target, "marker"), "utf8")).toBe("old\n");
+			expect(readFileSync(join(staged, "marker"), "utf8")).toBe("new\n");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
 		}
 	});
 });

--- a/surfaces/desktop/scripts/stage-runtime.test.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.test.mjs
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assertBunRuntime } from "./stage-runtime.mjs";
+import { assertBunRuntime, stageRuntime } from "./stage-runtime.mjs";
 
 describe("stage-runtime Bun validation", () => {
 	it("rejects an architecture-mismatched staged runtime", () => {
@@ -17,6 +17,22 @@ describe("stage-runtime Bun validation", () => {
 			);
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a foreign target before resolving a host runtime", () => {
+		const previousPlatform = process.env.ELECTRON_BUILDER_PLATFORM;
+		const previousArch = process.env.ELECTRON_BUILDER_ARCH;
+		const foreignPlatform = process.platform === "win32" ? "linux" : "win32";
+		process.env.ELECTRON_BUILDER_PLATFORM = foreignPlatform;
+		process.env.ELECTRON_BUILDER_ARCH = process.arch;
+		try {
+			expect(() => stageRuntime()).toThrow("Desktop runtime staging requires a native");
+		} finally {
+			if (previousPlatform === undefined) delete process.env.ELECTRON_BUILDER_PLATFORM;
+			else process.env.ELECTRON_BUILDER_PLATFORM = previousPlatform;
+			if (previousArch === undefined) delete process.env.ELECTRON_BUILDER_ARCH;
+			else process.env.ELECTRON_BUILDER_ARCH = previousArch;
 		}
 	});
 });

--- a/surfaces/desktop/scripts/stage-runtime.test.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.test.mjs
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { assertBunRuntime, replaceResources, stageRuntime } from "./stage-runtime.mjs";
@@ -71,6 +80,33 @@ describe("stage-runtime Bun validation", () => {
 			expect(() => replaceResources(target, staged, failFinalSwap)).toThrow("injected final swap failure");
 			expect(readFileSync(join(target, "marker"), "utf8")).toBe("old\n");
 			expect(readFileSync(join(staged, "marker"), "utf8")).toBe("new\n");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the backup when rollback also fails", () => {
+		const directory = mkdtempSync(join(tmpdir(), "signet-stage-runtime-"));
+		const target = join(directory, "resources");
+		const staged = join(directory, "staged");
+		mkdirSync(target);
+		mkdirSync(staged);
+		writeFileSync(join(target, "marker"), "old\n");
+		writeFileSync(join(staged, "marker"), "new\n");
+		let renameCalls = 0;
+		const failRollback = (source, destination) => {
+			renameCalls += 1;
+			if (renameCalls >= 2) throw new Error("injected rename failure");
+			renameSync(source, destination);
+		};
+
+		try {
+			expect(() => replaceResources(target, staged, failRollback)).toThrow(
+				"Unable to restore previous desktop resources",
+			);
+			const backups = readdirSync(directory).filter((entry) => entry.startsWith(".resources-backup-"));
+			expect(backups).toHaveLength(1);
+			expect(readFileSync(join(directory, backups[0], "resources", "marker"), "utf8")).toBe("old\n");
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}

--- a/surfaces/desktop/scripts/stage-runtime.test.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.test.mjs
@@ -35,4 +35,20 @@ describe("stage-runtime Bun validation", () => {
 			else process.env.ELECTRON_BUILDER_ARCH = previousArch;
 		}
 	});
+
+	it("rejects a foreign target architecture before resolving a host runtime", () => {
+		const previousPlatform = process.env.ELECTRON_BUILDER_PLATFORM;
+		const previousArch = process.env.ELECTRON_BUILDER_ARCH;
+		const foreignArch = process.arch === "x64" ? "arm64" : "x64";
+		process.env.ELECTRON_BUILDER_PLATFORM = process.platform;
+		process.env.ELECTRON_BUILDER_ARCH = foreignArch;
+		try {
+			expect(() => stageRuntime()).toThrow("Desktop runtime staging requires a native");
+		} finally {
+			if (previousPlatform === undefined) delete process.env.ELECTRON_BUILDER_PLATFORM;
+			else process.env.ELECTRON_BUILDER_PLATFORM = previousPlatform;
+			if (previousArch === undefined) delete process.env.ELECTRON_BUILDER_ARCH;
+			else process.env.ELECTRON_BUILDER_ARCH = previousArch;
+		}
+	});
 });

--- a/surfaces/desktop/scripts/stage-runtime.test.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.test.mjs
@@ -111,4 +111,29 @@ describe("stage-runtime Bun validation", () => {
 			rmSync(directory, { recursive: true, force: true });
 		}
 	});
+
+	it("reports backup cleanup failures without hiding the installed resources", () => {
+		const directory = mkdtempSync(join(tmpdir(), "signet-stage-runtime-"));
+		const target = join(directory, "resources");
+		const staged = join(directory, "staged");
+		mkdirSync(target);
+		mkdirSync(staged);
+		writeFileSync(join(target, "marker"), "old\n");
+		writeFileSync(join(staged, "marker"), "new\n");
+		const failCleanup = () => {
+			throw new Error("injected backup cleanup failure");
+		};
+
+		try {
+			expect(() => replaceResources(target, staged, renameSync, failCleanup)).toThrow(
+				"Unable to remove desktop resource backup",
+			);
+			expect(readFileSync(join(target, "marker"), "utf8")).toBe("new\n");
+			const backups = readdirSync(directory).filter((entry) => entry.startsWith(".resources-backup-"));
+			expect(backups).toHaveLength(1);
+			expect(readFileSync(join(directory, backups[0], "resources", "marker"), "utf8")).toBe("old\n");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Follow-up hardening for the cross-platform desktop support shipped in #1858 and v0.220.0.

- Accept valid universal macOS Mach-O app bundles when they contain the host architecture.
- Resolve the harness-regeneration Python interpreter on Windows instead of assuming a `python3` executable.
- Reject foreign target OS/architecture runtime staging before resources are replaced, and document the native-runner contract.

## Changes

- Parse 32-bit and 64-bit fat Mach-O headers and validate contained CPU types.
- Add a platform-aware Python command resolver using the existing executable lookup helper.
- Use `python`, `py -3`, or `python3` on Windows; preserve launchd-aware `python3` resolution on macOS and `python3`/`python` fallback on Unix.
- Return an explicit error when no Python 3 executable is available.
- Make packaged runtime filenames, executable permissions, and native dependency selection follow the normalized target platform.
- Require the runtime staging host OS and architecture to match the target before deleting or rewriting staged resources.
- Build resources in a temporary tree and swap them into place only after all copies and dependency installation succeed; restore the previous tree if the final swap fails; preserve the backup if rollback itself fails.
- Add regression tests for universal bundles, interpreter-selection paths, foreign-target staging, and resource-swap rollback.
- Document the native-runner requirement in `docs/TRAY.md`.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [x] Other: `@signet/desktop` and desktop documentation

## Screenshots

Not applicable: no UI rendering changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable: no migrations or durable state changes.

## Testing

- [x] Affected `bun test` suites pass
- [x] `bun run typecheck` passes
- [x] Touched-file Biome checks pass
- [ ] Tested against running daemon
- [ ] N/A

Affected test suites and runtime checks:

- `bun test platform/daemon/src/which.test.ts platform/daemon/src/harness-python.test.ts platform/daemon/src/routes/harnesses-route.test.ts surfaces/cli/src/features/desktop.test.ts` — 34 passed, 0 failed.
- `bun test surfaces/desktop/scripts/stage-runtime.test.mjs surfaces/desktop/src/stage-runtime-contract.test.ts` — 10 passed, 0 failed.
- `bun run stage:runtime` on Linux/x64 — staged native resources successfully.
- A forced failure from the staged Bun install path — exited nonzero while preserving the previous resource marker and leaving no temporary staging/backup directories.
- Swap, rollback, backup-cleanup, and temporary-tree-cleanup failure fixtures — preserved recoverable state without masking the installed result.
- `ELECTRON_BUILDER_PLATFORM=win32 ELECTRON_BUILDER_ARCH=x64 bun run stage:runtime` on Linux/x64 — rejected before resource replacement; preservation marker remained intact.
- `bun run typecheck` — passed.
- `bunx biome check surfaces/desktop/scripts/stage-runtime.test.mjs surfaces/desktop/src/stage-runtime-contract.test.ts` — passed; the pre-commit hook also validated the edited runtime script.
- `bun run lint` — exit 1 from pre-existing repository diagnostics outside this diff; no touched-file diagnostics were reported by the staged Biome check.
- The root `bun test` sweep was attempted previously but exceeded the local tool limit without returning an exit status; affected suites completed successfully.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

- The review batch that found these issues inspected an earlier pre-final PR snapshot. The sqlite-vec target-platform and foreign-AppImage findings from that snapshot were already fixed before #1858 merged; this PR addresses the remaining current-main findings.
- The repository does not contain `INDEX.md` or `dependencies.yaml` at the checked paths; this fix changes no spec or public API contract.
- Cross-target runtime staging is intentionally unsupported because staging executes the bundled Bun runtime to install production dependencies. Release jobs use native runners matching each artifact target.
