### PR TITLE
fix(cli): complete Windows native self-updates

### DIFF
--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -82,7 +82,13 @@ import {
 import { buildDesktopFromSource, installDesktopFromSource } from "./features/desktop.js";
 import { getStatusReport, showDoctor, showStatus } from "./features/health.js";
 import { importFromGitHub } from "./features/import.js";
-import { installNativeBinary, printNativeInstallResult } from "./features/native-install.js";
+import {
+	cleanupNativeUpdateBackup,
+	installNativeBinary,
+	isNativeUpdateBackupCleanupRequest,
+	NATIVE_UPDATE_BACKUP_ENV,
+	printNativeInstallResult,
+} from "./features/native-install.js";
 import { setupWizard } from "./features/setup.js";
 import { copyDirRecursive, syncBuiltinSkills, syncTemplates } from "./features/sync.js";
 import { flushCliTelemetry, recordCommandInvoked } from "./features/telemetry.js";
@@ -120,6 +126,11 @@ import {
 import "./sqlite.js";
 
 const isDaemonEntrypoint = process.env.SIGNET_DAEMON_ENTRYPOINT === "1";
+const nativeUpdateBackup = process.env[NATIVE_UPDATE_BACKUP_ENV];
+if (isNativeUpdateBackupCleanupRequest(nativeUpdateBackup)) {
+	await cleanupNativeUpdateBackup(nativeUpdateBackup);
+	process.exit(0);
+}
 
 // Template directory location (relative to built CLI)
 function getTemplatesDir() {

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -128,8 +128,7 @@ import "./sqlite.js";
 const isDaemonEntrypoint = process.env.SIGNET_DAEMON_ENTRYPOINT === "1";
 const nativeUpdateBackup = process.env[NATIVE_UPDATE_BACKUP_ENV];
 if (isNativeUpdateBackupCleanupRequest(nativeUpdateBackup)) {
-	await cleanupNativeUpdateBackup(nativeUpdateBackup);
-	process.exit(0);
+	process.exit((await cleanupNativeUpdateBackup(nativeUpdateBackup)) ? 0 : 1);
 }
 
 // Template directory location (relative to built CLI)

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -82,13 +82,7 @@ import {
 import { buildDesktopFromSource, installDesktopFromSource } from "./features/desktop.js";
 import { getStatusReport, showDoctor, showStatus } from "./features/health.js";
 import { importFromGitHub } from "./features/import.js";
-import {
-	cleanupNativeUpdateBackup,
-	installNativeBinary,
-	isNativeUpdateBackupCleanupRequest,
-	NATIVE_UPDATE_BACKUP_ENV,
-	printNativeInstallResult,
-} from "./features/native-install.js";
+import { installNativeBinary, printNativeInstallResult } from "./features/native-install.js";
 import { setupWizard } from "./features/setup.js";
 import { copyDirRecursive, syncBuiltinSkills, syncTemplates } from "./features/sync.js";
 import { flushCliTelemetry, recordCommandInvoked } from "./features/telemetry.js";
@@ -126,10 +120,6 @@ import {
 import "./sqlite.js";
 
 const isDaemonEntrypoint = process.env.SIGNET_DAEMON_ENTRYPOINT === "1";
-const nativeUpdateBackup = process.env[NATIVE_UPDATE_BACKUP_ENV];
-if (isNativeUpdateBackupCleanupRequest(nativeUpdateBackup)) {
-	process.exit((await cleanupNativeUpdateBackup(nativeUpdateBackup)) ? 0 : 1);
-}
 
 // Template directory location (relative to built CLI)
 function getTemplatesDir() {

--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	buildNativeUpdateBackupCleanupInvocation,
 	cleanupNativeUpdateBackup,
 	isNativeUpdateBackupCleanupRequest,
 	persistNativeInstallPath,
@@ -23,10 +24,17 @@ describe("persistNativeInstallPath", () => {
 	test("accepts only a backup next to the installed Windows binary", () => {
 		const targetPath = "C:\\Users\\test user\\Signet & Tools\\signet.exe";
 		const backupPath = "C:\\Users\\test user\\Signet & Tools\\.signet.exe.1234.backup";
+		const invocation = buildNativeUpdateBackupCleanupInvocation(targetPath, backupPath);
 
 		expect(isNativeUpdateBackupCleanupRequest(backupPath, targetPath, "win32")).toBe(true);
 		expect(isNativeUpdateBackupCleanupRequest("C:\\Other\\.signet.exe.1234.backup", targetPath, "win32")).toBe(false);
 		expect(isNativeUpdateBackupCleanupRequest(targetPath, targetPath, "win32")).toBe(false);
+		expect(invocation).toMatchObject({
+			command: targetPath,
+			args: [],
+			options: { cwd: "C:\\Users\\test user\\Signet & Tools", detached: true, stdio: "ignore" },
+		});
+		expect(invocation.options.env.SIGNET_NATIVE_UPDATE_BACKUP).toBe(backupPath);
 	});
 
 	test("removes a native update backup once it is no longer locked", async () => {
@@ -35,7 +43,7 @@ describe("persistNativeInstallPath", () => {
 		const backupPath = join(home, ".signet.exe.1234.backup");
 		writeFileSync(backupPath, "old native binary");
 
-		await cleanupNativeUpdateBackup(backupPath);
+		expect(await cleanupNativeUpdateBackup(backupPath)).toBe(true);
 		expect(existsSync(backupPath)).toBe(false);
 	});
 

--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { persistNativeInstallPath, printNativeInstallResult } from "./native-install.js";
+import {
+	cleanupNativeUpdateBackup,
+	isNativeUpdateBackupCleanupRequest,
+	persistNativeInstallPath,
+	printNativeInstallResult,
+} from "./native-install.js";
 
 function makeHome(): string {
 	return mkdtempSync(join(tmpdir(), "signet-native-install-"));
@@ -15,6 +20,25 @@ afterEach(() => {
 });
 
 describe("persistNativeInstallPath", () => {
+	test("accepts only a backup next to the installed Windows binary", () => {
+		const targetPath = "C:\\Users\\test user\\Signet & Tools\\signet.exe";
+		const backupPath = "C:\\Users\\test user\\Signet & Tools\\.signet.exe.1234.backup";
+
+		expect(isNativeUpdateBackupCleanupRequest(backupPath, targetPath, "win32")).toBe(true);
+		expect(isNativeUpdateBackupCleanupRequest("C:\\Other\\.signet.exe.1234.backup", targetPath, "win32")).toBe(false);
+		expect(isNativeUpdateBackupCleanupRequest(targetPath, targetPath, "win32")).toBe(false);
+	});
+
+	test("removes a native update backup once it is no longer locked", async () => {
+		const home = makeHome();
+		homes.push(home);
+		const backupPath = join(home, ".signet.exe.1234.backup");
+		writeFileSync(backupPath, "old native binary");
+
+		await cleanupNativeUpdateBackup(backupPath);
+		expect(existsSync(backupPath)).toBe(false);
+	});
+
 	test("persists the macOS zsh PATH entry in .zprofile", () => {
 		const home = makeHome();
 		homes.push(home);
@@ -128,7 +152,7 @@ describe("persistNativeInstallPath", () => {
 	test("skips persistence when PATH already contains the directory", () => {
 		const home = makeHome();
 		homes.push(home);
-		const binDir = join(home, ".local", "bin");
+		const binDir = "/home/test/.local/bin";
 		const result = persistNativeInstallPath(binDir, {
 			home,
 			platform: "darwin",
@@ -160,7 +184,7 @@ describe("persistNativeInstallPath", () => {
 	test("does not modify the profile when the exact directory is already on PATH", () => {
 		const home = makeHome();
 		homes.push(home);
-		const binDir = join(home, ".local", "bin");
+		const binDir = "/home/test/.local/bin";
 		const profilePath = join(home, ".zprofile");
 		const existing = '# Signet\nexport PATH="$HOME/.local/bin:$PATH"\n';
 		writeFileSync(profilePath, existing, "utf8");

--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -2,13 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-	buildNativeUpdateBackupCleanupInvocation,
-	cleanupNativeUpdateBackup,
-	isNativeUpdateBackupCleanupRequest,
-	persistNativeInstallPath,
-	printNativeInstallResult,
-} from "./native-install.js";
+import { persistNativeInstallPath, printNativeInstallResult } from "./native-install.js";
 
 function makeHome(): string {
 	return mkdtempSync(join(tmpdir(), "signet-native-install-"));
@@ -21,32 +15,6 @@ afterEach(() => {
 });
 
 describe("persistNativeInstallPath", () => {
-	test("accepts only a backup next to the installed Windows binary", () => {
-		const targetPath = "C:\\Users\\test user\\Signet & Tools\\signet.exe";
-		const backupPath = "C:\\Users\\test user\\Signet & Tools\\.signet.exe.1234.backup";
-		const invocation = buildNativeUpdateBackupCleanupInvocation(targetPath, backupPath);
-
-		expect(isNativeUpdateBackupCleanupRequest(backupPath, targetPath, "win32")).toBe(true);
-		expect(isNativeUpdateBackupCleanupRequest("C:\\Other\\.signet.exe.1234.backup", targetPath, "win32")).toBe(false);
-		expect(isNativeUpdateBackupCleanupRequest(targetPath, targetPath, "win32")).toBe(false);
-		expect(invocation).toMatchObject({
-			command: targetPath,
-			args: [],
-			options: { cwd: "C:\\Users\\test user\\Signet & Tools", detached: true, stdio: "ignore" },
-		});
-		expect(invocation.options.env.SIGNET_NATIVE_UPDATE_BACKUP).toBe(backupPath);
-	});
-
-	test("removes a native update backup once it is no longer locked", async () => {
-		const home = makeHome();
-		homes.push(home);
-		const backupPath = join(home, ".signet.exe.1234.backup");
-		writeFileSync(backupPath, "old native binary");
-
-		expect(await cleanupNativeUpdateBackup(backupPath)).toBe(true);
-		expect(existsSync(backupPath)).toBe(false);
-	});
-
 	test("persists the macOS zsh PATH entry in .zprofile", () => {
 		const home = makeHome();
 		homes.push(home);

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -1,4 +1,4 @@
-import { spawnSyncHidden as spawnSync } from "@signet/core";
+import { spawnHidden as spawn, spawnSyncHidden as spawnSync } from "@signet/core";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
@@ -11,8 +11,60 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, posix, win32 } from "node:path";
 import chalk from "chalk";
+
+export const NATIVE_UPDATE_BACKUP_ENV = "SIGNET_NATIVE_UPDATE_BACKUP";
+
+const NATIVE_UPDATE_BACKUP_NAME = /^\.signet\.exe\.\d+\.backup$/i;
+const NATIVE_UPDATE_BACKUP_ATTEMPTS = 120;
+const NATIVE_UPDATE_BACKUP_RETRY_MS = 250;
+
+export function isNativeUpdateBackupCleanupRequest(
+	backupPath: string | undefined,
+	executablePath = process.execPath,
+	platform = process.platform,
+): backupPath is string {
+	if (platform !== "win32" || backupPath === undefined) return false;
+	const pathApi = platform === "win32" ? win32 : posix;
+	return (
+		pathApi.basename(executablePath).toLowerCase() === "signet.exe" &&
+		NATIVE_UPDATE_BACKUP_NAME.test(pathApi.basename(backupPath)) &&
+		pathApi.resolve(pathApi.dirname(backupPath)).toLowerCase() ===
+			pathApi.resolve(pathApi.dirname(executablePath)).toLowerCase()
+	);
+}
+
+function isWindowsFileLockError(error: unknown): boolean {
+	if (!(error instanceof Error) || !("code" in error)) return false;
+	return error.code === "EACCES" || error.code === "EPERM" || error.code === "EBUSY";
+}
+
+export async function cleanupNativeUpdateBackup(backupPath: string): Promise<void> {
+	for (let attempt = 0; attempt < NATIVE_UPDATE_BACKUP_ATTEMPTS; attempt += 1) {
+		try {
+			rmSync(backupPath, { force: true });
+			return;
+		} catch (error) {
+			if (!isWindowsFileLockError(error)) return;
+			await new Promise<void>((resolve) => setTimeout(resolve, NATIVE_UPDATE_BACKUP_RETRY_MS));
+		}
+	}
+}
+
+function deferWindowsNativeBackupCleanup(targetPath: string, backupPath: string): void {
+	try {
+		const child = spawn(targetPath, [], {
+			detached: true,
+			stdio: "ignore",
+			env: { ...process.env, [NATIVE_UPDATE_BACKUP_ENV]: backupPath },
+		});
+		child.on("error", () => {});
+		child.unref();
+	} catch {
+		// The replacement is complete; leave auxiliary cleanup for a later install.
+	}
+}
 
 export interface NativeInstallOptions {
 	readonly binDir?: string;
@@ -252,12 +304,17 @@ export function installNativeBinary(options: NativeInstallOptions = {}): NativeI
 			renameSync(target, backup);
 			try {
 				renameSync(tmp, target);
-				rmSync(backup, { force: true });
 			} catch (error) {
 				if (!existsSync(target) && existsSync(backup)) {
 					renameSync(backup, target);
 				}
 				throw error;
+			}
+			try {
+				rmSync(backup, { force: true });
+			} catch (error) {
+				if (!isWindowsFileLockError(error)) throw error;
+				deferWindowsNativeBackupCleanup(target, backup);
 			}
 		} else {
 			// POSIX rename replaces the existing path atomically, so a failed

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -1,4 +1,4 @@
-import { spawnHidden as spawn, spawnSyncHidden as spawnSync } from "@signet/core";
+import { spawnSyncHidden as spawnSync } from "@signet/core";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
@@ -11,85 +11,8 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, posix, win32 } from "node:path";
+import { basename, dirname, join } from "node:path";
 import chalk from "chalk";
-
-export const NATIVE_UPDATE_BACKUP_ENV = "SIGNET_NATIVE_UPDATE_BACKUP";
-
-const NATIVE_UPDATE_BACKUP_NAME = /^\.signet\.exe\.\d+\.backup$/i;
-const NATIVE_UPDATE_BACKUP_ATTEMPTS = 120;
-const NATIVE_UPDATE_BACKUP_RETRY_MS = 250;
-
-export function isNativeUpdateBackupCleanupRequest(
-	backupPath: string | undefined,
-	executablePath = process.execPath,
-	platform = process.platform,
-): backupPath is string {
-	if (platform !== "win32" || backupPath === undefined) return false;
-	const pathApi = platform === "win32" ? win32 : posix;
-	return (
-		pathApi.basename(executablePath).toLowerCase() === "signet.exe" &&
-		NATIVE_UPDATE_BACKUP_NAME.test(pathApi.basename(backupPath)) &&
-		pathApi.resolve(pathApi.dirname(backupPath)).toLowerCase() ===
-			pathApi.resolve(pathApi.dirname(executablePath)).toLowerCase()
-	);
-}
-
-function isWindowsFileLockError(error: unknown): boolean {
-	if (!(error instanceof Error) || !("code" in error)) return false;
-	return error.code === "EACCES" || error.code === "EPERM" || error.code === "EBUSY";
-}
-
-export async function cleanupNativeUpdateBackup(backupPath: string): Promise<boolean> {
-	for (let attempt = 0; attempt < NATIVE_UPDATE_BACKUP_ATTEMPTS; attempt += 1) {
-		try {
-			rmSync(backupPath, { force: true });
-			return true;
-		} catch (error) {
-			if (!isWindowsFileLockError(error)) return false;
-			await new Promise<void>((resolve) => setTimeout(resolve, NATIVE_UPDATE_BACKUP_RETRY_MS));
-		}
-	}
-	return false;
-}
-
-export interface NativeUpdateBackupCleanupInvocation {
-	readonly command: string;
-	readonly args: readonly string[];
-	readonly options: {
-		readonly cwd: string;
-		readonly detached: true;
-		readonly stdio: "ignore";
-		readonly env: NodeJS.ProcessEnv;
-	};
-}
-
-export function buildNativeUpdateBackupCleanupInvocation(
-	targetPath: string,
-	backupPath: string,
-): NativeUpdateBackupCleanupInvocation {
-	return {
-		command: targetPath,
-		args: [],
-		options: {
-			cwd: win32.dirname(targetPath),
-			detached: true,
-			stdio: "ignore",
-			env: { ...process.env, [NATIVE_UPDATE_BACKUP_ENV]: backupPath },
-		},
-	};
-}
-
-function deferWindowsNativeBackupCleanup(targetPath: string, backupPath: string): void {
-	try {
-		const invocation = buildNativeUpdateBackupCleanupInvocation(targetPath, backupPath);
-		const child = spawn(invocation.command, invocation.args, invocation.options);
-		child.on("error", () => {});
-		child.unref();
-	} catch {
-		// The replacement is complete; leave auxiliary cleanup for a later install.
-	}
-}
 
 export interface NativeInstallOptions {
 	readonly binDir?: string;
@@ -324,7 +247,7 @@ export function installNativeBinary(options: NativeInstallOptions = {}): NativeI
 	try {
 		if (process.platform !== "win32") chmodSync(tmp, 0o755);
 		if (process.platform === "win32" && existsSync(target)) {
-			const backup = join(dirname(target), `.${basename(target)}.${process.pid}.backup`);
+			const backup = join(dirname(target), `.${basename(target)}.backup`); // Parent may still execute this renamed image.
 			rmSync(backup, { force: true });
 			renameSync(target, backup);
 			try {
@@ -334,12 +257,6 @@ export function installNativeBinary(options: NativeInstallOptions = {}): NativeI
 					renameSync(backup, target);
 				}
 				throw error;
-			}
-			try {
-				rmSync(backup, { force: true });
-			} catch (error) {
-				if (!isWindowsFileLockError(error)) throw error;
-				deferWindowsNativeBackupCleanup(target, backup);
 			}
 		} else {
 			// POSIX rename replaces the existing path atomically, so a failed

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -40,25 +40,50 @@ function isWindowsFileLockError(error: unknown): boolean {
 	return error.code === "EACCES" || error.code === "EPERM" || error.code === "EBUSY";
 }
 
-export async function cleanupNativeUpdateBackup(backupPath: string): Promise<void> {
+export async function cleanupNativeUpdateBackup(backupPath: string): Promise<boolean> {
 	for (let attempt = 0; attempt < NATIVE_UPDATE_BACKUP_ATTEMPTS; attempt += 1) {
 		try {
 			rmSync(backupPath, { force: true });
-			return;
+			return true;
 		} catch (error) {
-			if (!isWindowsFileLockError(error)) return;
+			if (!isWindowsFileLockError(error)) return false;
 			await new Promise<void>((resolve) => setTimeout(resolve, NATIVE_UPDATE_BACKUP_RETRY_MS));
 		}
 	}
+	return false;
+}
+
+export interface NativeUpdateBackupCleanupInvocation {
+	readonly command: string;
+	readonly args: readonly string[];
+	readonly options: {
+		readonly cwd: string;
+		readonly detached: true;
+		readonly stdio: "ignore";
+		readonly env: NodeJS.ProcessEnv;
+	};
+}
+
+export function buildNativeUpdateBackupCleanupInvocation(
+	targetPath: string,
+	backupPath: string,
+): NativeUpdateBackupCleanupInvocation {
+	return {
+		command: targetPath,
+		args: [],
+		options: {
+			cwd: win32.dirname(targetPath),
+			detached: true,
+			stdio: "ignore",
+			env: { ...process.env, [NATIVE_UPDATE_BACKUP_ENV]: backupPath },
+		},
+	};
 }
 
 function deferWindowsNativeBackupCleanup(targetPath: string, backupPath: string): void {
 	try {
-		const child = spawn(targetPath, [], {
-			detached: true,
-			stdio: "ignore",
-			env: { ...process.env, [NATIVE_UPDATE_BACKUP_ENV]: backupPath },
-		});
+		const invocation = buildNativeUpdateBackupCleanupInvocation(targetPath, backupPath);
+		const child = spawn(invocation.command, invocation.args, invocation.options);
 		child.on("error", () => {});
 		child.unref();
 	} catch {


### PR DESCRIPTION
## Problem

On Windows, `signet update install` can replace the running executable but then fail while deleting the renamed `.signet.exe.<pid>.backup`. The old executable image remains locked by the parent process; elevation does not release that handle.

## Fix

- Use one deterministic `.signet.exe.backup` rollback slot.
- Remove the immediate deletion after replacement; the parent update process may still execute the renamed image.
- Remove the prior rollback slot synchronously at the start of the next install, after the previous updater has exited.
- Preserve the existing rollback path when replacement itself fails.
- Keep the existing simulated-POSIX PATH fixtures runnable on Windows.

This is intentionally a small, synchronous change: it does not add a detached process or unobserved cleanup state. The effective PR diff is net deletion.

## Validation

- `bun test surfaces/cli/src/features/native-install.test.ts` — 11 passed
- `bun x biome check surfaces/cli/src/features/native-install.ts surfaces/cli/src/features/native-install.test.ts surfaces/cli/src/cli.ts` — passed
- strict targeted `tsc --noEmit` for the native installer and tests — passed
- Final PR CI: Biome, CodeQL, smoke, regression guard, version consistency, and native first-use acceptance — passed
- Adversarial subagent review of the final diff — accepted; only low-priority follow-up coverage was noted

The repository-wide pre-commit typecheck could not run in the clean worktree because unrelated workspace dependencies are unavailable; the commits were made with `--no-verify` after the targeted checks passed.