### PR TITLE
fix(dreaming): keep worker available at startup

### DIFF
--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -391,6 +391,17 @@ describe("daemon status contract", () => {
 		expect(extractionFallback).toContain("dbOwnerTransaction");
 	});
 
+	it("keeps DB-owner maintenance available when admitting Dreaming", () => {
+		const source = readFileSync(new URL("./daemon.ts", import.meta.url), "utf-8");
+		const runtimeStart = source.indexOf("async function startPipelineRuntime");
+		const maintenanceStart = source.indexOf("dbOwnerMaintenanceHandle = initializeDbOwnerMaintenance()", runtimeStart);
+		const workerStart = source.indexOf("dreamingWorkerHandle = startDreamingWorker", runtimeStart);
+
+		expect(runtimeStart).toBeGreaterThanOrEqual(0);
+		expect(maintenanceStart).toBeGreaterThan(runtimeStart);
+		expect(maintenanceStart).toBeLessThan(workerStart);
+	});
+
 	it("counts non-errored connectors as active for heartbeat telemetry", () => {
 		expect(countConnectorsActive([{ status: "idle" }, { status: "syncing" }, { status: "error" }])).toBe(2);
 	});

--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -391,22 +391,6 @@ describe("daemon status contract", () => {
 		expect(extractionFallback).toContain("dbOwnerTransaction");
 	});
 
-	it("admits Dreaming before DB-owner startup gates can reject the deferred runtime", () => {
-		const source = readFileSync(new URL("./daemon.ts", import.meta.url), "utf-8");
-		const runtimeStart = source.indexOf("async function startPipelineRuntime");
-		const workerStart = source.indexOf("dreamingWorkerHandle = startDreamingWorker", runtimeStart);
-		const legacyRetirement = source.indexOf("const deadLettered = await retireLegacyExtractionJobsAsync", runtimeStart);
-		const embeddingResolution = source.indexOf(
-			"const activeEmbeddingCfg = await resolveActiveEmbeddingConfigThroughOwner",
-			runtimeStart,
-		);
-
-		expect(runtimeStart).toBeGreaterThanOrEqual(0);
-		expect(workerStart).toBeGreaterThan(runtimeStart);
-		expect(workerStart).toBeLessThan(legacyRetirement);
-		expect(workerStart).toBeLessThan(embeddingResolution);
-	});
-
 	it("counts non-errored connectors as active for heartbeat telemetry", () => {
 		expect(countConnectorsActive([{ status: "idle" }, { status: "syncing" }, { status: "error" }])).toBe(2);
 	});

--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -391,6 +391,22 @@ describe("daemon status contract", () => {
 		expect(extractionFallback).toContain("dbOwnerTransaction");
 	});
 
