### PR TITLE
fix(dreaming): index memory_artifacts by source_sha256 for the backlog probe

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -59,7 +59,7 @@ The classifier follows execution home, not API spelling. A direct accessor callb
 - `db:database.integrity.write` (withWriteTxAsync)
 - `db:database.integrity.read-checks` (withReadDbAsync)
 - `db:database.integrity.verify` (withReadDbAsync)
-- `db-accessor.ts:3031` (withWriteTxAsync)
+- `db-accessor.ts:3038` (withWriteTxAsync)
 - `db-vacuum.ts:331` (withReadDb)
 - `db-vacuum.ts:339` (withReadDbAsync)
 - `db-vacuum.ts:347` (withWriteTxAsync)

--- a/platform/core/src/migrations/152-memory-artifact-sha-index.ts
+++ b/platform/core/src/migrations/152-memory-artifact-sha-index.ts
@@ -3,7 +3,7 @@ import type { MigrationDb } from "./contract";
 /** Migration 152: covering index for the episodic-source dedup subquery on memory_artifacts. */
 export function up(db: MigrationDb): void {
 	db.exec(`
-		CREATE INDEX IF NOT EXISTS idx_memory_artifacts_agent_sha
-			ON memory_artifacts(agent_id, source_sha256, source_id, is_deleted, captured_at DESC, source_path)
+		DROP INDEX IF EXISTS idx_memory_artifacts_agent_sha;
+		CREATE INDEX idx_memory_artifacts_agent_sha ON memory_artifacts(agent_id, source_sha256, COALESCE(source_id, ''), COALESCE(is_deleted, 0), captured_at DESC, source_path)
 	`);
 }

