### PR TITLE
fix(daemon): route OpenCode Pi calls

### DIFF
--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -80,6 +80,7 @@ export type {
 	AgentManifest,
 	AgentConfig,
 	LlmProvider,
+	LlmGenerateOptions,
 	LlmUsage,
 	LlmCacheRequestAccounting,
 	LlmGenerateResult,

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -76,6 +76,8 @@ export interface LlmGenerateOptions {
 	readonly maxTokens?: number;
 	readonly temperature?: number;
 	readonly signal?: AbortSignal;
+	/** Optional upstream session identity for providers that support session affinity. */
+	readonly sessionId?: string;
 	readonly responseFormat?: "json";
 	readonly think?: boolean;
 }

--- a/platform/daemon/src/inference-provider-matrix.test.ts
+++ b/platform/daemon/src/inference-provider-matrix.test.ts
@@ -160,6 +160,37 @@ function writeMatrixConfig(dir: string): void {
 	);
 }
 
+function writeOpenCodeMatrixConfig(dir: string): void {
+	mkdirSync(join(dir, "memory"), { recursive: true });
+	writeFileSync(
+		join(dir, "agent.yaml"),
+		`inference:
+  defaultPolicy: opencode
+  accounts:
+    opencode-account:
+      kind: api
+      providerFamily: opencode-go
+      credentialRef: SIGNET_MATRIX_PRIMARY_API_KEY
+  targets:
+    opencode:
+      executor: openai-compatible
+      account: opencode-account
+      endpoint: https://opencode.ai/zen/go/v1
+      models:
+        default:
+          model: deepseek-v4-flash
+          streaming: true
+  policies:
+    opencode:
+      mode: strict
+      allow:
+        - opencode/default
+      defaultTargets:
+        - opencode/default
+`,
+	);
+}
+
 afterEach(() => {
 	globalThis.fetch = originalFetch;
 	restoreCredential("SIGNET_MATRIX_STRUCTURED_API_KEY", originalStructuredApiKey);
@@ -170,6 +201,68 @@ afterEach(() => {
 });
 
 describe("InferenceRouter hermetic provider matrix (#1324)", () => {
+	test("propagates caller session affinity and isolates generated sessions (#1887)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-provider-matrix-opencode-"));
+		try {
+			writeOpenCodeMatrixConfig(dir);
+			setMatrixCredentials();
+			const probeHeaders: Headers[] = [];
+			const sessionIds: Array<string | null> = [];
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const headers = new Headers(init?.headers);
+				if (String(input).endsWith("/models")) {
+					probeHeaders.push(headers);
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				sessionIds.push(headers.get("x-opencode-session"));
+				return Promise.resolve(openAiSseResponse("routed response"));
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const callerOwned = await router.execute(
+				{ operation: "memory_extraction", promptPreview: "caller-owned session" },
+				"Use the caller-owned session.",
+				{ maxTokens: 32, timeoutMs: 1_000, sessionId: "caller-session" },
+			);
+			const generatedOne = await router.execute(
+				{ operation: "memory_extraction", promptPreview: "generated session one" },
+				"Use a generated session.",
+				{ maxTokens: 32, timeoutMs: 1_000 },
+			);
+			const generatedTwo = await router.execute(
+				{ operation: "memory_extraction", promptPreview: "generated session two" },
+				"Use another generated session.",
+				{ maxTokens: 32, timeoutMs: 1_000 },
+			);
+			const streamed = await router.stream(
+				{ operation: "memory_extraction", promptPreview: "stream session" },
+				"Use the stream session.",
+				{ maxTokens: 32, timeoutMs: 1_000, sessionId: "stream-session" },
+			);
+			if (streamed.ok) {
+				const reader = streamed.value.stream.getReader();
+				while (!(await reader.read()).done) {
+					// Drain the stream so the upstream request settles.
+				}
+			}
+
+			expect(callerOwned.ok).toBe(true);
+			expect(generatedOne.ok).toBe(true);
+			expect(generatedTwo.ok).toBe(true);
+			expect(streamed.ok).toBe(true);
+			expect(sessionIds).toHaveLength(4);
+			expect(sessionIds[0]).toBe("caller-session");
+			expect(sessionIds[1]).toMatch(/^[0-9a-f-]{36}$/);
+			expect(sessionIds[2]).toMatch(/^[0-9a-f-]{36}$/);
+			expect(sessionIds[3]).toBe("stream-session");
+			expect(sessionIds[1]).not.toBe(sessionIds[2]);
+			expect(probeHeaders.length).toBeGreaterThan(0);
+			expect(probeHeaders.every((headers) => headers.get("x-opencode-session") === null)).toBe(true);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	test("uses workload-selected targets, forwards output bounds, and parses structured output", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "signet-provider-matrix-structured-"));
 		try {

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFile as readFileAsync, stat as statAsync } from "node:fs/promises";
 import { isAbsolute, join, normalize, resolve } from "node:path";
 import type { AgentSessionEvent, ToolDefinition } from "@earendil-works/pi-coding-agent";
@@ -1008,6 +1009,7 @@ export class InferenceRouter {
 			readonly acpxHooks?: AcpxHooksMode;
 			readonly signal?: AbortSignal;
 			readonly abortSignal?: AbortSignal;
+			readonly sessionId?: string;
 		},
 	): Promise<RouterResult<InferenceExecutionResult>> {
 		const background = this.beginBackgroundExecution(request.operation, request.agentId, "inference");
@@ -1269,6 +1271,7 @@ export class InferenceRouter {
 			readonly refresh?: boolean;
 			readonly acpxHooks?: AcpxHooksMode;
 			readonly signal?: AbortSignal;
+			readonly sessionId?: string;
 		},
 	): Promise<RouterResult<InferenceExecutionResult>> {
 		const loaded = await this.loadConfig(opts?.refresh ?? false);
@@ -1276,6 +1279,7 @@ export class InferenceRouter {
 		const decision = await this.explain(request, false);
 		if (!decision.ok) return decision;
 		const attempts: InferenceExecutionAttempt[] = [];
+		const sessionId = opts?.sessionId ?? randomUUID();
 		for (const targetRef of [decision.value.targetRef, ...decision.value.fallbackTargetRefs]) {
 			if (opts?.signal?.aborted) break;
 			const parsed = parseRoutingTargetRef(targetRef);
@@ -1312,6 +1316,7 @@ export class InferenceRouter {
 					timeoutMs: opts?.timeoutMs,
 					maxTokens: opts?.maxTokens,
 					signal: opts?.signal,
+					sessionId,
 					// aggregate_recall is latency-sensitive (the routing engine already
 					// excludes ACPX subprocesses for it). Suppress thinking for the same
 					// reason: thinking tokens would dominate the synthesis budget.
@@ -1374,6 +1379,7 @@ export class InferenceRouter {
 			readonly maxTokens?: number;
 			readonly refresh?: boolean;
 			readonly abortSignal?: AbortSignal;
+			readonly sessionId?: string;
 		},
 	): Promise<RouterResult<InferenceStreamResult>> {
 		const loaded = await this.loadConfig(opts?.refresh ?? false);
@@ -1388,6 +1394,7 @@ export class InferenceRouter {
 		if (!decision.ok) return decision;
 
 		const attempts: InferenceExecutionAttempt[] = [];
+		const sessionId = opts?.sessionId ?? randomUUID();
 		for (const targetRef of [decision.value.targetRef, ...decision.value.fallbackTargetRefs]) {
 			const parsed = parseRoutingTargetRef(targetRef);
 			if (!parsed.ok) {
@@ -1427,6 +1434,7 @@ export class InferenceRouter {
 					timeoutMs: opts?.timeoutMs,
 					maxTokens: opts?.maxTokens,
 					abortSignal: opts?.abortSignal,
+					sessionId,
 					// aggregate_recall is latency-sensitive: suppress thinking tokens
 					// (mirrors the execute path and the routing engine's ACPX exclusion).
 					reasoning: request.operation === "aggregate_recall" ? false : undefined,

--- a/platform/daemon/src/pipeline/pi-provider.test.ts
+++ b/platform/daemon/src/pipeline/pi-provider.test.ts
@@ -81,6 +81,137 @@ describe("pi provider catalog models", () => {
 		expect(resolved.piModel.baseUrl).toBe("https://opencode.ai/zen/go/v1");
 	});
 
+	test("routes supplied OpenCode session affinity through non-interactive Pi calls (#1887)", async () => {
+		const originalFetch = globalThis.fetch;
+		const requestHeaders: Headers[] = [];
+		globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+			const headers = new Headers(init?.headers);
+			requestHeaders.push(headers);
+			if (init?.method !== "GET" && !headers.get("x-opencode-session")) {
+				return Promise.resolve(new Response("missing x-opencode-session", { status: 400 }));
+			}
+			return Promise.resolve(
+				new Response(
+					[
+						`data: ${JSON.stringify({ choices: [{ delta: { content: "done" } }] })}\n\n`,
+						`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\n`,
+						"data: [DONE]\n\n",
+					].join(""),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				),
+			);
+		}) as unknown as typeof fetch;
+		try {
+			const model = getModels("opencode-go").find((candidate) => candidate.id === "deepseek-v4-flash");
+			expect(model).toBeDefined();
+			const provider = createPiModelProvider({
+				executor: "openai-compatible",
+				providerFamily: "opencode-go",
+				model: "deepseek-v4-flash",
+				piModel: model as Model<Api>,
+				apiKey: "test-key",
+			});
+
+			await expect(provider.available()).resolves.toBe(true);
+			await expect(provider.generate("non-interactive call", { sessionId: "request-session" })).resolves.toBe("done");
+			const streamWithUsage = provider.streamWithUsage;
+			if (!streamWithUsage) throw new Error("expected Pi stream support");
+			const result = await streamWithUsage("non-interactive stream", { sessionId: "request-session" });
+			const reader = result.stream.getReader();
+			while (!(await reader.read()).done) {
+				// Drain the stream so the upstream request settles.
+			}
+
+			expect(requestHeaders).toHaveLength(3);
+			expect(requestHeaders[0]?.get("x-opencode-session")).toBeNull();
+			expect(requestHeaders[0]?.get("x-opencode-client")).toBeNull();
+			expect(requestHeaders.slice(1).map((headers) => headers.get("x-opencode-session"))).toEqual([
+				"request-session",
+				"request-session",
+			]);
+			expect(requestHeaders.slice(1).every((headers) => headers.get("x-opencode-client") === "pi")).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("preserves configured OpenCode headers and isolates unrelated providers", async () => {
+		const originalFetch = globalThis.fetch;
+		const requestHeaders: Headers[] = [];
+		globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+			requestHeaders.push(new Headers(init?.headers));
+			return Promise.resolve(
+				new Response(
+					[
+						`data: ${JSON.stringify({ choices: [{ delta: { content: "done" } }] })}\n\n`,
+						`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\n`,
+						"data: [DONE]\n\n",
+					].join(""),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				),
+			);
+		}) as unknown as typeof fetch;
+		try {
+			const openCodeModel = getModels("opencode-go").find((candidate) => candidate.id === "deepseek-v4-flash");
+			if (!openCodeModel) throw new Error("expected OpenCode Go catalog model");
+			const configuredOpenCodeModel = {
+				...openCodeModel,
+				headers: {
+					"X-OpenCode-Session": "configured-session",
+					"X-OpenCode-Client": "configured-client",
+				},
+			};
+			const openCodeProvider = createPiModelProvider({
+				executor: "openai-compatible",
+				providerFamily: "opencode-go",
+				model: "deepseek-v4-flash",
+				piModel: configuredOpenCodeModel,
+				apiKey: "test-key",
+			});
+			await expect(openCodeProvider.generate("configured headers", { sessionId: "generated-session" })).resolves.toBe(
+				"done",
+			);
+
+			const unrelatedModel = getModels("openrouter")[0];
+			if (!unrelatedModel) throw new Error("expected OpenRouter catalog model");
+			const unrelatedProvider = createPiModelProvider({
+				executor: "openrouter",
+				providerFamily: "openrouter",
+				model: unrelatedModel.id,
+				piModel: unrelatedModel,
+				apiKey: "test-key",
+			});
+			await expect(unrelatedProvider.generate("unrelated provider", { sessionId: "unrelated-session" })).resolves.toBe(
+				"done",
+			);
+
+			const endpointModel = {
+				...openCodeModel,
+				provider: "custom-opencode",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+			};
+			const endpointProvider = createPiModelProvider({
+				executor: "openai-compatible",
+				model: "deepseek-v4-flash",
+				piModel: endpointModel,
+				apiKey: "test-key",
+			});
+			await expect(endpointProvider.generate("endpoint detection", { sessionId: "endpoint-session" })).resolves.toBe(
+				"done",
+			);
+
+			expect(requestHeaders).toHaveLength(3);
+			expect(requestHeaders[0]?.get("x-opencode-session")).toBe("configured-session");
+			expect(requestHeaders[0]?.get("x-opencode-client")).toBe("configured-client");
+			expect(requestHeaders[1]?.get("x-opencode-session")).toBeNull();
+			expect(requestHeaders[1]?.get("x-opencode-client")).toBeNull();
+			expect(requestHeaders[2]?.get("x-opencode-session")).toBe("endpoint-session");
+			expect(requestHeaders[2]?.get("x-opencode-client")).toBe("pi");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
 	test("does not label a remote zero-rate model as provider-reported cost", () => {
 		const provider = createPiModelProvider({
 			executor: "openai-compatible",

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -15,6 +15,7 @@ import {
 	InMemoryCredentialStore,
 	type Model,
 	type OpenAICompletionsCompat,
+	type ProviderHeaders,
 	type ThinkingLevel,
 	type Usage,
 } from "@earendil-works/pi-ai";
@@ -213,6 +214,36 @@ interface ResolvedModel {
 
 function isLocalBaseUrl(url: string): boolean {
 	return /^https?:\/\/(127\.0\.0\.1|localhost|\[?::1\]?)/i.test(url);
+}
+
+function isOpenCodeModel(config: PiModelProviderConfig, model: Model<Api>): boolean {
+	if (config.providerFamily === "opencode" || config.providerFamily === "opencode-go") return true;
+	if (model.provider === "opencode" || model.provider === "opencode-go") return true;
+	try {
+		return new URL(model.baseUrl).hostname === "opencode.ai";
+	} catch {
+		return false;
+	}
+}
+
+function hasHeader(model: Model<Api>, name: string): boolean {
+	return Object.keys(model.headers ?? {}).some((key) => key.toLowerCase() === name);
+}
+
+function openCodeHeaders(
+	config: PiModelProviderConfig,
+	model: Model<Api>,
+	sessionId: string | undefined,
+): ProviderHeaders | undefined {
+	// ModelRuntime's direct API does not run pi-coding-agent's SDK provider
+	// attribution transform. Keep only the OpenCode defaults here; session
+	// lifetime is owned by the router and configured model headers win.
+	if (!sessionId || !isOpenCodeModel(config, model)) return undefined;
+	const headers: Record<string, string> = {
+		...(hasHeader(model, "x-opencode-session") ? {} : { "x-opencode-session": sessionId }),
+		...(hasHeader(model, "x-opencode-client") ? {} : { "x-opencode-client": "pi" }),
+	};
+	return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
 function localAccountingForConfig(config: PiModelProviderConfig): AccountingProvenance | undefined {
@@ -553,6 +584,8 @@ export function createPiModelProvider(
 	): {
 		apiKey: string | undefined;
 		signal: AbortSignal;
+		sessionId?: string;
+		transformHeaders?: (headers: ProviderHeaders) => ProviderHeaders;
 		maxTokens?: number;
 		temperature?: number;
 		reasoning?: ThinkingLevel;
@@ -563,9 +596,15 @@ export function createPiModelProvider(
 		//   opts.reasoning undefined   -> use the provider's configured level
 		const effectiveReasoning: ThinkingLevel | undefined =
 			opts?.reasoning === false ? undefined : (opts?.reasoning ?? reasoning);
+		const headers = openCodeHeaders(config, piModel, opts?.sessionId);
+		const transformHeaders = headers
+			? (requestHeaders: ProviderHeaders): ProviderHeaders => ({ ...headers, ...requestHeaders })
+			: undefined;
 		return {
 			apiKey,
 			signal: abort.signal,
+			...(opts?.sessionId ? { sessionId: opts.sessionId } : {}),
+			...(transformHeaders ? { transformHeaders } : {}),
 			...(opts?.maxTokens ? { maxTokens: opts.maxTokens } : {}),
 			...(typeof opts?.temperature === "number" ? { temperature: opts.temperature } : {}),
 			...(effectiveReasoning !== undefined ? { reasoning: effectiveReasoning } : {}),

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -25,6 +25,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import {
 	type AcpxModelSelection,
 	DEFAULT_PROVIDER_RATE_LIMIT,
+	type LlmGenerateOptions,
 	type LlmGenerateResult,
 	type LlmProvider,
 	type LlmUsage,
@@ -454,11 +455,10 @@ export async function acquireLlmConcurrencyPermit(
 
 export type { LlmProvider, LlmGenerateResult } from "@signet/core";
 
-export type LlmProviderCallOptions = {
-	readonly timeoutMs?: number;
-	readonly maxTokens?: number;
-	readonly temperature?: number;
-	readonly signal?: AbortSignal;
+export type LlmProviderCallOptions = Pick<
+	LlmGenerateOptions,
+	"timeoutMs" | "maxTokens" | "temperature" | "signal" | "sessionId"
+> & {
 	readonly abortSignal?: AbortSignal;
 	/**
 	 * Per-call thinking-level override for pi-ai-backed providers.

--- a/web/docs/src/content/docs/pipeline/workers-maintenance.md
+++ b/web/docs/src/content/docs/pipeline/workers-maintenance.md
@@ -217,6 +217,11 @@ All LLM calls go through an `LlmProvider` interface with two methods:
 `generate(prompt, opts?)` returning a `Promise<string>`, and `available()`
 returning a `Promise<boolean>`.
 
+`opts.sessionId` is optional upstream session-affinity metadata. The router keeps a
+caller-provided ID or creates one per routed inference execution. Providers that
+do not support session affinity ignore it; Pi agent sessions keep Pi's native
+session ID.
+
 Two implementations are shipped:
 
 **LlamaCppProvider** calls the llama.cpp server via its OpenAI-compatible


### PR DESCRIPTION
## Summary

Fixes #1887 by carrying upstream session-affinity identity through Signet's shared inference contract for Pi's non-interactive daemon requests.

## Changes

- Add optional `sessionId` metadata to the shared `LlmGenerateOptions` contract.
- Have the inference router retain a caller-provided ID or create one per routed unary/stream execution.
- Use Pi `ModelRuntime`'s `transformHeaders` seam to apply OpenCode defaults only to OpenCode/OpenCode Go models and `opencode.ai` endpoints.
- Preserve configured request/model headers and keep OpenCode session headers off the `/models` availability probe.
- Keep Pi `AgentSession` lifecycle and native session IDs unchanged.
- Add provider and router regressions for session lifetime, explicit-header precedence, unrelated providers, endpoint detection, and probe behavior.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A: daemon/core/docs change.

## Migration Notes (if applicable)

N/A: no migration.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Additional verification:

- `bun test platform/daemon/src/pipeline platform/daemon/src/inference-provider-matrix.test.ts platform/daemon/src/inference-provider-factory.test.ts`: passed.
- `bun test platform/daemon/src/pipeline/pi-provider.test.ts platform/daemon/src/inference-provider-matrix.test.ts`: 23 passed, 0 failed.
- `bun run --filter '@signet/daemon' build`: passed.
- `bun run format:check`: passed; existing generated connector bundle size warnings remain.
- `bunx biome check` on all eight changed files: passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Non-interactive routed calls now receive an explicit affinity ID from the router. A caller-provided ID is retained; otherwise each routed unary or stream execution receives a fresh UUID. Pi agent-session calls continue through pi-coding-agent's native stable session mechanism. The direct path uses Pi's public ModelRuntime header-transform hook because the SDK's OpenCode attribution helper is not exported; Signet owns only the unavoidable OpenCode adapter, not session lifecycle.