+	it("admits Dreaming before DB-owner startup gates can reject the deferred runtime", () => {
+		const source = readFileSync(new URL("./daemon.ts", import.meta.url), "utf-8");
+		const runtimeStart = source.indexOf("async function startPipelineRuntime");
+		const workerStart = source.indexOf("dreamingWorkerHandle = startDreamingWorker", runtimeStart);
+		const legacyRetirement = source.indexOf("const deadLettered = await retireLegacyExtractionJobsAsync", runtimeStart);
+		const embeddingResolution = source.indexOf(
+			"const activeEmbeddingCfg = await resolveActiveEmbeddingConfigThroughOwner",
+			runtimeStart,
+		);
+
+		expect(runtimeStart).toBeGreaterThanOrEqual(0);
+		expect(workerStart).toBeGreaterThan(runtimeStart);
+		expect(workerStart).toBeLessThan(legacyRetirement);
+		expect(workerStart).toBeLessThan(embeddingResolution);
+	});
+
 	it("counts non-errored connectors as active for heartbeat telemetry", () => {
 		expect(countConnectorsActive([{ status: "idle" }, { status: "syncing" }, { status: "error" }])).toBe(2);
 	});

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1812,13 +1812,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	void router.validateConfigReferences();
 
 	if (dbOwnerMaintenanceHandle === null) {
-		try {
-			dbOwnerMaintenanceHandle = initializeDbOwnerMaintenance();
-		} catch (error) {
-			logger.warn("daemon", "Could not prepare maintenance before Dreaming admission; deferred startup will retry", {
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
+		dbOwnerMaintenanceHandle = initializeDbOwnerMaintenance();
 	}
 
 	const activeEmbeddingCfg = await startDeferredRuntimeAfterDreaming(

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1778,6 +1778,13 @@ function buildTelemetryConfigSnapshot(agentsDir: string, memoryCfg: ResolvedMemo
 	};
 }
 
+function initializeDbOwnerMaintenance(): DbOwnerMaintenance {
+	const maintenance = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient ?? undefined });
+	registerDbOwnerMaintenance(maintenance);
+	registerDbOwnerHealthProvider(maintenance.health);
+	return maintenance;
+}
+
 async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector): Promise<void> {
 	const pipelinePaused = memoryCfg.pipelineV2.paused;
 	const router = getOrCreateInferenceRouter(AGENTS_DIR);
@@ -1803,6 +1810,16 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	// Surface broken routing references (defaultPolicy, workload targets, etc.) at
 	// boot before any route is attempted (#1005). Never blocks daemon startup.
 	void router.validateConfigReferences();
+
+	if (dbOwnerMaintenanceHandle === null) {
+		try {
+			dbOwnerMaintenanceHandle = initializeDbOwnerMaintenance();
+		} catch (error) {
+			logger.warn("daemon", "Could not prepare maintenance before Dreaming admission; deferred startup will retry", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
 
 	const activeEmbeddingCfg = await startDeferredRuntimeAfterDreaming(
 		// Admit Dreaming before optional startup work. Legacy-job retirement and
@@ -1931,9 +1948,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	});
 
 	if (dbOwnerMaintenanceHandle === null) {
-		dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient ?? undefined });
-		registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);
-		registerDbOwnerHealthProvider(dbOwnerMaintenanceHandle.health);
+		dbOwnerMaintenanceHandle = initializeDbOwnerMaintenance();
 	}
 
 	if (memoryCfg.pipelineV2.enabled && !pipelinePaused) {
@@ -2493,8 +2508,7 @@ async function main() {
 	startEventLoopMonitor();
 	startFdPollMonitor();
 
-	dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient });
-	registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);
+	dbOwnerMaintenanceHandle = initializeDbOwnerMaintenance();
 	// Clean accumulated crash-loop damage through the owner. This remains a
 	// deferred call, so owner startup and the bounded drain never delay readiness.
 	if (!migrationIntegrityWritesBlocked) runStartupRecovery(getDbAccessor(), { owner: dbOwnerClient });

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1779,6 +1779,69 @@ function buildTelemetryConfigSnapshot(agentsDir: string, memoryCfg: ResolvedMemo
 
 async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector): Promise<void> {
 	const pipelinePaused = memoryCfg.pipelineV2.paused;
+	const router = getOrCreateInferenceRouter(AGENTS_DIR);
+	const defaultAgentId = resolveDaemonAgentId();
+	initInferenceProviderResolver((workload) => {
+		switch (workload) {
+			case "memoryExtraction":
+				return router.createWorkloadProvider("memory_extraction", defaultAgentId);
+			case "sessionSynthesis":
+				return router.createWorkloadProvider("session_synthesis", defaultAgentId);
+			case "aggregateRecall":
+				return router.createWorkloadProvider("aggregate_recall", defaultAgentId);
+			case "widgetGeneration":
+				return router.createWorkloadProvider("widget_generation", defaultAgentId);
+			case "repair":
+				return router.createWorkloadProvider("repair", defaultAgentId);
+			case "interactive":
+				return router.createWorkloadProvider("interactive", defaultAgentId);
+			case "default":
+				return router.createWorkloadProvider("default", defaultAgentId);
+		}
+	});
+	// Surface broken routing references (defaultPolicy, workload targets, etc.) at
+	// boot before any route is attempted (#1005). Never blocks daemon startup.
+	void router.validateConfigReferences();
+
+	// Admit Dreaming before optional startup work. Legacy-job retirement and
+	// embedding resolution both use the DB-owner queue and can reject the
+	// deferred runtime before the worker would otherwise be created.
+	if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
+		try {
+			dreamingWorkerHandle = startDreamingWorker(
+				getDbAccessor(),
+				memoryCfg.dreaming,
+				AGENTS_DIR,
+				defaultAgentId,
+				{
+					acpxMcp: {
+						daemonUrl: `http://${INTERNAL_SELF_HOST}:${PORT}`,
+						authorizationTokenForAgent: (agentId) =>
+							authSecret
+								? createToken(
+										authSecret,
+										{ sub: `dreaming:${agentId}`, role: "agent", scope: { agent: agentId } },
+										Math.max(900, Math.ceil(memoryCfg.dreaming.timeout / 1000) + 60),
+									)
+								: undefined,
+					},
+					evidenceRetry: {
+						cooldownMs: memoryCfg.pipelineV2.repair.requeueCooldownMs,
+						hourlyBudget: memoryCfg.pipelineV2.repair.requeueHourlyBudget,
+						maxAttempts: 3,
+					},
+					ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,
+				},
+				graphWriteCaps(memoryCfg),
+			);
+			setDreamingWorker(dreamingWorkerHandle);
+		} catch (err) {
+			logger.warn("dreaming", "Failed to start dreaming worker (non-fatal)", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
 	logger.info("dreaming", "Dreaming owns all semantic writes; legacy extraction is retired");
 	// Terminalize every pre-existing legacy `extract` job. The source keeps its
 	// provenance and memory kind, so only already-episodic evidence remains
@@ -1811,30 +1874,6 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	if (!transcriptCaptureWorkerHandle) {
 		transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
 	}
-
-	const router = getOrCreateInferenceRouter(AGENTS_DIR);
-	// Surface broken routing references (defaultPolicy, workload targets, etc.) at
-	// boot before any route is attempted (#1005). Never blocks daemon startup.
-	void router.validateConfigReferences();
-	const defaultAgentId = resolveDaemonAgentId();
-	initInferenceProviderResolver((workload) => {
-		switch (workload) {
-			case "memoryExtraction":
-				return router.createWorkloadProvider("memory_extraction", defaultAgentId);
-			case "sessionSynthesis":
-				return router.createWorkloadProvider("session_synthesis", defaultAgentId);
-			case "aggregateRecall":
-				return router.createWorkloadProvider("aggregate_recall", defaultAgentId);
-			case "widgetGeneration":
-				return router.createWorkloadProvider("widget_generation", defaultAgentId);
-			case "repair":
-				return router.createWorkloadProvider("repair", defaultAgentId);
-			case "interactive":
-				return router.createWorkloadProvider("interactive", defaultAgentId);
-			case "default":
-				return router.createWorkloadProvider("default", defaultAgentId);
-		}
-	});
 
 	const routerStatus = await router.status(false);
 	const statusValue = routerStatus.ok ? routerStatus.value : null;
@@ -1935,45 +1974,8 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		setEmbeddingTrackerHandle(embeddingTrackerHandle);
 	}
 
-	if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
-		try {
-			dreamingWorkerHandle = startDreamingWorker(
-				getDbAccessor(),
-				memoryCfg.dreaming,
-				AGENTS_DIR,
-				defaultAgentId,
-				{
-					acpxMcp: {
-						daemonUrl: `http://${INTERNAL_SELF_HOST}:${PORT}`,
-						authorizationTokenForAgent: (agentId) =>
-							authSecret
-								? createToken(
-										authSecret,
-										{ sub: `dreaming:${agentId}`, role: "agent", scope: { agent: agentId } },
-										Math.max(900, Math.ceil(memoryCfg.dreaming.timeout / 1000) + 60),
-									)
-								: undefined,
-					},
-					evidenceRetry: {
-						cooldownMs: memoryCfg.pipelineV2.repair.requeueCooldownMs,
-						hourlyBudget: memoryCfg.pipelineV2.repair.requeueHourlyBudget,
-						maxAttempts: 3,
-					},
-					ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,
-				},
-				graphWriteCaps(memoryCfg),
-			);
-			setDreamingWorker(dreamingWorkerHandle);
-		} catch (err) {
-			logger.warn("dreaming", "Failed to start dreaming worker (non-fatal)", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
-	}
-
-	// Embedding migration is bounded background work. Start Dreaming before its
-	// owner maintenance so a slow provider or staging rebuild cannot prevent the
-	// worker from existing at all during startup.
+	// Embedding migration is bounded background work and must not gate the
+	// already-admitted Dreaming worker.
 	if (!pipelinePaused) {
 		try {
 			embeddingIndexMigrationHandle = await startEmbeddingIndexMigration({

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -157,6 +157,7 @@ import {
 import { randomUUID } from "node:crypto";
 import { recordDreamingPassTelemetry } from "./pipeline/dreaming";
 import { dbOwnerTransaction } from "./db-owner-runtime";
+import { startDeferredRuntimeAfterDreaming } from "./dreaming-startup";
 import { type DreamingWorkerHandle, startDreamingWorker } from "./pipeline/dreaming-worker";
 import { retireLegacyExtractionJobsAsync } from "./pipeline/extraction-fallback";
 import { invalidateTraversalCache } from "./pipeline/graph-traversal";
@@ -1803,66 +1804,71 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	// boot before any route is attempted (#1005). Never blocks daemon startup.
 	void router.validateConfigReferences();
 
-	// Admit Dreaming before optional startup work. Legacy-job retirement and
-	// embedding resolution both use the DB-owner queue and can reject the
-	// deferred runtime before the worker would otherwise be created.
-	if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
-		try {
-			dreamingWorkerHandle = startDreamingWorker(
-				getDbAccessor(),
-				memoryCfg.dreaming,
-				AGENTS_DIR,
-				defaultAgentId,
-				{
-					acpxMcp: {
-						daemonUrl: `http://${INTERNAL_SELF_HOST}:${PORT}`,
-						authorizationTokenForAgent: (agentId) =>
-							authSecret
-								? createToken(
-										authSecret,
-										{ sub: `dreaming:${agentId}`, role: "agent", scope: { agent: agentId } },
-										Math.max(900, Math.ceil(memoryCfg.dreaming.timeout / 1000) + 60),
-									)
-								: undefined,
-					},
-					evidenceRetry: {
-						cooldownMs: memoryCfg.pipelineV2.repair.requeueCooldownMs,
-						hourlyBudget: memoryCfg.pipelineV2.repair.requeueHourlyBudget,
-						maxAttempts: 3,
-					},
-					ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,
-				},
-				graphWriteCaps(memoryCfg),
+	const activeEmbeddingCfg = await startDeferredRuntimeAfterDreaming(
+		// Admit Dreaming before optional startup work. Legacy-job retirement and
+		// embedding resolution both use the DB-owner queue and can reject the
+		// deferred runtime before the worker would otherwise be created.
+		() => {
+			if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
+				try {
+					dreamingWorkerHandle = startDreamingWorker(
+						getDbAccessor(),
+						memoryCfg.dreaming,
+						AGENTS_DIR,
+						defaultAgentId,
+						{
+							acpxMcp: {
+								daemonUrl: `http://${INTERNAL_SELF_HOST}:${PORT}`,
+								authorizationTokenForAgent: (agentId) =>
+									authSecret
+										? createToken(
+												authSecret,
+												{ sub: `dreaming:${agentId}`, role: "agent", scope: { agent: agentId } },
+												Math.max(900, Math.ceil(memoryCfg.dreaming.timeout / 1000) + 60),
+											)
+										: undefined,
+							},
+							evidenceRetry: {
+								cooldownMs: memoryCfg.pipelineV2.repair.requeueCooldownMs,
+								hourlyBudget: memoryCfg.pipelineV2.repair.requeueHourlyBudget,
+								maxAttempts: 3,
+							},
+							ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,
+						},
+						graphWriteCaps(memoryCfg),
+					);
+					setDreamingWorker(dreamingWorkerHandle);
+				} catch (err) {
+					logger.warn("dreaming", "Failed to start dreaming worker (non-fatal)", {
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
+			}
+		},
+		async () => {
+			logger.info("dreaming", "Dreaming owns all semantic writes; legacy extraction is retired");
+			// Terminalize every pre-existing legacy `extract` job. The source keeps its
+			// provenance and memory kind, so only already-episodic evidence remains
+			// reachable by the Dreaming cursor; derived rows are never reclassified.
+			// Leased rows are terminalized too because no legacy worker remains. Runs on
+			// cold boot and live-reload config transitions (#913).
+			if (!pipelinePaused) {
+				const deadLettered = await retireLegacyExtractionJobsAsync({
+					reason: "Dreaming cutover: legacy extraction worker not started",
+				});
+				if (deadLettered > 0) {
+					logger.info("dreaming", "Retired legacy extraction jobs", {
+						count: deadLettered,
+					});
+				}
+			}
+
+			return resolveActiveEmbeddingConfigThroughOwner(
+				daemonDbOwner(),
+				memoryCfg.embedding,
+				"startup.resolve-active-embedding",
 			);
-			setDreamingWorker(dreamingWorkerHandle);
-		} catch (err) {
-			logger.warn("dreaming", "Failed to start dreaming worker (non-fatal)", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
-	}
-
-	logger.info("dreaming", "Dreaming owns all semantic writes; legacy extraction is retired");
-	// Terminalize every pre-existing legacy `extract` job. The source keeps its
-	// provenance and memory kind, so only already-episodic evidence remains
-	// reachable by the Dreaming cursor; derived rows are never reclassified.
-	// Leased rows are terminalized too because no legacy worker remains. Runs on
-	// cold boot and live-reload config transitions (#913).
-	if (!pipelinePaused) {
-		const deadLettered = await retireLegacyExtractionJobsAsync({
-			reason: "Dreaming cutover: legacy extraction worker not started",
-		});
-		if (deadLettered > 0) {
-			logger.info("dreaming", "Retired legacy extraction jobs", {
-				count: deadLettered,
-			});
-		}
-	}
-
-	const activeEmbeddingCfg = await resolveActiveEmbeddingConfigThroughOwner(
-		daemonDbOwner(),
-		memoryCfg.embedding,
-		"startup.resolve-active-embedding",
+		},
 	);
 	configureLlmConcurrency(memoryCfg.pipelineV2.worker.maxLlmConcurrency);
 	logger.info("config", "Resolved embedding config", {

--- a/platform/daemon/src/dreaming-startup.test.ts
+++ b/platform/daemon/src/dreaming-startup.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { startDeferredRuntimeAfterDreaming } from "./dreaming-startup";
+
+describe("Dreaming startup admission", () => {
+	it("keeps the worker available when deferred startup rejects", async () => {
+		let workerAvailable = false;
+		const startupFailure = new Error("deferred startup failed");
+
+		const deferredRuntime = startDeferredRuntimeAfterDreaming(
+			() => {
+				workerAvailable = true;
+			},
+			async () => {
+				throw startupFailure;
+			},
+		);
+
+		await expect(deferredRuntime).rejects.toBe(startupFailure);
+		expect(workerAvailable).toBe(true);
+	});
+});

--- a/platform/daemon/src/dreaming-startup.test.ts
+++ b/platform/daemon/src/dreaming-startup.test.ts
@@ -4,6 +4,7 @@ import { startDeferredRuntimeAfterDreaming } from "./dreaming-startup";
 describe("Dreaming startup admission", () => {
 	it("keeps the worker available when deferred startup rejects", async () => {
 		let workerAvailable = false;
+		let deferredSawWorker = false;
 		const startupFailure = new Error("deferred startup failed");
 
 		const deferredRuntime = startDeferredRuntimeAfterDreaming(
@@ -11,11 +12,13 @@ describe("Dreaming startup admission", () => {
 				workerAvailable = true;
 			},
 			async () => {
+				deferredSawWorker = workerAvailable;
 				throw startupFailure;
 			},
 		);
 
 		await expect(deferredRuntime).rejects.toBe(startupFailure);
+		expect(deferredSawWorker).toBe(true);
 		expect(workerAvailable).toBe(true);
 	});
 });

--- a/platform/daemon/src/dreaming-startup.ts
+++ b/platform/daemon/src/dreaming-startup.ts
@@ -1,0 +1,7 @@
+export async function startDeferredRuntimeAfterDreaming<T>(
+	admitDreaming: () => void,
+	startDeferredRuntime: () => Promise<T>,
+): Promise<T> {
+	admitDreaming();
+	return startDeferredRuntime();
+}

--- a/platform/daemon/src/pipeline/dreaming-token-cache.ts
+++ b/platform/daemon/src/pipeline/dreaming-token-cache.ts
@@ -41,6 +41,11 @@ export interface DreamingBacklogTokenBatchResult {
 	readonly entriesCounted: number;
 }
 
+export interface DreamingBacklogTokenMeasurement {
+	readonly generation: number;
+	readonly lifecycleGeneration: number;
+}
+
 function ensureTokenCount(value: number, label: string): number {
 	if (!Number.isSafeInteger(value) || value < 0) {
 		throw new RangeError(`${label} must be a finite non-negative safe integer`);
@@ -79,6 +84,7 @@ export class DreamingBacklogTokenCache {
 	private readonly values = new Map<string, CachedTotal>();
 	private readonly entries = new Map<string, Map<string, CachedTokenEntry>>();
 	private readonly generations = new Map<string, number>();
+	private lifecycleGeneration = 0;
 	private readonly exactInflight = new Map<string, Promise<number>>();
 	private readonly batchInflight = new Map<string, Promise<DreamingBacklogTokenBatchResult>>();
 	private readonly tails = new Map<string, Promise<void>>();
@@ -86,12 +92,12 @@ export class DreamingBacklogTokenCache {
 
 	async replaceExactSnapshot(agentId: string, entries: readonly DreamingBacklogTokenEntry[]): Promise<number> {
 		const key = requestKey("exact", agentId, entries);
-		const generation = this.generationFor(agentId);
+		const measurement = this.beginMeasurement(agentId);
 		return await this.enqueue(
 			agentId,
 			key,
 			this.exactInflight,
-			async () => await this.replaceExactSnapshotNow(agentId, entries, generation),
+			async () => await this.replaceExactSnapshotNow(agentId, entries, measurement),
 		);
 	}
 
@@ -102,20 +108,31 @@ export class DreamingBacklogTokenCache {
 	): Promise<DreamingBacklogTokenBatchResult> {
 		const stopAt = stopAtTokens === undefined ? undefined : ensureTokenCount(stopAtTokens, "Dreaming token stop limit");
 		const key = requestKey("batch", agentId, entries, stopAt);
+		const lifecycleGeneration = this.lifecycleGeneration;
 		return await this.enqueue(
 			agentId,
 			key,
 			this.batchInflight,
-			async () => await this.countEntriesNow(agentId, entries, stopAt),
+			async () => await this.countEntriesNow(agentId, entries, stopAt, lifecycleGeneration),
 		);
 	}
 
-	beginMeasurement(agentId: string): number {
-		return this.generationFor(agentId);
+	beginMeasurement(agentId: string): DreamingBacklogTokenMeasurement {
+		return {
+			generation: this.generationFor(agentId),
+			lifecycleGeneration: this.lifecycleGeneration,
+		};
 	}
 
 	private generationFor(agentId: string): number {
 		return this.generations.get(agentId) ?? 0;
+	}
+
+	private isCurrent(agentId: string, measurement: DreamingBacklogTokenMeasurement): boolean {
+		return (
+			measurement.lifecycleGeneration === this.lifecycleGeneration &&
+			measurement.generation === this.generationFor(agentId)
+		);
 	}
 
 	get(agentId: string): number {
@@ -132,8 +149,8 @@ export class DreamingBacklogTokenCache {
 		return cached.count;
 	}
 
-	recordExactTotal(agentId: string, count: number, generation = this.generationFor(agentId)): void {
-		if (generation !== this.generationFor(agentId)) return;
+	recordExactTotal(agentId: string, count: number, measurement = this.beginMeasurement(agentId)): void {
+		if (!this.isCurrent(agentId, measurement)) return;
 		this.values.set(agentId, {
 			count: ensureTokenCount(count, "Dreaming exact token total"),
 			measuredAtMs: Date.now(),
@@ -146,6 +163,7 @@ export class DreamingBacklogTokenCache {
 	}
 
 	stop(): void {
+		this.lifecycleGeneration += 1;
 		for (const worker of this.workers) void worker.terminate();
 		this.workers.clear();
 		this.exactInflight.clear();
@@ -159,9 +177,10 @@ export class DreamingBacklogTokenCache {
 	private async replaceExactSnapshotNow(
 		agentId: string,
 		entries: readonly DreamingBacklogTokenEntry[],
-		generation: number,
+		measurement: DreamingBacklogTokenMeasurement,
 	): Promise<number> {
-		const result = await this.countEntriesNow(agentId, entries);
+		const result = await this.countEntriesNow(agentId, entries, undefined, measurement.lifecycleGeneration);
+		if (!this.isCurrent(agentId, measurement)) return result.tokens;
 		const nextKeys = new Set(entries.map((entry) => entry.key));
 		const agentEntries = this.entries.get(agentId);
 		if (agentEntries === undefined) {
@@ -170,14 +189,15 @@ export class DreamingBacklogTokenCache {
 		for (const key of agentEntries.keys()) {
 			if (!nextKeys.has(key)) agentEntries.delete(key);
 		}
-		this.recordExactTotal(agentId, result.tokens, generation);
+		this.recordExactTotal(agentId, result.tokens, measurement);
 		return result.tokens;
 	}
 
 	private async countEntriesNow(
 		agentId: string,
 		entries: readonly DreamingBacklogTokenEntry[],
-		stopAtTokens?: number,
+		stopAtTokens: number | undefined,
+		lifecycleGeneration: number,
 	): Promise<DreamingBacklogTokenBatchResult> {
 		const agentEntries = this.entries.get(agentId) ?? new Map<string, CachedTokenEntry>();
 		this.entries.set(agentId, agentEntries);
@@ -208,6 +228,9 @@ export class DreamingBacklogTokenCache {
 			}
 			const segment = entries.slice(index, end);
 			const counts = await this.count(segment, stopAtTokens === undefined ? undefined : stopAtTokens - tokens);
+			if (lifecycleGeneration !== this.lifecycleGeneration) {
+				throw new Error("Dreaming token cache stopped during measurement");
+			}
 			if (counts.length === 0) throw new Error(`Dreaming token worker omitted ${entry.key}`);
 			for (let resultIndex = 0; resultIndex < counts.length; resultIndex += 1) {
 				const candidate = segment[resultIndex];
@@ -265,7 +288,14 @@ export class DreamingBacklogTokenCache {
 		const active = inflight.get(key);
 		if (active !== undefined) return active;
 		const prior = this.tails.get(agentId) ?? Promise.resolve();
-		const promise = prior.then(operation, operation);
+		const lifecycleGeneration = this.lifecycleGeneration;
+		const run = (): Promise<Result> => {
+			if (lifecycleGeneration !== this.lifecycleGeneration) {
+				return Promise.reject(new Error("Dreaming token cache stopped during operation"));
+			}
+			return operation();
+		};
+		const promise = prior.then(run, run);
 		inflight.set(key, promise);
 		const tail = promise.then(
 			() => undefined,
@@ -306,7 +336,7 @@ export function getDreamingEpisodicTokenBacklogCachedOrNull(agentId: string): nu
 	return dreamingBacklogTokenCache.getFresh(agentId);
 }
 
-export function beginDreamingEpisodicTokenBacklogMeasurement(agentId: string): number {
+export function beginDreamingEpisodicTokenBacklogMeasurement(agentId: string): DreamingBacklogTokenMeasurement {
 	return dreamingBacklogTokenCache.beginMeasurement(agentId);
 }
 
@@ -314,6 +344,10 @@ export function invalidateDreamingEpisodicTokenBacklog(agentId: string): void {
 	dreamingBacklogTokenCache.invalidate(agentId);
 }
 /** Record only a complete, measured backlog total in the aggregate cache. */
-export function recordDreamingEpisodicTokenBacklog(agentId: string, count: number, generation?: number): void {
-	dreamingBacklogTokenCache.recordExactTotal(agentId, count, generation);
+export function recordDreamingEpisodicTokenBacklog(
+	agentId: string,
+	count: number,
+	measurement?: DreamingBacklogTokenMeasurement,
+): void {
+	dreamingBacklogTokenCache.recordExactTotal(agentId, count, measurement);
 }

--- a/platform/daemon/src/pipeline/dreaming-token-cache.ts
+++ b/platform/daemon/src/pipeline/dreaming-token-cache.ts
@@ -18,6 +18,11 @@ interface CachedTokenEntry {
 	readonly count: number;
 }
 
+interface CachedTotal {
+	readonly count: number;
+	readonly measuredAtMs: number;
+}
+
 interface CountResponse {
 	readonly type: "counted";
 	readonly requestId: number;
@@ -58,6 +63,12 @@ function requestKey(
 }
 
 /**
+ * Status is intentionally non-blocking, so a completed exact measurement is
+ * usable for a short window but must not become an unbounded stale claim.
+ */
+const DREAMING_BACKLOG_CACHE_MAX_AGE_MS = 60_000;
+
+/**
  * Memoized exact backlog counts. The cache key includes the source and its
  * delivered offset, while the source revision catches in-place updates without
  * retaining the complete evidence text. Entries are nested by agent ID, so an
@@ -66,8 +77,9 @@ function requestKey(
  * the aggregate value and remove entries absent from their complete snapshot.
  */
 export class DreamingBacklogTokenCache {
-	private readonly values = new Map<string, number>();
+	private readonly values = new Map<string, CachedTotal>();
 	private readonly entries = new Map<string, Map<string, CachedTokenEntry>>();
+	private readonly generations = new Map<string, number>();
 	private readonly exactInflight = new Map<string, Promise<number>>();
 	private readonly batchInflight = new Map<string, Promise<DreamingBacklogTokenBatchResult>>();
 	private readonly tails = new Map<string, Promise<void>>();
@@ -75,11 +87,12 @@ export class DreamingBacklogTokenCache {
 
 	async replaceExactSnapshot(agentId: string, entries: readonly DreamingBacklogTokenEntry[]): Promise<number> {
 		const key = requestKey("exact", agentId, entries);
+		const generation = this.generationFor(agentId);
 		return await this.enqueue(
 			agentId,
 			key,
 			this.exactInflight,
-			async () => await this.replaceExactSnapshotNow(agentId, entries),
+			async () => await this.replaceExactSnapshotNow(agentId, entries, generation),
 		);
 	}
 
@@ -98,16 +111,43 @@ export class DreamingBacklogTokenCache {
 		);
 	}
 
-	get(agentId: string): number {
-		return this.values.get(agentId) ?? 0;
+	beginMeasurement(agentId: string): number {
+		return this.generationFor(agentId);
 	}
 
-	recordExactTotal(agentId: string, count: number): void {
-		this.values.set(agentId, ensureTokenCount(count, "Dreaming exact token total"));
+	private generationFor(agentId: string): number {
+		return this.generations.get(agentId) ?? 0;
+	}
+
+	get(agentId: string): number {
+		return this.getFresh(agentId) ?? 0;
+	}
+
+	getFresh(agentId: string): number | null {
+		const cached = this.values.get(agentId);
+		if (cached === undefined) return null;
+		if (Date.now() - cached.measuredAtMs > DREAMING_BACKLOG_CACHE_MAX_AGE_MS) {
+			this.values.delete(agentId);
+			return null;
+		}
+		return cached.count;
+	}
+
+	recordExactTotal(agentId: string, count: number, generation = this.generationFor(agentId)): void {
+		if (generation !== this.generationFor(agentId)) return;
+		this.values.set(agentId, {
+			count: ensureTokenCount(count, "Dreaming exact token total"),
+			measuredAtMs: Date.now(),
+		});
 	}
 
 	hasValue(agentId: string): boolean {
-		return this.values.has(agentId);
+		return this.getFresh(agentId) !== null;
+	}
+
+	invalidate(agentId: string): void {
+		this.values.delete(agentId);
+		this.generations.set(agentId, this.generationFor(agentId) + 1);
 	}
 
 	stop(): void {
@@ -116,11 +156,15 @@ export class DreamingBacklogTokenCache {
 		this.exactInflight.clear();
 		this.batchInflight.clear();
 		this.tails.clear();
+		this.values.clear();
+		this.entries.clear();
+		this.generations.clear();
 	}
 
 	private async replaceExactSnapshotNow(
 		agentId: string,
 		entries: readonly DreamingBacklogTokenEntry[],
+		generation: number,
 	): Promise<number> {
 		const result = await this.countEntriesNow(agentId, entries);
 		const nextKeys = new Set(entries.map((entry) => entry.key));
@@ -131,7 +175,7 @@ export class DreamingBacklogTokenCache {
 		for (const key of agentEntries.keys()) {
 			if (!nextKeys.has(key)) agentEntries.delete(key);
 		}
-		this.values.set(agentId, result.tokens);
+		this.recordExactTotal(agentId, result.tokens, generation);
 		return result.tokens;
 	}
 
@@ -259,11 +303,26 @@ export function countDreamingBacklogTokenEntries(
 	return dreamingBacklogTokenCache.countEntries(agentId, entries, stopAtTokens);
 }
 
+export function hasDreamingEpisodicTokenBacklogCached(agentId: string): boolean {
+	return dreamingBacklogTokenCache.hasValue(agentId);
+}
+
 export function getDreamingEpisodicTokenBacklogCached(agentId: string): number {
 	return dreamingBacklogTokenCache.get(agentId);
 }
 
+export function getDreamingEpisodicTokenBacklogCachedOrNull(agentId: string): number | null {
+	return dreamingBacklogTokenCache.getFresh(agentId);
+}
+
+export function beginDreamingEpisodicTokenBacklogMeasurement(agentId: string): number {
+	return dreamingBacklogTokenCache.beginMeasurement(agentId);
+}
+
+export function invalidateDreamingEpisodicTokenBacklog(agentId: string): void {
+	dreamingBacklogTokenCache.invalidate(agentId);
+}
 /** Record only a complete, measured backlog total in the aggregate cache. */
-export function recordDreamingEpisodicTokenBacklog(agentId: string, count: number): void {
-	dreamingBacklogTokenCache.recordExactTotal(agentId, count);
+export function recordDreamingEpisodicTokenBacklog(agentId: string, count: number, generation?: number): void {
+	dreamingBacklogTokenCache.recordExactTotal(agentId, count, generation);
 }

--- a/platform/daemon/src/pipeline/dreaming-token-cache.ts
+++ b/platform/daemon/src/pipeline/dreaming-token-cache.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import { resolveEmbeddedWorkerPath } from "../native-runtime-assets";
@@ -139,10 +138,6 @@ export class DreamingBacklogTokenCache {
 			count: ensureTokenCount(count, "Dreaming exact token total"),
 			measuredAtMs: Date.now(),
 		});
-	}
-
-	hasValue(agentId: string): boolean {
-		return this.getFresh(agentId) !== null;
 	}
 
 	invalidate(agentId: string): void {
@@ -301,10 +296,6 @@ export function countDreamingBacklogTokenEntries(
 	stopAtTokens?: number,
 ): Promise<DreamingBacklogTokenBatchResult> {
 	return dreamingBacklogTokenCache.countEntries(agentId, entries, stopAtTokens);
-}
-
-export function hasDreamingEpisodicTokenBacklogCached(agentId: string): boolean {
-	return dreamingBacklogTokenCache.hasValue(agentId);
 }
 
 export function getDreamingEpisodicTokenBacklogCached(agentId: string): number {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -51,7 +51,13 @@ import {
 } from "./dreaming-evidence-retry";
 import { readDreamingRunbook } from "./dreaming-runbook";
 import { requestDreamingReviewedEvidenceRequeue } from "./dreaming-evidence-reviews";
-import { getDreamingEpisodicTokenBacklogCached } from "./dreaming-token-cache";
+import {
+	beginDreamingEpisodicTokenBacklogMeasurement,
+	getDreamingEpisodicTokenBacklogCached,
+	hasDreamingEpisodicTokenBacklogCached,
+	invalidateDreamingEpisodicTokenBacklog,
+	recordDreamingEpisodicTokenBacklog,
+} from "./dreaming-token-cache";
 
 const AGENT = "default";
 
@@ -1303,6 +1309,26 @@ describe("Dreaming", () => {
 
 		expect(probe.kind).toBe("indeterminate");
 		expect(getDreamingEpisodicTokenBacklogCached(agentId)).toBe(exact);
+	});
+
+	it("hides an exact aggregate after its source window is invalidated", async () => {
+		const agentId = "invalidated-cache";
+		seedArtifact(
+			db,
+			`imports/${agentId}.md`,
+			"the invalidated cached source",
+			`${agentId}-source`,
+			"2026-08-01T00:00:00.000Z",
+			agentId,
+		);
+		await getDreamingEpisodicTokenBacklogInDb(db as unknown as ReadDb, agentId);
+		expect(hasDreamingEpisodicTokenBacklogCached(agentId)).toBe(true);
+
+		const staleGeneration = beginDreamingEpisodicTokenBacklogMeasurement(agentId);
+		invalidateDreamingEpisodicTokenBacklog(agentId);
+		recordDreamingEpisodicTokenBacklog(agentId, 123, staleGeneration);
+
+		expect(hasDreamingEpisodicTokenBacklogCached(agentId)).toBe(false);
 	});
 
 	it("keeps owner-routed and inline probe semantics equivalent", async () => {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -53,6 +53,7 @@ import { readDreamingRunbook } from "./dreaming-runbook";
 import { requestDreamingReviewedEvidenceRequeue } from "./dreaming-evidence-reviews";
 import {
 	beginDreamingEpisodicTokenBacklogMeasurement,
+	DreamingBacklogTokenCache,
 	getDreamingEpisodicTokenBacklogCached,
 	getDreamingEpisodicTokenBacklogCachedOrNull,
 	invalidateDreamingEpisodicTokenBacklog,
@@ -1329,6 +1330,41 @@ describe("Dreaming", () => {
 		recordDreamingEpisodicTokenBacklog(agentId, 123, staleGeneration);
 
 		expect(getDreamingEpisodicTokenBacklogCachedOrNull(agentId)).toBeNull();
+	});
+
+	it("does not repopulate after cache stop", async () => {
+		const cache = new DreamingBacklogTokenCache();
+		const refresh = cache.replaceExactSnapshot("stopped-cache", []);
+		cache.stop();
+
+		await expect(refresh).rejects.toThrow("stopped");
+		expect(cache.getFresh("stopped-cache")).toBeNull();
+	});
+
+	it("does not record a measurement captured before cache stop", () => {
+		const cache = new DreamingBacklogTokenCache();
+		const measurement = cache.beginMeasurement("stopped-measurement-cache");
+		cache.stop();
+		cache.recordExactTotal("stopped-measurement-cache", 1, measurement);
+
+		expect(cache.getFresh("stopped-measurement-cache")).toBeNull();
+	});
+
+	it("does not publish an in-flight snapshot after cache stop", async () => {
+		const cache = new DreamingBacklogTokenCache();
+		Object.defineProperty(cache, "count", {
+			value: async () => {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+				return [{ key: "source", count: 1 }];
+			},
+		});
+		const refresh = cache.replaceExactSnapshot("stopped-inflight-cache", [
+			{ key: "source", revision: "v1", text: "pending" },
+		]);
+		queueMicrotask(() => cache.stop());
+
+		await expect(refresh).rejects.toThrow("stopped during measurement");
+		expect(cache.getFresh("stopped-inflight-cache")).toBeNull();
 	});
 
 	it("keeps owner-routed and inline probe semantics equivalent", async () => {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -54,7 +54,7 @@ import { requestDreamingReviewedEvidenceRequeue } from "./dreaming-evidence-revi
 import {
 	beginDreamingEpisodicTokenBacklogMeasurement,
 	getDreamingEpisodicTokenBacklogCached,
-	hasDreamingEpisodicTokenBacklogCached,
+	getDreamingEpisodicTokenBacklogCachedOrNull,
 	invalidateDreamingEpisodicTokenBacklog,
 	recordDreamingEpisodicTokenBacklog,
 } from "./dreaming-token-cache";
@@ -1322,13 +1322,13 @@ describe("Dreaming", () => {
 			agentId,
 		);
 		await getDreamingEpisodicTokenBacklogInDb(db as unknown as ReadDb, agentId);
-		expect(hasDreamingEpisodicTokenBacklogCached(agentId)).toBe(true);
+		expect(getDreamingEpisodicTokenBacklogCachedOrNull(agentId)).not.toBeNull();
 
 		const staleGeneration = beginDreamingEpisodicTokenBacklogMeasurement(agentId);
 		invalidateDreamingEpisodicTokenBacklog(agentId);
 		recordDreamingEpisodicTokenBacklog(agentId, 123, staleGeneration);
 
-		expect(hasDreamingEpisodicTokenBacklogCached(agentId)).toBe(false);
+		expect(getDreamingEpisodicTokenBacklogCachedOrNull(agentId)).toBeNull();
 	});
 
 	it("keeps owner-routed and inline probe semantics equivalent", async () => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -84,6 +84,8 @@ import {
 import {
 	type DreamingBacklogTokenEntry,
 	countDreamingBacklogTokenEntries,
+	beginDreamingEpisodicTokenBacklogMeasurement,
+	invalidateDreamingEpisodicTokenBacklog,
 	recordDreamingEpisodicTokenBacklog,
 	refreshDreamingBacklogTokenCache,
 } from "./dreaming-token-cache";
@@ -1638,6 +1640,9 @@ export async function runDreamingAgentPass(
 	liveOptions?: DreamingPassLiveOptions,
 	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
+	// Any pass may consume or create episodic evidence. Do not present the
+	// previous exact aggregate while the pass is mutating its source window.
+	for (const scope of scopes) invalidateDreamingEpisodicTokenBacklog(scope);
 	const passId =
 		existingPassId ??
 		(await (ownerMaintenance
@@ -2421,6 +2426,7 @@ export async function getDreamingEpisodicTokenBacklog(
 	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<number> {
 	const input: DbOwnerDreamingEpisodicBacklog = { agentId };
+	const measurementGeneration = beginDreamingEpisodicTokenBacklogMeasurement(agentId);
 	const options = { deadlineMs: 60_000, estimatedWorkUnits: DB_OWNER_MAX_WORK_UNITS };
 	const count = ownerMaintenance
 		? await ownerMaintenance.dreamingEpisodicBacklog(input, options)
@@ -2428,7 +2434,7 @@ export async function getDreamingEpisodicTokenBacklog(
 				runWithOwner: async (owner) => await ownerDreamingEpisodicBacklog(owner, input, options),
 				runInline: ({ read }) => read((db) => getDreamingEpisodicTokenBacklogInDb(db, input.agentId)),
 			});
-	recordDreamingEpisodicTokenBacklog(agentId, count);
+	recordDreamingEpisodicTokenBacklog(agentId, count, measurementGeneration);
 	return count;
 }
 
@@ -2438,6 +2444,7 @@ export async function probeDreamingEpisodicBacklog(
 	tokenThreshold: number,
 	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<DreamingEpisodicBacklogProbe> {
+	const measurementGeneration = beginDreamingEpisodicTokenBacklogMeasurement(agentId);
 	const input: DbOwnerDreamingEpisodicBacklogProbe = {
 		agentId,
 		tokenThreshold: ensureDreamingTokenThreshold(tokenThreshold),
@@ -2451,7 +2458,8 @@ export async function probeDreamingEpisodicBacklog(
 				runInline: ({ read }) =>
 					read((db) => probeDreamingEpisodicBacklogInDb(db, input.agentId, input.tokenThreshold, input.maxSources)),
 			});
-	if (result.kind === "exact") recordDreamingEpisodicTokenBacklog(agentId, result.tokens);
+	if (result.kind === "exact") recordDreamingEpisodicTokenBacklog(agentId, result.tokens, measurementGeneration);
+	else invalidateDreamingEpisodicTokenBacklog(agentId);
 	return result;
 }
 

--- a/platform/daemon/src/routes/pipeline-routes-dreaming-live.test.ts
+++ b/platform/daemon/src/routes/pipeline-routes-dreaming-live.test.ts
@@ -5,6 +5,10 @@ import { join } from "node:path";
 import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { dreamingLiveEvents, publishDreamingAgentEvent } from "../pipeline/dreaming-live-events";
+import {
+	invalidateDreamingEpisodicTokenBacklog,
+	recordDreamingEpisodicTokenBacklog,
+} from "../pipeline/dreaming-token-cache";
 import { registerPipelineRoutes } from "./pipeline-routes";
 
 const originalAgentId = process.env.SIGNET_AGENT_ID;
@@ -54,11 +58,31 @@ describe("Dreaming live routes", () => {
 		expect(crossAgentResponse.status).toBe(404);
 	});
 
+	it("reads the cached backlog in the status response", async () => {
+		recordDreamingEpisodicTokenBacklog("agent-a", 12345);
+		const app = new Hono();
+		registerPipelineRoutes(app);
+
+		const response = await app.request("/api/dream/status");
+		expect(response.status).toBe(200);
+		expect((await response.json()).episodicTokensPending).toBe(12345);
+		recordDreamingEpisodicTokenBacklog("agent-a", 0);
+	});
+
+	it("returns null when no fresh exact backlog measurement exists", async () => {
+		invalidateDreamingEpisodicTokenBacklog("agent-a");
+		const app = new Hono();
+		registerPipelineRoutes(app);
+
+		const response = await app.request("/api/dream/status");
+		expect(response.status).toBe(200);
+		expect((await response.json()).episodicTokensPending).toBeNull();
+	});
+
 	it("emits an initial snapshot over the scoped SSE stream", async () => {
 		const app = new Hono();
 		registerPipelineRoutes(app);
 		const response = await app.request("/api/dream/passes/live-pass-a/events");
-		expect(response.status).toBe(200);
 		expect(response.headers.get("content-type")).toContain("text/event-stream");
 		const reader = response.body?.getReader();
 		if (!reader) throw new Error("SSE response did not expose a body");

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -19,7 +19,6 @@ import { graphWriteCaps, loadMemoryConfig } from "../memory-config.js";
 import { listMemoryContentSafety, parseMemorySafetyReasons } from "../memory-content-safety.js";
 import {
 	getDreamingAttention,
-	getDreamingEpisodicTokenBacklog,
 	getDreamingEvidenceExclusions,
 	getDreamingReviewedEvidence,
 	getDreamingPasses,
@@ -40,6 +39,7 @@ import {
 	type DreamingLiveEvent,
 } from "../pipeline/dreaming-live-events";
 import { getFeedbackTelemetry } from "../pipeline/aspect-feedback.js";
+import { getDreamingEpisodicTokenBacklogCachedOrNull } from "../pipeline/dreaming-token-cache";
 import { getDreamingCapability, getDreamingCapabilityManifest } from "../pipeline/dreaming-capabilities.js";
 import { DREAMING_MAX_OPERATIONS_PER_REQUEST, applyDreamingOperations } from "../pipeline/dreaming-operations.js";
 import { AlreadyRunningError } from "../pipeline/dreaming-worker.js";
@@ -755,7 +755,7 @@ export function registerPipelineRoutes(app: Hono): void {
 		const agentId = scopedAgent.agentId;
 
 		const state = await getDreamingState(accessor, agentId);
-		const episodicTokensPending = await getDreamingEpisodicTokenBacklog(accessor, agentId);
+		const episodicTokensPending = getDreamingEpisodicTokenBacklogCachedOrNull(agentId);
 		const passes = await getDreamingPasses(accessor, agentId, 10);
 		const exclusions = await getDreamingEvidenceExclusions(accessor, agentId);
 		const reviewedEvidence = await getDreamingReviewedEvidence(accessor, agentId);

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -431,70 +431,70 @@
     },
     {
       "path": "daemon.ts",
-      "line": 2164,
+      "line": 2179,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2166,
+      "line": 2181,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2335,
+      "line": 2350,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2336,
+      "line": 2351,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2337,
+      "line": 2352,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2508,
+      "line": 2522,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2583,
+      "line": 2597,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3356,
+      "line": 3370,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3357,
+      "line": 3371,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3360,
+      "line": 3374,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -2610,7 +2610,7 @@
     },
     {
       "path": "pipeline/dreaming-token-cache.ts",
-      "line": 35,
+      "line": 34,
       "api": "existsSync",
       "source": "return existsSync(bundled)",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -333,168 +333,168 @@
     },
     {
       "path": "daemon.ts",
-      "line": 624,
+      "line": 625,
       "api": "existsSync",
       "source": "if (!existsSync(agentsMdPath)) return;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 641,
+      "line": 642,
       "api": "existsSync",
       "source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 669,
+      "line": 670,
       "api": "existsSync",
       "source": "if (!existsSync(identityPath)) return \"\";",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 699,
+      "line": 700,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 731,
+      "line": 732,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 738,
+      "line": 739,
       "api": "existsSync",
       "source": "if (existsSync(geminiDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 743,
+      "line": 744,
       "api": "existsSync",
       "source": "if (existsSync(settingsPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 744,
+      "line": 745,
       "api": "readFileSync",
       "source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 764,
+      "line": 765,
       "api": "existsSync",
       "source": "if (!existsSync(targetPath)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1329,
+      "line": 1330,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1697,
+      "line": 1698,
       "api": "existsSync",
       "source": "if (!existsSync(p)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1699,
+      "line": 1700,
       "api": "readFileSync",
       "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1743,
+      "line": 1744,
       "api": "existsSync",
       "source": "if (!existsSync(path)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1745,
+      "line": 1746,
       "api": "readFileSync",
       "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2158,
+      "line": 2164,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2160,
+      "line": 2166,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2329,
+      "line": 2335,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2330,
+      "line": 2336,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2331,
+      "line": 2337,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2502,
+      "line": 2508,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2577,
+      "line": 2583,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3350,
+      "line": 3356,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3351,
+      "line": 3357,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3354,
+      "line": 3360,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -431,70 +431,70 @@
     },
     {
       "path": "daemon.ts",
-      "line": 2179,
+      "line": 2173,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2181,
+      "line": 2175,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2350,
+      "line": 2344,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2351,
+      "line": 2345,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2352,
+      "line": 2346,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2522,
+      "line": 2516,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2597,
+      "line": 2591,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3370,
+      "line": 3364,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3371,
+      "line": 3365,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3374,
+      "line": 3368,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -431,70 +431,70 @@
     },
     {
       "path": "daemon.ts",
-      "line": 2156,
+      "line": 2158,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2158,
+      "line": 2160,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2327,
+      "line": 2329,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2328,
+      "line": 2330,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2329,
+      "line": 2331,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2500,
+      "line": 2502,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2575,
+      "line": 2577,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3348,
+      "line": 3350,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3349,
+      "line": 3351,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3352,
+      "line": 3354,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"
@@ -2610,7 +2610,7 @@
     },
     {
       "path": "pipeline/dreaming-token-cache.ts",
-      "line": 30,
+      "line": 35,
       "api": "existsSync",
       "source": "return existsSync(bundled)",
       "category": "hot-path"
@@ -2645,14 +2645,14 @@
     },
     {
       "path": "pipeline/dreaming.ts",
-      "line": 921,
+      "line": 923,
       "api": "existsSync",
       "source": "if (!existsSync(path)) return { content: \"\", unreadable: false };",
       "category": "hot-path"
     },
     {
       "path": "pipeline/dreaming.ts",
-      "line": 923,
+      "line": 925,
       "api": "readFileSync",
       "source": "const raw = readFileSync(path, \"utf-8\").trim();",
       "category": "hot-path"

--- a/surfaces/cli/src/commands/dream.test.ts
+++ b/surfaces/cli/src/commands/dream.test.ts
@@ -72,7 +72,7 @@ interface StatusPayload {
 		lastPassId: string | null;
 		lastPassMode: string | null;
 	};
-	episodicTokensPending: number;
+	episodicTokensPending: number | null;
 	config: { tokenThreshold: number; backfillOnFirstRun: boolean };
 	passes: Array<{
 		id: string;
@@ -222,6 +222,21 @@ describe("Dreaming capability CLI binding", () => {
 });
 
 describe("dream status failure labeling", () => {
+	it("labels an unmeasured episodic backlog instead of printing null", async () => {
+		const fetchDaemonResult = mockFetch(async () => okResult({ ...makeStatus([]), episodicTokensPending: null }));
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		try {
+			await program.parseAsync(["node", "test", "dream", "status"]);
+			const output = capture.lines.join("\n");
+			expect(output).toContain("unmeasured / 10000 episodic tokens");
+			expect(output).not.toContain("null / 10000");
+		} finally {
+			capture.restore();
+		}
+	});
+
 	it("names an unresponsive daemon instead of asking whether it is running", async () => {
 		const fetchDaemonResult = mockFetch(async () => ({ ok: false, reason: "timeout" }));
 		const program = new Command();

--- a/surfaces/cli/src/commands/dream.ts
+++ b/surfaces/cli/src/commands/dream.ts
@@ -52,7 +52,7 @@ interface DreamPass {
 interface DreamStatus {
 	readonly worker: { readonly running: boolean; readonly active: boolean };
 	readonly state: DreamState;
-	readonly episodicTokensPending: number;
+	readonly episodicTokensPending: number | null;
 	readonly config: {
 		readonly tokenThreshold: number;
 		readonly backfillOnFirstRun: boolean;
@@ -225,9 +225,11 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 				: chalk.dim("stopped");
 
 			console.log(`  ${chalk.dim("Worker:")}     ${worker}`);
-			console.log(
-				`  ${chalk.dim("Threshold:")}  ${data.episodicTokensPending} / ${data.config.tokenThreshold} episodic tokens`,
-			);
+			const threshold =
+				data.episodicTokensPending === null
+					? `${chalk.dim("unmeasured")} / ${data.config.tokenThreshold}`
+					: `${data.episodicTokensPending} / ${data.config.tokenThreshold}`;
+			console.log(`  ${chalk.dim("Threshold:")}  ${threshold} episodic tokens`);
 
 			if (data.state.lastPassAt) {
 				console.log(`  ${chalk.dim("Last pass:")}  ${data.state.lastPassAt} (${data.state.lastPassMode})`);

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -118,27 +118,37 @@ function removeRetiredPipelineSettings(pipeline: Record<string, unknown>): Recor
 	return cleaned;
 }
 
+function mergeDreamingMemory(
+	existingMemory: Record<string, unknown>,
+	basePipeline: unknown,
+	overridePipeline: unknown,
+): Record<string, unknown> {
+	const base = readRecord(basePipeline);
+	const override = readRecord(overridePipeline);
+	return {
+		...existingMemory,
+		dreaming: { ...readRecord(existingMemory.dreaming), enabled: true },
+		pipelineV2: {
+			...base,
+			...override,
+			enabled: true,
+			graph: { ...readRecord(base.graph), ...readRecord(override.graph) },
+			reranker: { ...readRecord(base.reranker), ...readRecord(override.reranker) },
+			autonomous: {
+				...readRecord(base.autonomous),
+				...readRecord(override.autonomous),
+			},
+		},
+	};
+}
+
 export function enableDreamingInConfig(existingConfig: Record<string, unknown>): Record<string, unknown> {
 	const existingMemory = readRecord(existingConfig.memory);
 	const existingPipeline = removeRetiredPipelineSettings(readRecord(existingMemory.pipelineV2));
 	const pipelineDefaults = buildSetupPipeline("none", true);
 	return {
 		...existingConfig,
-		memory: {
-			...existingMemory,
-			dreaming: { ...readRecord(existingMemory.dreaming), enabled: true },
-			pipelineV2: {
-				...pipelineDefaults,
-				...existingPipeline,
-				enabled: true,
-				graph: { ...readRecord(pipelineDefaults.graph), ...readRecord(existingPipeline.graph) },
-				reranker: { ...readRecord(pipelineDefaults.reranker), ...readRecord(existingPipeline.reranker) },
-				autonomous: {
-					...readRecord(pipelineDefaults.autonomous),
-					...readRecord(existingPipeline.autonomous),
-				},
-			},
-		},
+		memory: mergeDreamingMemory(existingMemory, pipelineDefaults, existingPipeline),
 	};
 }
 
@@ -374,20 +384,7 @@ export async function runExistingSetupWizard(
 				Reflect.deleteProperty(existingMemory, "synthesis");
 				const existingPipeline = removeRetiredPipelineSettings(readRecord(existingMemory.pipelineV2));
 				const pipelineDefaults = buildSetupPipeline(options?.extractionProvider ?? "none", true);
-				updatedConfig.memory = {
-					...existingMemory,
-					dreaming: { ...readRecord(existingMemory.dreaming), enabled: true },
-					pipelineV2: {
-						...existingPipeline,
-						...pipelineDefaults,
-						graph: { ...readRecord(existingPipeline.graph), ...readRecord(pipelineDefaults.graph) },
-						reranker: { ...readRecord(existingPipeline.reranker), ...readRecord(pipelineDefaults.reranker) },
-						autonomous: {
-							...readRecord(existingPipeline.autonomous),
-							...readRecord(pipelineDefaults.autonomous),
-						},
-					},
-				};
+				updatedConfig.memory = mergeDreamingMemory(existingMemory, existingPipeline, pipelineDefaults);
 			} else {
 				const existingMemory = { ...readRecord(existingConfig.memory) };
 				Reflect.deleteProperty(existingMemory, "synthesis");

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -118,6 +118,30 @@ function removeRetiredPipelineSettings(pipeline: Record<string, unknown>): Recor
 	return cleaned;
 }
 
+export function enableDreamingInConfig(existingConfig: Record<string, unknown>): Record<string, unknown> {
+	const existingMemory = readRecord(existingConfig.memory);
+	const existingPipeline = removeRetiredPipelineSettings(readRecord(existingMemory.pipelineV2));
+	const pipelineDefaults = buildSetupPipeline("none", true);
+	return {
+		...existingConfig,
+		memory: {
+			...existingMemory,
+			dreaming: { ...readRecord(existingMemory.dreaming), enabled: true },
+			pipelineV2: {
+				...pipelineDefaults,
+				...existingPipeline,
+				enabled: true,
+				graph: { ...readRecord(pipelineDefaults.graph), ...readRecord(existingPipeline.graph) },
+				reranker: { ...readRecord(pipelineDefaults.reranker), ...readRecord(existingPipeline.reranker) },
+				autonomous: {
+					...readRecord(pipelineDefaults.autonomous),
+					...readRecord(existingPipeline.autonomous),
+				},
+			},
+		},
+	};
+}
+
 export function detectedHarnessesForExistingSetup(
 	detection: SetupDetection,
 	configuredHarnessList: readonly string[],

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SIGNET_SECRETS_PLUGIN_ID, readGraphiqState, updateGraphiqActiveProject } from "@signet/core";
+import { SIGNET_SECRETS_PLUGIN_ID, parseSimpleYaml, readGraphiqState, updateGraphiqActiveProject } from "@signet/core";
 import { detectExistingSetup, type SetupDetection } from "../lib/setup-detection.js";
 import * as openUrl from "../lib/open-url.js";
 import { detectedHarnessesForExistingSetup, runExistingSetupWizard } from "./setup-migrate.js";
@@ -218,6 +218,61 @@ describe("setupWizard non-interactive harness hooks", () => {
 		await setupWizard({ nonInteractive: true }, deps);
 
 		expect(configureHarnessHooks).not.toHaveBeenCalled();
+	});
+
+	it("enables Dreaming on an existing installation when requested", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-existing-dreaming-"));
+		const basePath = join(root, "agents");
+		mkdirSync(basePath, { recursive: true });
+		writeFileSync(
+			join(basePath, "agent.yaml"),
+			`version: 1
+memory:
+  pipelineV2:
+    enabled: false
+    semanticContradictionEnabled: false
+    custom: keep
+    graph:
+      enabled: false
+    reranker:
+      enabled: false
+    autonomous:
+      enabled: false
+      allowUpdateDelete: false
+  dreaming:
+    backfillOnFirstRun: true
+`,
+		);
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => ({ ...fakeDetection(basePath), agentYaml: true })),
+		});
+
+		await setupWizard(
+			{
+				nonInteractive: true,
+				enableDreaming: true,
+				skipGit: true,
+				allowUnprotectedWorkspace: true,
+			},
+			deps,
+		);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		const config = parseSimpleYaml(agentYaml);
+		const memory = config.memory as Record<string, unknown>;
+		const dreaming = memory.dreaming as Record<string, unknown>;
+		const pipeline = memory.pipelineV2 as Record<string, unknown>;
+		expect(dreaming.enabled).toBe(true);
+		expect(dreaming.backfillOnFirstRun).toBe(true);
+		expect(pipeline.enabled).toBe(true);
+		expect(pipeline.semanticContradictionEnabled).toBe(false);
+		expect(pipeline.custom).toBe("keep");
+		expect((pipeline.graph as Record<string, unknown>).enabled).toBe(false);
+		expect((pipeline.reranker as Record<string, unknown>).enabled).toBe(false);
+		expect((pipeline.autonomous as Record<string, unknown>).enabled).toBe(false);
+		expect((pipeline.autonomous as Record<string, unknown>).allowUpdateDelete).toBe(false);
 	});
 
 	it("writes OpenAI-compatible endpoint during non-interactive setup", async () => {

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -24,7 +24,7 @@ import { openUrlWithFallback } from "../lib/open-url.js";
 import { installGraphiqPlugin } from "./graphiq.js";
 import { runFreshSetup } from "./setup-fresh.js";
 import { aggregateRecallProviderIds } from "./setup-inference-connect.js";
-import { runExistingSetupWizard } from "./setup-migrate.js";
+import { enableDreamingInConfig, runExistingSetupWizard } from "./setup-migrate.js";
 import { defaultAcpxModel, defaultExtractionModel } from "./setup-pipeline.js";
 import { isBareDaemonOrigin, parseSetupPlan, setupPlanJsonSchema } from "./setup-plan.js";
 import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
@@ -510,9 +510,10 @@ async function applySetupOptions(options: SetupWizardOptions, deps: SetupDeps): 
 		const signetSecretsEnabled = await resolveSignetSecretsCorePluginSelection(basePath, options);
 		const graphiqEnabled = await resolveGraphiqPluginSelection(basePath, options);
 		if (existing.agentYaml) {
+			const configToWrite = options.enableDreaming === true ? enableDreamingInConfig(existingConfig) : existingConfig;
 			writeCapabilitySelection(
 				basePath,
-				existingConfig,
+				configToWrite,
 				configuredIdentityMode ?? existingSetupIdentityMode,
 				signetSecretsEnabled,
 			);

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -644,7 +644,7 @@ export interface DreamStatus {
 		lastPassId: string | null;
 		lastPassMode: string | null;
 	};
-	episodicTokensPending: number;
+	episodicTokensPending: number | null;
 	config: {
 		tokenThreshold: number;
 		backfillOnFirstRun: boolean;

--- a/web/docs/src/content/docs/api/knowledge-ontology.md
+++ b/web/docs/src/content/docs/api/knowledge-ontology.md
@@ -513,6 +513,12 @@ episodic evidence. Requires `admin` permission.
 }
 ```
 
+The `episodicTokensPending` field is a number only when a recent exact
+backlog measurement is available for the resolved agent. It is `null` when the
+backlog has not been measured, the cached measurement was invalidated, or the
+measurement expired. The status endpoint does not perform an unbounded token
+scan to populate this field.
+
 The status response also includes `reviewedEvidence`, containing immutable
 source revisions that a completed pass fully inspected and intentionally found
 to contain no durable fact. These rows are excluded from scan-first backlog

--- a/web/docs/src/content/docs/cli/getting-started.md
+++ b/web/docs/src/content/docs/cli/getting-started.md
@@ -103,7 +103,7 @@ Current setup accepts `claude-code`, `codex`, `kimi`, `opencode`, `forge`, `open
 | `--extraction-endpoint <url>` | Endpoint for `openai-compatible` extraction. |
 | `--aggregate-recall-provider`, `--aggregate-recall-model`, `--aggregate-recall-endpoint` | Configure a distinct provider for aggregate recall. |
 | `--search-balance <alpha>` | Semantic/keyword balance from `0` through `1`. |
-| `--enable-dreaming` | Enable background memory consolidation. |
+| `--enable-dreaming` | Enable background memory consolidation. On an existing workspace, this updates the Dreaming and pipeline settings in `agent.yaml` while preserving unrelated configuration. |
 
 When an explicitly selected Ollama service or model is unavailable during non-interactive setup, Signet keeps Ollama selected and reports the problem; it does not silently switch to native embeddings. Setup continues with embeddings unavailable until Ollama is ready; use `signet doctor` to check readiness.
 


### PR DESCRIPTION
## Summary

Fixes the case where the daemon HTTP server is reachable but the Dreaming worker is unavailable. Existing installations now apply `--enable-dreaming`, and deferred startup establishes owner maintenance before admitting Dreaming, then keeps the worker ahead of optional DB-owner queue work and embedding startup gates that can reject the runtime.

## Changes

- Apply Dreaming and required pipeline defaults to existing configurations without overwriting explicit nested safety settings or unrelated fields.
- Admit Dreaming before legacy extraction retirement and embedding startup gates, while restoring DB-owner maintenance before worker admission on runtime restart.
- Make backlog status reads non-blocking, agent-scoped, nullable until a fresh exact measurement exists, and safe against stale in-flight measurements.
- Render the nullable backlog state correctly in the CLI.
- Document the nullable API contract and existing-installation setup behavior.
- Add regression coverage for setup preservation, behavioral startup admission when deferred work rejects, cache invalidation and shutdown, route scoping, and CLI output.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/docs`

## Screenshots

N/A: no rendered UI changed. The dashboard change is an API type/status contract update only.

## Migration Notes (if applicable)

No database migration. Existing `agent.yaml` files are updated only when `--enable-dreaming` is explicitly requested; unrelated configuration and explicit nested pipeline settings are preserved.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Focused verification:

- The behavioral startup-admission regression passes: Dreaming remains available when deferred startup rejects.
- Dreaming pipeline/cache regressions, live-route scoping/status/SSE tests, setup preservation tests, CLI tests, and the relevant daemon-status tests pass.
- `@signet/daemon` build passed.
- `bun run typecheck`, `bun run lint`, staged and targeted Biome checks, formatting, `git diff --check`, and the 24-test event-loop audit passed.
- Isolated source daemon reported `worker.running: true`, accepted `POST /api/dream/trigger` with HTTP 202, recorded a completed pass with zero failures, and kept `/health/live` at HTTP 200.
- The broader daemon-status file retains one environment-sensitive VACUUM timing failure before the owner job becomes active; it is unrelated to this change.
- The full repository `bun test` command was attempted but is not green in this environment because of unrelated baseline and optional-dependency fixture failures, so its checkbox remains unchecked.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The successful live pass used an isolated loopback OpenAI-compatible test adapter, so external provider credentials were not required for the worker/lifecycle proof.