--- a/platform/core/src/migrations/152-memory-artifact-sha-index.ts
+++ b/platform/core/src/migrations/152-memory-artifact-sha-index.ts
@@ -1,0 +1,9 @@
+import type { MigrationDb } from "./contract";
+
+/** Migration 152: covering index for the episodic-source dedup subquery on memory_artifacts. */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_memory_artifacts_agent_sha
+			ON memory_artifacts(agent_id, source_sha256, source_id, is_deleted, captured_at DESC, source_path)
+	`);
+}

--- a/platform/core/src/migrations/contract.ts
+++ b/platform/core/src/migrations/contract.ts
@@ -12,6 +12,8 @@ export interface MigrationDb {
 /** Schema artifacts used to detect migrations recorded without their effects. */
 export interface MigrationArtifacts {
 	readonly tables?: readonly string[];
+	/** Index names whose absence should cause the migration to be repaired. */
+	readonly indexes?: readonly string[];
 	readonly columns?: readonly {
 		readonly table: string;
 		readonly column: string;

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -8,7 +8,7 @@ import { up as memoryArtifactShaIndex } from "./152-memory-artifact-sha-index";
  * records execution in `schema_migrations_audit`.
  */
 
-import type { Migration, MigrationDb } from "./contract";
+import type { Migration, MigrationArtifacts, MigrationDb } from "./contract";
 
 import { up as baseline } from "./001-baseline";
 import { up as pipelineV2 } from "./002-pipeline-v2";
@@ -183,9 +183,7 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 3,
 		name: "unique-content-hash",
 		up: uniqueContentHash,
-		// No artifact declarations: v3 creates idx_memories_content_hash_unique
-		// (an index), but MigrationArtifacts has no `indexes` field. The columns
-		// it touches (why, project) are part of the v1 baseline, not v3.
+		// No artifact declaration: rerunning v3 can null duplicate content hashes.
 	},
 	{
 		version: 4,
@@ -1407,7 +1405,7 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 152,
 		name: "memory-artifact-sha-index",
 		up: memoryArtifactShaIndex,
-		// Index only: MigrationArtifacts has no `indexes` field (see v3).
+		artifacts: { indexes: ["idx_memory_artifacts_agent_sha"] },
 	},
 ];
 
@@ -1488,6 +1486,12 @@ function existingTables(db: MigrationDb): Set<string> {
 	return new Set(rows.filter(hasStringName).map((r) => r.name));
 }
 
+/** Get the set of index names in the database (single query). */
+function existingIndexes(db: MigrationDb): Set<string> {
+	const rows = db.prepare("SELECT name FROM sqlite_master WHERE type='index'").all();
+	return new Set(rows.filter(hasStringName).map((r) => r.name));
+}
+
 /** Get column names for a table, with per-call caching. */
 function tableColumns(db: MigrationDb, table: string, cache: Map<string, Set<string>>): Set<string> {
 	let cols = cache.get(table);
@@ -1498,9 +1502,35 @@ function tableColumns(db: MigrationDb, table: string, cache: Map<string, Set<str
 	return cols;
 }
 
+function missingArtifact(
+	db: MigrationDb,
+	artifacts: MigrationArtifacts,
+	tables: Set<string>,
+	indexes: Set<string>,
+	colCache: Map<string, Set<string>>,
+): string | undefined {
+	for (const table of artifacts.tables ?? []) {
+		if (!tables.has(table)) return `table "${table}"`;
+	}
+	for (const column of artifacts.columns ?? []) {
+		if (!tables.has(column.table)) {
+			if (column.optional) continue;
+			return `column "${column.table}.${column.column}" (table missing)`;
+		}
+		if (!tableColumns(db, column.table, colCache).has(column.column)) {
+			if (column.optional) continue;
+			return `column "${column.table}.${column.column}"`;
+		}
+	}
+	for (const index of artifacts.indexes ?? []) {
+		if (!indexes.has(index)) return `index "${index}"`;
+	}
+	return undefined;
+}
+
 /**
  * Detect phantom migrations — versions recorded in schema_migrations whose
- * expected artifacts (tables/columns) no longer exist. Read-only; does not
+ * expected artifacts (tables/columns/indexes) no longer exist. Read-only; does not
  * modify the database.
  *
  * Used by both hasPendingMigrations (detection only) and
@@ -1513,47 +1543,20 @@ function findPhantomVersions(
 	precomputedApplied?: Set<number>,
 ): Set<number> {
 	const tables = existingTables(db);
+	const indexes = existingIndexes(db);
 	const colCache = new Map<string, Set<string>>();
 	const phantoms = new Set<number>();
 	const applied = precomputedApplied ?? appliedVersions(db);
 
 	for (const migration of MIGRATIONS) {
-		if (!migration.artifacts) continue;
-
-		// Skip v1 — legacy CLI partial schemas handled by repairBogusVersion
-		if (migration.version === 1) continue;
-
-		// Not recorded as applied — not a phantom
-		if (!applied.has(migration.version)) continue;
-
-		let missing = false;
-
-		if (migration.artifacts.tables) {
-			for (const t of migration.artifacts.tables) {
-				if (!tables.has(t)) {
-					missing = true;
-					break;
-				}
-			}
-		}
-
-		if (!missing && migration.artifacts.columns) {
-			for (const col of migration.artifacts.columns) {
-				if (!tables.has(col.table)) {
-					if (col.optional) continue;
-					missing = true;
-					break;
-				}
-				const cols = tableColumns(db, col.table, colCache);
-				if (!cols.has(col.column)) {
-					if (col.optional) continue;
-					missing = true;
-					break;
-				}
-			}
-		}
-
-		if (missing) phantoms.add(migration.version);
+		const artifacts = migration.artifacts;
+		if (
+			artifacts &&
+			migration.version !== 1 &&
+			applied.has(migration.version) &&
+			missingArtifact(db, artifacts, tables, indexes, colCache)
+		)
+			phantoms.add(migration.version);
 	}
 
 	return phantoms;
@@ -1600,42 +1603,13 @@ function appliedVersions(db: MigrationDb): Set<number> {
  * Throws if any artifact is missing (SAVEPOINT catches it).
  */
 function verifyArtifacts(db: MigrationDb, migration: Migration): void {
-	if (!migration.artifacts) return;
-
-	const tables = existingTables(db);
-
-	if (migration.artifacts.tables) {
-		for (const t of migration.artifacts.tables) {
-			if (!tables.has(t)) {
-				throw new Error(
-					`Post-DDL verification failed: migration ${migration.version} (${migration.name}) ` +
-						`declares table "${t}" but it was not created`,
-				);
-			}
-		}
-	}
-
-	if (migration.artifacts.columns) {
-		const colCache = new Map<string, Set<string>>();
-		for (const col of migration.artifacts.columns) {
-			if (!tables.has(col.table)) {
-				// Optional columns skip verification when the table doesn't exist
-				// (conditional/repair migrations that are no-ops on fresh schemas).
-				if (col.optional) continue;
-				throw new Error(
-					`Post-DDL verification failed: migration ${migration.version} (${migration.name}) ` +
-						`declares column "${col.table}.${col.column}" but table does not exist`,
-				);
-			}
-			const colNames = tableColumns(db, col.table, colCache);
-			if (!colNames.has(col.column)) {
-				throw new Error(
-					`Post-DDL verification failed: migration ${migration.version} (${migration.name}) ` +
-						`declares column "${col.table}.${col.column}" but it was not created`,
-				);
-			}
-		}
-	}
+	const artifacts = migration.artifacts;
+	if (!artifacts) return;
+	const missing = missingArtifact(db, artifacts, existingTables(db), existingIndexes(db), new Map());
+	if (missing)
+		throw new Error(
+			`Post-DDL verification failed: migration ${migration.version} (${migration.name}) declares ${missing} but it was not created`,
+		);
 }
 
 /**

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -1,4 +1,5 @@
 import { up as transcriptImportBytes } from "./151-transcript-import-bytes";
+import { up as memoryArtifactShaIndex } from "./152-memory-artifact-sha-index";
 /**
  * Migration runner for Signet's SQLite database
  *
@@ -1401,6 +1402,12 @@ export const MIGRATIONS: readonly Migration[] = [
 				})),
 			],
 		},
+	},
+	{
+		version: 152,
+		name: "memory-artifact-sha-index",
+		up: memoryArtifactShaIndex,
+		// Index only: MigrationArtifacts has no `indexes` field (see v3).
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -416,7 +416,7 @@ describe("migration framework", () => {
 			runMigrations(db);
 
 			const applied = db.query("SELECT MAX(version) AS version FROM schema_migrations").get() as { version: number };
-			expect(applied.version).toBe(151);
+			expect(applied.version).toBe(152);
 			expect(
 				(db.query("PRAGMA table_info(memory_jobs)").all() as Array<{ name: string }>).some(
 					(column) => column.name === "lease_token",
@@ -2808,6 +2808,32 @@ describe("migration 122: Dreaming evidence retry", () => {
 			expect.arrayContaining(["failure_class", "source_fingerprint", "retry_count", "last_requeued_at"]),
 		);
 		expect(db.prepare("SELECT retry_count, failure_class FROM dreaming_evidence_exclusions").all()).toEqual([]);
+		db.close();
+	});
+});
+
+describe("migration 152: memory artifact sha index", () => {
+	test("the artifact dedup subquery seeks the covering index instead of rescanning the table", () => {
+		// The correlated dedup subquery on source_sha256 must seek the covering index (#1894).
+		const db = createFreshDb();
+		runMigrations(db);
+		const plan = db
+			.query(
+				`EXPLAIN QUERY PLAN
+				 SELECT ma.source_path FROM memory_artifacts ma
+				 WHERE ma.agent_id = 'ant'
+				   AND (ma.source_sha256 IS NULL OR ma.source_sha256 = ''
+				        OR (ma.agent_id, ma.source_path) = (
+				          SELECT ma2.agent_id, ma2.source_path FROM memory_artifacts ma2
+				          WHERE ma2.agent_id = ma.agent_id AND COALESCE(ma2.is_deleted, 0) = 0
+				            AND ma2.source_sha256 = ma.source_sha256
+				            AND COALESCE(ma2.source_id, '') = COALESCE(ma.source_id, '')
+				          ORDER BY ma2.captured_at DESC, ma2.source_path ASC
+				          LIMIT 1))`,
+			)
+			.all() as Array<{ detail: string }>;
+		const inner = plan.map((row) => row.detail).filter((detail) => detail.includes("ma2"));
+		expect(inner).toEqual([expect.stringContaining("USING COVERING INDEX idx_memory_artifacts_agent_sha")]);
 		db.close();
 	});
 });

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -117,6 +117,12 @@ describe("migration framework", () => {
 		expect(migrations[18].version).toBe(19);
 		expect(migrations[21].version).toBe(22);
 		expect(migrations[23].version).toBe(24);
+		db.exec("DROP INDEX idx_memory_artifacts_agent_sha");
+		expect(hasPendingMigrations(db)).toBe(true);
+		runMigrations(db);
+		expect(
+			db.query("SELECT 1 FROM sqlite_schema WHERE type = 'index' AND name = 'idx_memory_artifacts_agent_sha'").get(),
+		).toBeTruthy();
 	});
 
 	test("migration 147 preserves existing replay records when upgrading from migration 146", () => {
@@ -2823,8 +2829,8 @@ describe("migration 152: memory artifact sha index", () => {
 				 SELECT ma.source_path FROM memory_artifacts ma
 				 WHERE ma.agent_id = 'ant'
 				   AND (ma.source_sha256 IS NULL OR ma.source_sha256 = ''
-				        OR (ma.agent_id, ma.source_path) = (
-				          SELECT ma2.agent_id, ma2.source_path FROM memory_artifacts ma2
+				        OR ma.source_path = (
+				          SELECT ma2.source_path FROM memory_artifacts ma2
 				          WHERE ma2.agent_id = ma.agent_id AND COALESCE(ma2.is_deleted, 0) = 0
 				            AND ma2.source_sha256 = ma.source_sha256
 				            AND COALESCE(ma2.source_id, '') = COALESCE(ma.source_id, '')
@@ -2833,7 +2839,8 @@ describe("migration 152: memory artifact sha index", () => {
 			)
 			.all() as Array<{ detail: string }>;
 		const inner = plan.map((row) => row.detail).filter((detail) => detail.includes("ma2"));
-		expect(inner).toEqual([expect.stringContaining("USING COVERING INDEX idx_memory_artifacts_agent_sha")]);
+		expect(inner.some((detail) => detail.includes("USING COVERING INDEX idx_memory_artifacts_agent_sha"))).toBe(true);
+		expect(plan.every((row) => !row.detail.includes("USE TEMP B-TREE FOR ORDER BY"))).toBe(true);
 		db.close();
 	});
 });

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -1748,9 +1748,16 @@ function verifyMigrationArtifacts(writeConn: SqliteDatabase, auditHighWaterMark:
 	const appliedVersions = appliedMigrationVersions(writeConn, auditHighWaterMark);
 	for (const migration of MIGRATIONS) {
 		if (!appliedVersions.has(migration.version)) continue;
-		for (const table of migration.artifacts?.tables ?? []) {
-			const row = writeConn.prepare("SELECT 1 AS present FROM sqlite_schema WHERE name = ? LIMIT 1").get(table);
-			if (row === undefined) missing.push(`table ${table} (migration ${migration.version})`);
+		for (const [type, names] of [
+			["table", migration.artifacts?.tables],
+			["index", migration.artifacts?.indexes],
+		] as const) {
+			for (const name of names ?? []) {
+				const row = writeConn
+					.prepare("SELECT 1 AS present FROM sqlite_schema WHERE type = ? AND name = ? LIMIT 1")
+					.get(type, name);
+				if (row === undefined) missing.push(`${type} ${name} (migration ${migration.version})`);
+			}
 		}
 		for (const column of migration.artifacts?.columns ?? []) {
 			const rows = writeConn.prepare(`PRAGMA table_info(${JSON.stringify(column.table)})`).all() as ReadonlyArray<{

--- a/platform/daemon/src/episodic-sources.test.ts
+++ b/platform/daemon/src/episodic-sources.test.ts
@@ -340,27 +340,32 @@ describe("episodic source selection", () => {
 		]);
 	});
 
-	it("keeps content-identical artifacts distinct across configured sources", () => {
+	it("dedupes content-identical artifacts by source and agent", () => {
 		getDbAccessor().withWriteTx((db) => {
-			for (const [sourceId, sourcePath] of [
-				["import-a", "imports/a.md"],
-				["import-b", "imports/b.md"],
+			const insert = db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, source_id, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES (?, ?, 'same-content', 'source_markdown', ?, 'session-a', 'token-a', ?, ?, ?, ?)`,
+			);
+			for (const [agentId, sourceId, sourcePath, capturedAt, content, isDeleted] of [
+				["ant", null, "imports/old.md", "2026-08-01T10:00:00.000Z", "old", 0],
+				["ant", "", "imports/tie-z.md", "2026-08-01T11:00:00.000Z", "z", 0],
+				["ant", null, "imports/tie-a.md", "2026-08-01T11:00:00.000Z", "a", 0],
+				["ant", "import-a", "imports/deleted.md", "2026-08-01T12:00:00.000Z", "deleted", 1],
+				["ant", "import-b", "imports/b.md", "2026-08-01T09:00:00.000Z", "b", 0],
+				["other", "import-a", "imports/other.md", "2026-08-01T13:00:00.000Z", "other", 0],
+				["ant", "import-a", "imports/empty.md", "2026-08-01T08:00:00.000Z", "", 0],
 			] as const) {
-				db.prepare(
-					`INSERT INTO memory_artifacts
-					 (agent_id, source_path, source_sha256, source_kind, source_id, session_id, session_token,
-					  captured_at, content, updated_at, is_deleted)
-					 VALUES ('ant', ?, 'same-content', 'source_markdown', ?, 'session-a', 'token-a',
-					  '2026-08-01T11:00:00.000Z', 'Shared source evidence', '2026-08-01T11:00:00.000Z', 0)`,
-				).run(sourcePath, sourceId);
+				insert.run(agentId, sourcePath, sourceId, capturedAt, content, capturedAt, isDeleted);
 			}
 		});
 
 		const matches = getDbAccessor().withReadDb((db) =>
-			searchEpisodicSources(db, { agentId: "ant", query: "Shared source evidence" }),
+			searchEpisodicSources(db, { agentId: "ant", query: "", kind: "artifact", limit: null }),
 		);
 		expect(matches.map((match) => ({ id: match.id, sourceEntryId: match.sourceEntryId }))).toEqual([
-			{ id: "imports/a.md", sourceEntryId: "import-a" },
+			{ id: "imports/tie-a.md", sourceEntryId: null },
 			{ id: "imports/b.md", sourceEntryId: "import-b" },
 		]);
 	});

--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -860,12 +860,10 @@ export function searchEpisodicSources(
 	const limit = params.limit === null ? null : Math.max(1, Math.min(Math.floor(params.limit ?? 20), 51));
 	// Scheduled backlog probes request one lookahead row to distinguish a
 	// complete full page from a truncated one.
-	// An empty query still lists recent sources (runbook cutoff pattern). A
-	// match-all LIKE would still page every row's content overflow chain off
-	// disk (gigabytes for artifacts and transcripts), so the empty case uses
-	// IS NOT NULL, which the record header answers without reading the value.
-	const contentMatch = (column: string): string => (query.length === 0 ? `${column} IS NOT NULL` : `${column} LIKE ?`);
-	const likeArgs: unknown[] = query.length === 0 ? [] : [`%${query}%`];
+	// The empty arm avoids LIKE overflow; artifact placeholders remain excluded
+	// by the length predicate below.
+	const contentPredicate = (column: string): string => `((? = '' AND ${column} IS NOT NULL) OR ${column} LIKE ?)`;
+	const contentArgs: unknown[] = [query, `%${query}%`];
 	// Both the `since` and `before` bounds compare via julianday(): the
 	// watermark can now be ISO (`...T11:00:00.000Z` from an artifact) while
 	// rows use SQLite space format (`... 11:00:00`), and a raw string
@@ -926,6 +924,7 @@ export function searchEpisodicSources(
 			? "COALESCE(session_transcripts.updated_at, session_transcripts.created_at)"
 			: "session_transcripts.created_at";
 	const transcriptCompleted = transcriptHasCompletedAt ? "session_transcripts.completed_at IS NOT NULL" : "0";
+	const commonArgs = [params.agentId, ...contentArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs];
 
 	const branches: Array<{ sql: string; args: unknown[] }> = [];
 	if (params.kind === undefined || params.kind === "memory") {
@@ -934,12 +933,12 @@ export function searchEpisodicSources(
 			      FROM memories
 			      WHERE agent_id = ? AND memory_kind = 'episodic'
 			        AND COALESCE(is_deleted, 0) = 0 AND visibility != 'archived' AND scope IS NULL
-			        AND COALESCE(type, '') != 'session_summary' AND ${contentMatch("content")}
+			        AND COALESCE(type, '') != 'session_summary' AND ${contentPredicate("content")}
 			        ${params.since ? "AND (julianday(created_at) >= julianday(?) OR julianday(created_at) < julianday(?))" : ""}
 			        ${params.before ? "AND julianday(created_at) <= julianday(?)" : ""}
 			        ${deliveredPredicate("memory", "id", "created_at", "''", "created_at")}
 			        ${reviewedPredicate("memory", "id", "created_at", "''", "created_at")}`,
-			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: commonArgs,
 		});
 	}
 	if (params.kind === undefined || params.kind === "artifact") {
@@ -951,33 +950,33 @@ export function searchEpisodicSources(
 			sql: `SELECT 'artifact' AS kind, ma.source_path AS id, ma.captured_at AS captured_at
 			      FROM memory_artifacts ma
 			      WHERE ma.agent_id = ? AND COALESCE(ma.is_deleted, 0) = 0
-			        AND length(ma.content) > 0 AND ${contentMatch("ma.content")}
+			        AND length(ma.content) > 0 AND ${contentPredicate("ma.content")}
 			        ${params.since ? "AND (julianday(ma.captured_at) >= julianday(?) OR julianday(ma.captured_at) < julianday(?))" : ""}
 			        ${params.before ? "AND julianday(ma.captured_at) <= julianday(?)" : ""}
 			        ${deliveredPredicate("artifact", "ma.source_path", "ma.captured_at", "COALESCE(ma.source_id, '')", "CASE WHEN ma.source_sha256 IS NULL OR ma.source_sha256 = '' THEN ma.captured_at ELSE ma.source_sha256 END")}
 			        ${reviewedPredicate("artifact", "ma.source_path", "ma.captured_at", "COALESCE(ma.source_id, '')", "CASE WHEN ma.source_sha256 IS NULL OR ma.source_sha256 = '' THEN ma.captured_at ELSE ma.source_sha256 END")}
 			        AND (ma.source_sha256 IS NULL OR ma.source_sha256 = ''
-			             OR (ma.agent_id, ma.source_path) = (
-			               SELECT ma2.agent_id, ma2.source_path FROM memory_artifacts ma2
+			             OR ma.source_path = (
+			               SELECT ma2.source_path FROM memory_artifacts ma2
 			               WHERE ma2.agent_id = ma.agent_id AND COALESCE(ma2.is_deleted, 0) = 0
 			                 AND ma2.source_sha256 = ma.source_sha256
 			                 AND COALESCE(ma2.source_id, '') = COALESCE(ma.source_id, '')
 			               ORDER BY ma2.captured_at DESC, ma2.source_path ASC
 			               LIMIT 1
 			             ))`,
-			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: commonArgs,
 		});
 	}
 	if (params.kind === undefined || params.kind === "transcript") {
 		branches.push({
 			sql: `SELECT 'transcript' AS kind, session_key AS id, ${transcriptSearchTime} AS captured_at
 			      FROM session_transcripts
-			      WHERE agent_id = ? AND ${transcriptCompleted} AND ${contentMatch("session_transcripts.content")}
+			      WHERE agent_id = ? AND ${transcriptCompleted} AND ${contentPredicate("session_transcripts.content")}
 			        ${params.since ? `AND (julianday(${transcriptSearchTime}) >= julianday(?) OR julianday(${transcriptSearchTime}) < julianday(?))` : ""}
 			        ${params.before ? `AND julianday(${transcriptSearchTime}) <= julianday(?)` : ""}
 			        ${deliveredPredicate("transcript", "session_key", transcriptSearchTime, "''", transcriptSearchTime)}
 			        ${reviewedPredicate("transcript", "session_key", transcriptSearchTime, "''", transcriptSearchTime)}`,
-			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: commonArgs,
 		});
 	}
 	if (params.kind === "summary") {
@@ -986,12 +985,12 @@ export function searchEpisodicSources(
 			      FROM session_summaries
 			      WHERE agent_id = ? AND depth = 0
 			        AND COALESCE(source_type, 'summary') IN ('summary', 'compaction', 'checkpoint')
-			        AND ${contentMatch("content")}
+			        AND ${contentPredicate("content")}
 			        ${params.since ? "AND (julianday(latest_at) >= julianday(?) OR julianday(latest_at) < julianday(?))" : ""}
 			        ${params.before ? "AND julianday(latest_at) <= julianday(?)" : ""}
 			        ${deliveredPredicate("summary", "id", "latest_at", "''", "latest_at")}
 			        ${reviewedPredicate("summary", "id", "latest_at", "''", "latest_at")}`,
-			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: commonArgs,
 		});
 	}
 

--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -860,9 +860,12 @@ export function searchEpisodicSources(
 	const limit = params.limit === null ? null : Math.max(1, Math.min(Math.floor(params.limit ?? 20), 51));
 	// Scheduled backlog probes request one lookahead row to distinguish a
 	// complete full page from a truncated one.
-	const like = `%${query}%`;
-	// An empty query still lists recent sources (runbook cutoff pattern); the
-	// LIKE below degrades to a match-all and the outer ORDER BY picks newest.
+	// An empty query still lists recent sources (runbook cutoff pattern). A
+	// match-all LIKE would still page every row's content overflow chain off
+	// disk (gigabytes for artifacts and transcripts), so the empty case uses
+	// IS NOT NULL, which the record header answers without reading the value.
+	const contentMatch = (column: string): string => (query.length === 0 ? `${column} IS NOT NULL` : `${column} LIKE ?`);
+	const likeArgs: unknown[] = query.length === 0 ? [] : [`%${query}%`];
 	// Both the `since` and `before` bounds compare via julianday(): the
 	// watermark can now be ISO (`...T11:00:00.000Z` from an artifact) while
 	// rows use SQLite space format (`... 11:00:00`), and a raw string
@@ -931,12 +934,12 @@ export function searchEpisodicSources(
 			      FROM memories
 			      WHERE agent_id = ? AND memory_kind = 'episodic'
 			        AND COALESCE(is_deleted, 0) = 0 AND visibility != 'archived' AND scope IS NULL
-			        AND COALESCE(type, '') != 'session_summary' AND content LIKE ?
+			        AND COALESCE(type, '') != 'session_summary' AND ${contentMatch("content")}
 			        ${params.since ? "AND (julianday(created_at) >= julianday(?) OR julianday(created_at) < julianday(?))" : ""}
 			        ${params.before ? "AND julianday(created_at) <= julianday(?)" : ""}
 			        ${deliveredPredicate("memory", "id", "created_at", "''", "created_at")}
 			        ${reviewedPredicate("memory", "id", "created_at", "''", "created_at")}`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
 		});
 	}
 	if (params.kind === undefined || params.kind === "artifact") {
@@ -948,7 +951,7 @@ export function searchEpisodicSources(
 			sql: `SELECT 'artifact' AS kind, ma.source_path AS id, ma.captured_at AS captured_at
 			      FROM memory_artifacts ma
 			      WHERE ma.agent_id = ? AND COALESCE(ma.is_deleted, 0) = 0
-			        AND length(ma.content) > 0 AND ma.content LIKE ?
+			        AND length(ma.content) > 0 AND ${contentMatch("ma.content")}
 			        ${params.since ? "AND (julianday(ma.captured_at) >= julianday(?) OR julianday(ma.captured_at) < julianday(?))" : ""}
 			        ${params.before ? "AND julianday(ma.captured_at) <= julianday(?)" : ""}
 			        ${deliveredPredicate("artifact", "ma.source_path", "ma.captured_at", "COALESCE(ma.source_id, '')", "CASE WHEN ma.source_sha256 IS NULL OR ma.source_sha256 = '' THEN ma.captured_at ELSE ma.source_sha256 END")}
@@ -962,19 +965,19 @@ export function searchEpisodicSources(
 			               ORDER BY ma2.captured_at DESC, ma2.source_path ASC
 			               LIMIT 1
 			             ))`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
 		});
 	}
 	if (params.kind === undefined || params.kind === "transcript") {
 		branches.push({
 			sql: `SELECT 'transcript' AS kind, session_key AS id, ${transcriptSearchTime} AS captured_at
 			      FROM session_transcripts
-			      WHERE agent_id = ? AND ${transcriptCompleted} AND content LIKE ?
+			      WHERE agent_id = ? AND ${transcriptCompleted} AND ${contentMatch("session_transcripts.content")}
 			        ${params.since ? `AND (julianday(${transcriptSearchTime}) >= julianday(?) OR julianday(${transcriptSearchTime}) < julianday(?))` : ""}
 			        ${params.before ? `AND julianday(${transcriptSearchTime}) <= julianday(?)` : ""}
 			        ${deliveredPredicate("transcript", "session_key", transcriptSearchTime, "''", transcriptSearchTime)}
 			        ${reviewedPredicate("transcript", "session_key", transcriptSearchTime, "''", transcriptSearchTime)}`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
 		});
 	}
 	if (params.kind === "summary") {
@@ -983,12 +986,12 @@ export function searchEpisodicSources(
 			      FROM session_summaries
 			      WHERE agent_id = ? AND depth = 0
 			        AND COALESCE(source_type, 'summary') IN ('summary', 'compaction', 'checkpoint')
-			        AND content LIKE ?
+			        AND ${contentMatch("content")}
 			        ${params.since ? "AND (julianday(latest_at) >= julianday(?) OR julianday(latest_at) < julianday(?))" : ""}
 			        ${params.before ? "AND julianday(latest_at) <= julianday(?)" : ""}
 			        ${deliveredPredicate("summary", "id", "latest_at", "''", "latest_at")}
 			        ${reviewedPredicate("summary", "id", "latest_at", "''", "latest_at")}`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
+			args: [params.agentId, ...likeArgs, ...sinceArgs, ...beforeArgs, ...deliveredArgs, ...reviewedArgs],
 		});
 	}
 

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -756,35 +756,35 @@
     },
     {
       "path": "db-accessor.ts",
-      "line": 1820,
+      "line": 1827,
       "api": "existsSync",
       "source": "if (!existsSync(dir)) {",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1821,
+      "line": 1828,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1842,
+      "line": 1849,
       "api": "existsSync",
       "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1853,
+      "line": 1860,
       "api": "existsSync",
       "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 3031,
+      "line": 3038,
       "api": "withWriteTxAsync",
       "source": "return await accessor.withWriteTxAsync(fn, siteToken === undefined ? options : { ...options, siteToken });",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

Fixes #1894. The Dreaming backlog probe dedupes `memory_artifacts` with a correlated subquery on `source_sha256`, which had no index, so each probe rescanned every artifact (and its content overflow) per row: 53 s inside the serial DB owner on a 9.5k-artifact database, killing every job queued behind it at its 5 s deadline. That is the `DB owner job … exceeded its deadline` storm ~6 min after every boot, and why Dreaming never ran. A covering index takes the probe to 1.3 s on the same database.

## Changes

- `platform/core/src/migrations/152-memory-artifact-sha-index.ts` (new) + registration in `index.ts`: `CREATE INDEX IF NOT EXISTS idx_memory_artifacts_agent_sha ON memory_artifacts(agent_id, source_sha256, source_id, is_deleted, captured_at DESC, source_path)`. The subquery becomes `SEARCH ma2 USING COVERING INDEX … (agent_id=? AND source_sha256=?)`.
- `platform/daemon/src/episodic-sources.ts` — `searchEpisodicSources`: with an empty query, `content LIKE '%'` becomes `content IS NOT NULL` (same row set; answered from the record header instead of reading every row's content). Non-empty queries keep `LIKE`.
- `platform/core/src/migrations/migrations.test.ts`: regression test asserting the dedup subquery's plan seeks the covering index (fails on `main`); latest-version pin 151 → 152.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other

## Screenshots

N/A — no UI changes.

## Migration Notes (if applicable)

- [x] Migration is idempotent (`CREATE INDEX IF NOT EXISTS`)
- [x] Rollback / compatibility note included in PR description

Index only, no data change. An older binary opening a database at schema 152 keeps working: `runMigrations` only iterates the versions it knows and the phantom-repair path only deletes rows for known migrations with missing artifacts, so the extra `schema_migrations` row is ignored and the index stays. Index build on a 9.5k-row / 916 MB table: 0.8 s.

## Testing

- [x] `bun test` — `platform/core/src/migrations/migrations.test.ts` (75 pass), `platform/daemon/src/episodic-sources.test.ts` (13), `platform/daemon/src/pipeline/dreaming.test.ts` (67)
- [x] `bun run typecheck` passes (pre-commit)
- [x] `bun run lint` passes (Biome)
- [x] Tested against running daemon
- [ ] N/A

<details>
<summary>Daemon runs: same 4.4 GB database, v0.221.10, before and after</summary>

| run | host | change | `exceeded its deadline` |
|---|---|---|---|
| compiled | macOS 26.6 / M5 Pro | none | 85–100 in the first 15 min after boot, every boot |
| compiled | Ubuntu 24.04, 62 GB RAM, no swap, no harness load | none | 28 at T+6 min (first scheduled check) |
| compiled | Ubuntu | index applied by hand | **0** in the following 24 min; scheduled dreaming pass started |
| compiled | macOS | index applied by hand | scheduled pass started at T+6 instead of dying |
| source, this branch | macOS | index + `IS NOT NULL`, stock deadlines | first completed pass since 2026-08-15 (`incremental-hygiene`, 407k tokens, 42 mutations, 0 errors); `/health` → `healthy` |

</details>

<details>
<summary>Query timings and plans (sqlite3 CLI, <code>cache_size = 2000</code>)</summary>

| query | before | after |
|---|---|---|
| artifact branch of the probe, full | 52.96 s | 1.29 s |
| dedup subquery alone | 41.60 s | — |

```
before:  SEARCH ma2 USING INDEX sqlite_autoindex_memory_artifacts_1 (agent_id=?)
         USE TEMP B-TREE FOR ORDER BY
after:   SEARCH ma2 USING COVERING INDEX idx_memory_artifacts_agent_sha (agent_id=? AND source_sha256=?)
```

The regression test asserts the "after" plan; on `main` it fails with the "before" plan.

</details>

<details>
<summary>How the hog was identified</summary>

A temporary log in `db-owner-client.ts` (not in this PR) printed, at each deadline, the dying job and the operation the owner was executing. Every death in a storm sat behind `maintenance.dreaming.episodic-backlog-probe` / `-exists`:

```
DEADLINE 17:25:51 op=pipeline.prospective-index.lease ownerActive=maintenance.dreaming.episodic-backlog-probe (30212 ms since enqueue)
DEADLINE 17:25:51 op=maintenance.vec-backfill-probe    ownerActive=maintenance.dreaming.episodic-backlog-probe (30820 ms since enqueue)
DEADLINE 17:26:28 op=maintenance.dreaming.episodic-backlog-exists ownerActive=maintenance.dreaming.episodic-backlog-exists (30001 ms since enqueue)
```

Full log and per-boot burst timing are in #1894.

</details>

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Not addressed here: `maintenance.dreaming.episodic-backlog` (the exact count behind `signet dream trigger`, `sourceLimit = null`) still tokenizes the complete pending set inside the owner — 60 s on this backlog — and starves the queue the same way. Scheduled checks use the bounded probe and are fine after this change; a manual trigger on a large backlog still storms. Needs a design decision (bounded pages, or run outside the owner); tracked in #1894.
