### PR TITLE
feat(codex): add ChatGPT desktop plugin path

### DIFF
--- a/.github/workflows/codex-windows.yml
+++ b/.github/workflows/codex-windows.yml
@@ -1,0 +1,41 @@
+name: Codex Windows Contract
+
+on:
+  pull_request:
+    paths:
+      - "integrations/codex/**"
+      - "libs/connector-base/**"
+      - "platform/core/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/codex-windows.yml"
+  push:
+    branches: [main]
+    paths:
+      - "integrations/codex/**"
+      - "libs/connector-base/**"
+      - "platform/core/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/codex-windows.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  connector:
+    name: Codex connector Windows tests
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+          PUPPETEER_SKIP_DOWNLOAD: "1"
+        run: bun install --frozen-lockfile
+      - name: Build connector dependencies
+        run: bun run --filter "@signet/core" --filter "@signet/connector-base" build
+      - name: Run Codex connector tests
+        run: bun test --max-concurrency=1 integrations/codex

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Signet runs underneath the tools you already use. Run `signet setup` to configur
 |[Claude Code](https://docs.anthropic.com/en/docs/claude-code)|Hooks + MCP|
 |[OpenCode](https://github.com/sst/opencode)|Plugin|
 |[OpenClaw](https://github.com/openclaw/openclaw)|Plugin|
-|[Codex](https://github.com/openai/codex)|Hooks + MCP|
+|[Codex](https://github.com/openai/codex)|Native plugin + hooks/MCP fallback|
 |[Kimi Code](https://github.com/MoonshotAI/kimi-cli)|Hooks + MCP / ACPX|
 |[Hermes Agent](https://github.com/NousResearch/hermes-agent)|Memory provider plugin|
 |[Pi](https://github.com/mariozechner/pi-coding-agent)|Extension|

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -15,9 +15,8 @@ older Codex installs.
   used by Linux desktop packages, and known per-user/system Windows roots,
   including bundled Codex executables and Node runtimes, so native plugin
   installation does not depend on the desktop app's shell `PATH`
-- Honors `CODEX_HOME` (including `~` expansion) so native Windows, WSL, Linux,
-  macOS, and Codex CLI installations can deliberately share or separate their
-  plugin/config state
+- Honors `CODEX_HOME` (including `~` expansion) so multiple Codex clients on
+  the same OS can deliberately share or separate their plugin/config state
 - Uses absolute Signet launch commands when running from the packaged native
   binary; the MCP worker is started with `SIGNET_MCP_STDIO_WORKER=1`
 - On Windows, writes a hashed `.cmd` hook wrapper so Codex can launch paths
@@ -99,12 +98,13 @@ CLI owns marketplace and plugin state; Signet only patches the legacy global
 MCP/hooks path when it must fall back.
 
 On Windows, the native ChatGPT app and native Codex CLI normally share
-`%USERPROFILE%\\.codex`. A Codex CLI running inside WSL uses Linux `~/.codex`
-unless `CODEX_HOME` points it at the Windows directory, so configure that
-explicitly if both surfaces should see the same plugin. The Linux ChatGPT
-desktop app is currently preview software; the connector checks its standard
-`/usr/lib/chatgpt`, `/opt/chatgpt`, and per-user resource roots, then falls back
-to `PATH`.
+`%USERPROFILE%\\.codex`. Keep WSL/Linux and macOS installs on their native state
+directories instead of pointing them at a Windows `CODEX_HOME`: generated hook
+and MCP commands contain platform-specific absolute paths and Windows `.cmd`
+wrappers. Install the integration separately per OS when those environments
+need Signet. The Linux ChatGPT desktop app is currently preview software; the
+connector checks its standard `/usr/lib/chatgpt`, `/opt/chatgpt`, and per-user
+resource roots, then falls back to `PATH`.
 
 In ChatGPT desktop Work/Codex mode, Codex presents the generated plugin hooks
 for one-time manual review. Approve the Signet hooks in the desktop prompt so

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,16 +1,30 @@
-# Codex CLI Integration
+# Codex and ChatGPT Desktop Integration
 
-Signet connector for [Codex CLI](https://github.com/openai/codex).
+Signet connector for [Codex CLI](https://github.com/openai/codex) and the
+Codex runtime bundled inside the ChatGPT desktop app.
 
 ## What It Does
 
-Integrates Signet with Codex CLI through the native Codex plugin surfaces when
-available, with a compatibility path for older Codex installs.
+Integrates Signet with Codex CLI and ChatGPT desktop Work/Codex mode through
+the native Codex plugin surfaces when available, with a compatibility path for
+older Codex installs.
 
-- Installs a local Codex plugin marketplace bundle with Signet metadata, skills,
+- Installs a local Codex plugin marketplace bundle with Signet metadata, hooks,
   and MCP configuration
+- Discovers `Codex.app` and `ChatGPT.app` on macOS, the ChatGPT resource roots
+  used by Linux desktop packages, and known per-user/system Windows roots,
+  including bundled Codex executables and Node runtimes, so native plugin
+  installation does not depend on the desktop app's shell `PATH`
+- Honors `CODEX_HOME` (including `~` expansion) so native Windows, WSL, Linux,
+  macOS, and Codex CLI installations can deliberately share or separate their
+  plugin/config state
+- Uses absolute Signet launch commands when running from the packaged native
+  binary; the MCP worker is started with `SIGNET_MCP_STDIO_WORKER=1`
+- On Windows, writes a hashed `.cmd` hook wrapper so Codex can launch paths
+  containing spaces without embedding environment assignments in its wrapped
+  `cmd.exe /C` command line
 - Registers compatibility lifecycle hooks for `SessionStart`,
-  `UserPromptSubmit`, and `SessionEnd` while Codex plugin hook loading is not
+  `UserPromptSubmit`, `PreToolUse`, and `Stop` when native plugin hooks are not
   available
 - Falls back to direct `hooks.json` and `[mcp_servers.signet]` patching for
   older Codex versions
@@ -18,9 +32,9 @@ available, with a compatibility path for older Codex installs.
   Codex-generated `MEMORY.md` or `memory_summary.md`
 - Configurable timeout grace periods (5 s for SessionStart, 2 s for UserPromptSubmit)
 - Supports remote daemon URL via `SIGNET_DAEMON_URL` environment variable
-- On macOS, discovers and validates the bundled Codex Desktop Node runtime on
-  install and refreshes only stale Signet-owned hook and MCP commands after a
-  Codex Desktop packaging update
+- Discovers and validates the bundled desktop Node runtime on install and
+  refreshes only stale Signet-owned hook and MCP commands after a desktop
+  packaging update
 
 ## Installation
 
@@ -43,7 +57,8 @@ agent's scoped data.
 
 Interactive setup can also detect Codex CLI and offer to configure it. On a
 machine where you only want to install the Codex integration, use the standalone
-npm installer:
+npm installer. The same installer works when the only Codex executable is the
+one bundled by ChatGPT.app:
 
 ```bash
 npx -y @signetai/codex-plugin install --url http://signet-home.tailnet:3850 --api-key sig_sk_...
@@ -74,6 +89,30 @@ daemon memories are preserved.
 ```
 
 The connector extends `BaseConnector` from `@signet/connector-base` and implements `install()` / `uninstall()` for reversible setup.
+
+The generated bundle uses the `.codex-plugin`/`.mcp.json` compatibility layout
+that current Codex CLI and ChatGPT desktop Work/Codex runtimes load for local
+stdio servers. A separate portable root manifest is intentionally deferred:
+the current bundled Codex runtime does not load local stdio MCP reliably when
+that manifest is present. When native plugin support is available, the Codex
+CLI owns marketplace and plugin state; Signet only patches the legacy global
+MCP/hooks path when it must fall back.
+
+On Windows, the native ChatGPT app and native Codex CLI normally share
+`%USERPROFILE%\\.codex`. A Codex CLI running inside WSL uses Linux `~/.codex`
+unless `CODEX_HOME` points it at the Windows directory, so configure that
+explicitly if both surfaces should see the same plugin. The Linux ChatGPT
+desktop app is currently preview software; the connector checks its standard
+`/usr/lib/chatgpt`, `/opt/chatgpt`, and per-user resource roots, then falls back
+to `PATH`.
+
+In ChatGPT desktop Work/Codex mode, Codex presents the generated plugin hooks
+for one-time manual review. Approve the Signet hooks in the desktop prompt so
+they can run outside the sandbox; choosing to continue without trust leaves
+the plugin installed but disables its lifecycle hooks. This integration targets
+the local Codex runtime used by Work/Codex mode; Chat mode and hosted OAuth are
+separate future work. It talks to that local Codex executable directly; the
+Codex app server is not required for plugin installation.
 
 The Codex plugin exposes Signet-specific tools such as `signet_recall`,
 `signet_source_search`, `signet_session_search`, and `signet_save_note`.

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CodexConnector, buildMcpBlock, resolveCodexDesktopNode } from "./index.js";
+import { CodexConnector, buildHooksFile, buildMcpBlock, resolveCodexCli, resolveCodexDesktopNode } from "./index.js";
 
 class TempConnector extends CodexConnector {
 	constructor(private home: string) {
@@ -42,11 +42,21 @@ class NativePluginTempConnector extends TempConnector {
 	protected override installNativePlugin(codexHome: string): { success: boolean; filesWritten: readonly string[] } {
 		const installedRoot = join(codexHome, "plugins", "cache", "signet-local", "signet", "0.1.0");
 		mkdirSync(installedRoot, { recursive: true });
+		if (!readFileIfExists(this.getConfigPath()).includes('[plugins."signet@signet-local"]')) {
+			writeFileSync(
+				this.getConfigPath(),
+				`${readFileIfExists(this.getConfigPath())}\n[marketplaces.signet-local]\nsource_type = 'local'\nsource = '/tmp/signet-plugin-marketplace'\n\n[plugins."signet@signet-local"]\nenabled = true\n`,
+			);
+		}
 		return { success: true, filesWritten: [installedRoot] };
 	}
 	protected override removeNativePlugin(codexHome: string): void {
 		rmSync(join(codexHome, "plugins", "cache", "signet-local", "signet"), { recursive: true, force: true });
 	}
+}
+
+function readFileIfExists(path: string): string {
+	return existsSync(path) ? readFileSync(path, "utf-8").trimEnd() : "";
 }
 
 class NativePluginFailingTempConnector extends TempConnector {
@@ -55,6 +65,21 @@ class NativePluginFailingTempConnector extends TempConnector {
 	}
 	protected override installNativePlugin(): { success: boolean; filesWritten: readonly string[]; warning: string } {
 		return { success: false, filesWritten: [], warning: "native plugin add failed in test" };
+	}
+}
+
+class NativePluginCommandTempConnector extends TempConnector {
+	constructor(
+		home: string,
+		private codexCommand: string,
+	) {
+		super(home);
+	}
+	protected override resolveCodexCli(): string {
+		return this.codexCommand;
+	}
+	protected override supportsNativePluginInstall(): boolean {
+		return true;
 	}
 }
 
@@ -72,6 +97,12 @@ class NativePluginConfigParsingTempConnector extends TempConnector {
 		}
 		const installedRoot = join(codexHome, "plugins", "cache", "signet-local", "signet", "0.1.0");
 		mkdirSync(installedRoot, { recursive: true });
+		if (!readFileIfExists(this.getConfigPath()).includes('[plugins."signet@signet-local"]')) {
+			writeFileSync(
+				this.getConfigPath(),
+				`${readFileIfExists(this.getConfigPath())}\n[marketplaces.signet-local]\nsource_type = 'local'\nsource = '/tmp/signet-plugin-marketplace'\n\n[plugins."signet@signet-local"]\nenabled = true\n`,
+			);
+		}
 		return { success: true, filesWritten: [installedRoot] };
 	}
 }
@@ -88,6 +119,7 @@ let previousApiKey: string | undefined;
 let previousToken: string | undefined;
 let previousForceCompatHooks: string | undefined;
 let previousWrapperDir: string | undefined;
+let previousCodexHome: string | undefined;
 let previousArgvEntry: string | undefined;
 let previousExecPath: string;
 
@@ -108,6 +140,7 @@ beforeEach(() => {
 	previousToken = process.env.SIGNET_TOKEN;
 	previousForceCompatHooks = process.env.SIGNET_CODEX_FORCE_COMPAT_HOOKS;
 	previousWrapperDir = process.env.SIGNET_WRAPPER_DIR;
+	previousCodexHome = process.env.CODEX_HOME;
 	previousArgvEntry = process.argv[1];
 	previousExecPath = process.execPath;
 	Reflect.deleteProperty(process.env, "SIGNET_SESSION_START_TIMEOUT");
@@ -118,6 +151,7 @@ beforeEach(() => {
 	Reflect.deleteProperty(process.env, "SIGNET_TOKEN");
 	Reflect.deleteProperty(process.env, "SIGNET_CODEX_FORCE_COMPAT_HOOKS");
 	Reflect.deleteProperty(process.env, "SIGNET_WRAPPER_DIR");
+	Reflect.deleteProperty(process.env, "CODEX_HOME");
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
@@ -134,6 +168,7 @@ afterEach(() => {
 	restoreEnv("SIGNET_TOKEN", previousToken);
 	restoreEnv("SIGNET_CODEX_FORCE_COMPAT_HOOKS", previousForceCompatHooks);
 	restoreEnv("SIGNET_WRAPPER_DIR", previousWrapperDir);
+	restoreEnv("CODEX_HOME", previousCodexHome);
 	if (previousArgvEntry === undefined) process.argv.splice(1, 1);
 	else process.argv[1] = previousArgvEntry;
 	process.execPath = previousExecPath;
@@ -154,6 +189,10 @@ function nativePluginConnector(): TempConnector {
 
 function failingNativePluginConnector(): TempConnector {
 	return new NativePluginFailingTempConnector(tempHome);
+}
+
+function nativePluginCommandConnector(codexCommand: string): TempConnector {
+	return new NativePluginCommandTempConnector(tempHome, codexCommand);
 }
 
 function configParsingNativePluginConnector(): TempConnector {
@@ -297,7 +336,11 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		expect(content).toContain(
 			"trusted_hash = 'sha256:8a71d58ff6a7d2c9c6b5587da1e3aba4e4ff020a198318e428ff71f7b4fab6af'",
 		);
-		expect(content.match(/enabled = true/g)?.length).toBe(3);
+		expect(content).toContain(`${prefix}pre_tool_use:0:0"]`);
+		expect(content).toContain(
+			"trusted_hash = 'sha256:0ecfffe8a9fbb8efa06ba68f59ee00d653427a37009573a9da24ff698b371c3c'",
+		);
+		expect(content.match(/enabled = true/g)?.length).toBe(4);
 	});
 
 	test("repairs disabled Signet hook state on reinstall", async () => {
@@ -439,8 +482,7 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(config).toContain("[marketplaces.signet-local]");
 		expect(config).toContain('[plugins."signet@signet-local"]');
 		expect(config).toContain("enabled = true");
-		expect(config).toContain("[mcp_servers.signet]");
-		expect(config).toContain("command = 'signet-mcp'");
+		expect(config).not.toContain("[mcp_servers.signet]");
 		expect(config).not.toContain(`[hooks.state."${hooksPath}:`);
 		expect(existsSync(hooksPath)).toBe(false);
 
@@ -451,7 +493,7 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		};
 		expect(plugin.mcpServers).toBe("./.mcp.json");
 		expect(plugin.skills).toBe("./skills/");
-		expect(plugin.hooks).toBe("./hooks/hooks.json");
+		expect(plugin.hooks).toBeUndefined();
 	});
 
 	test("native plugin install remains idempotent", async () => {
@@ -464,6 +506,31 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(firstConfig.match(/\[marketplaces\.signet-local\]/g)).toHaveLength(1);
 	});
 
+	test("registers the generated marketplace before installing the native plugin", async () => {
+		if (process.platform === "win32") return;
+		const logPath = join(tempHome, "codex-commands.log");
+		const fakeCodex = join(tempHome, "fake-codex");
+		writeFileSync(
+			fakeCodex,
+			[
+				"#!/bin/sh",
+				`printf '%s\\n' "$*" >> '${logPath}'`,
+				'case "$1 $2" in',
+				'  "plugin marketplace") exit 0 ;;',
+				'  "plugin add") echo "Installed plugin root: /fake/signet" ;;',
+				"esac",
+			].join("\n"),
+			"utf-8",
+		);
+		chmodSync(fakeCodex, 0o755);
+
+		await nativePluginCommandConnector(fakeCodex).install(tempHome);
+
+		const calls = readFileSync(logPath, "utf-8").trim().split("\n");
+		expect(calls[0]).toStartWith("plugin marketplace add ");
+		expect(calls[1]).toBe("plugin add signet@signet-local");
+	});
+
 	test("native plugin install removes stale compatibility Signet hooks", async () => {
 		await connector().install(tempHome);
 		expect(existsSync(hooksPath)).toBe(true);
@@ -473,7 +540,7 @@ describe("CodexConnector.install — native plugin bundle", () => {
 
 		const config = readFileSync(configPath, "utf-8");
 		expect(config).toContain('[plugins."signet@signet-local"]');
-		expect(config).toContain("[mcp_servers.signet]");
+		expect(config).not.toContain("[mcp_servers.signet]");
 		expect(config).not.toContain(`[hooks.state."${hooksPath}:`);
 		expect(existsSync(hooksPath)).toBe(false);
 	});
@@ -489,6 +556,7 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		);
 		expect(config).toContain(`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]`);
 		expect(existsSync(hooksPath)).toBe(true);
+		expect(config).not.toContain("[mcp_servers.signet]");
 	});
 
 	test("removes stale compatibility MCP before native plugin add reads Codex config", async () => {
@@ -508,11 +576,10 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		const result = await configParsingNativePluginConnector().install(tempHome);
 
 		const config = readFileSync(configPath, "utf-8");
-		expect(result.message).toBe("Codex integration installed — native plugin bundle + compatibility MCP server");
+		expect(result.message).toBe("Codex integration installed — native plugin bundle");
 		expect(result.warnings).not.toContain("codex refused stale mcp_servers.signet");
 		expect(config).toContain('[plugins."signet@signet-local"]');
-		expect(config).toContain("[mcp_servers.signet]");
-		expect(config).toContain("command = 'signet-mcp'");
+		expect(config).not.toContain("[mcp_servers.signet]");
 		expect(config).not.toContain("transport = 'sse'");
 	});
 
@@ -561,6 +628,38 @@ describe("CodexConnector.uninstall — config.toml cleanup", () => {
 		const content = readFileSync(configPath, "utf-8");
 		expect(content).not.toContain("[mcp_servers.signet]");
 		expect(content).not.toContain("[hooks.state.");
+	});
+
+	test("removes native plugin descendant tables without touching other config", async () => {
+		writeFileSync(
+			configPath,
+			[
+				"[model]",
+				'name = "gpt-4o"',
+				"",
+				"[marketplaces.signet-local]",
+				"source_type = 'local'",
+				"",
+				'[plugins."signet@signet-local"]',
+				"enabled = true",
+				"",
+				'[plugins."signet@signet-local".metadata]',
+				"managed = true",
+				"",
+				"[history]",
+				"enabled = true",
+				"",
+			].join("\n"),
+		);
+
+		await connector().uninstall();
+
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain("[model]");
+		expect(content).toContain("[history]");
+		expect(content).not.toContain("[marketplaces.signet-local]");
+		expect(content).not.toContain('[plugins."signet@signet-local"]');
+		expect(content).not.toContain("managed = true");
 	});
 
 	test("preserves other sections when removing signet entry", async () => {
@@ -661,6 +760,17 @@ describe("buildMcpBlock — TOML quoting", () => {
 	test("includes args line when args are present", () => {
 		const block = buildMcpBlock({ command: "node", args: ["mcp.js", "--port", "3000"] });
 		expect(block).toContain("args = ['mcp.js', '--port', '3000']");
+	});
+
+	test("includes environment for an absolute native MCP worker", () => {
+		const block = buildMcpBlock({
+			command: "/Users/example/.local/bin/signet",
+			args: [],
+			env: { SIGNET_MCP_STDIO_WORKER: "1" },
+		});
+
+		expect(block).toContain("[mcp_servers.signet.env]");
+		expect(block).toContain("SIGNET_MCP_STDIO_WORKER = '1'");
 	});
 });
 
@@ -990,6 +1100,87 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		);
 	});
 
+	test("discovers the Codex executable bundled by ChatGPT.app", () => {
+		const appPath = join(tempHome, "Applications", "ChatGPT.app");
+		const codex = join(appPath, "Contents", "Resources", "codex");
+		mkdirSync(join(codex, ".."), { recursive: true });
+		writeFileSync(
+			codex,
+			'#!/bin/sh\nif [ "$1" = "plugin" ]; then echo plugin-help; else echo codex-cli 0.153.4; fi\n',
+			"utf-8",
+		);
+		chmodSync(codex, 0o755);
+
+		expect(resolveCodexCli([appPath])).toBe(codex);
+	});
+
+	test("discovers Linux ChatGPT resource layouts", () => {
+		const appPath = join(tempHome, "chatgpt");
+		const codex = join(appPath, "resources", "codex");
+		mkdirSync(join(codex, ".."), { recursive: true });
+		writeFileSync(codex, "codex fixture\n", "utf-8");
+
+		expect(resolveCodexCli([appPath], (path) => path === codex, "linux")).toBe(codex);
+	});
+
+	test("discovers Windows ChatGPT resource layouts and node.exe", () => {
+		const appPath = join(tempHome, "ChatGPT");
+		const codex = join(appPath, "app", "resources", "codex.exe");
+		const node = join(appPath, "resources", "runtime", "node.exe");
+		mkdirSync(join(codex, ".."), { recursive: true });
+		mkdirSync(join(node, ".."), { recursive: true });
+		writeFileSync(codex, "codex fixture\n", "utf-8");
+		writeFileSync(node, "node fixture\n", "utf-8");
+
+		expect(resolveCodexCli([appPath], (path) => path === codex, "win32")).toBe(codex);
+		expect(resolveCodexDesktopNode([appPath], (path) => path === node, "win32")).toBe(node);
+	});
+
+	test("discovers Windows Store package roots", () => {
+		const packagesRoot = join(tempHome, "Packages");
+		const codex = join(packagesRoot, "OpenAI.ChatGPT-Desktop_1.0.0", "resources", "codex.exe");
+		mkdirSync(join(codex, ".."), { recursive: true });
+		writeFileSync(codex, "codex fixture\n", "utf-8");
+
+		expect(resolveCodexCli([packagesRoot], (path) => path === codex, "win32")).toBe(codex);
+	});
+
+	test("honors CODEX_HOME for the desktop connector", async () => {
+		const configuredHome = join(tempHome, "configured-codex-home");
+		process.env.CODEX_HOME = configuredHome;
+		const c = new (class extends CodexConnector {
+			protected override supportsNativePluginInstall(): boolean {
+				return false;
+			}
+		})();
+
+		await c.install(tempHome);
+
+		expect(existsSync(join(configuredHome, "config.toml"))).toBe(true);
+		expect(existsSync(join(configuredHome, "hooks.json"))).toBe(true);
+		expect(existsSync(join(codexDir, "config.toml"))).toBe(false);
+	});
+
+	test("uses an absolute native Signet binary for hooks and MCP when no wrapper entry exists", async () => {
+		const nativeBinary = join(tempHome, "bin", "signet");
+		mkdirSync(join(nativeBinary, ".."), { recursive: true });
+		writeFileSync(nativeBinary, "native fixture\n", "utf-8");
+		chmodSync(nativeBinary, 0o755);
+		process.execPath = nativeBinary;
+		process.argv[1] = "/$bunfs/root/signet";
+
+		await connector().install(tempHome);
+
+		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
+		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
+		expect(startHandler.command).toBe(`${nativeBinary} hook session-start -H codex --codex-json`);
+
+		const config = readFileSync(configPath, "utf-8");
+		expect(config).toContain(`command = '${nativeBinary}'`);
+		expect(config).toContain("[mcp_servers.signet.env]");
+		expect(config).toContain("SIGNET_MCP_STDIO_WORKER = '1'");
+	});
+
 	test("installs with malformed but valid hooks.json", async () => {
 		for (const hooks of [
 			{ SessionStart: "x" },
@@ -1034,6 +1225,38 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(commands.some((command) => command === "signet hook session-start -H codex --codex-json")).toBe(true);
 	});
 
+	test("preserves third-party handlers in a mixed matcher group", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							matcher: "*",
+							hooks: [
+								{ type: "command", command: "third-party-reviewer --session", timeout: 4 },
+								{ type: "command", command: "signet hook session-start -H codex", timeout: 4 },
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		await connector().install(tempHome);
+		const installed = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
+		const handlers = installed.SessionStart.flatMap((group) => group.hooks as Record<string, unknown>[]);
+		expect(handlers.some((handler) => handler.command === "third-party-reviewer --session")).toBe(true);
+		expect(handlers.filter((handler) => String(handler.command).includes("signet hook session-start")).length).toBe(1);
+
+		await connector().uninstall();
+		const remaining = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
+		expect(remaining.SessionStart).toHaveLength(1);
+		expect((remaining.SessionStart[0].hooks as Record<string, unknown>[])[0].command).toBe(
+			"third-party-reviewer --session",
+		);
+	});
+
 	test("does not use array-form command (regression: issue #481)", async () => {
 		await connector().install(tempHome);
 		const json = readHooksJson();
@@ -1069,6 +1292,20 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		const bundled = JSON.parse(readFileSync(bundledPath, "utf-8"));
 
 		expect(codexHookContractErrors(bundled)).toEqual([]);
+	});
+
+	test("uses a quote-safe Windows wrapper command when one is available", () => {
+		const hooks = buildHooksFile(
+			["C:\\Program Files\\Signet\\signet.exe"],
+			"https://signet.example.test",
+			"C:\\Users\\Example User\\.codex\\.tmp\\signet-codex-hook-0123456789abcdef.cmd",
+			"win32",
+		) as unknown as { hooks: Record<string, Array<{ hooks: Array<Record<string, unknown>> }>> };
+		const command = hooks.hooks.SessionStart[0]?.hooks[0]?.commandWindows;
+		expect(command).toBe(
+			'"C:\\Users\\Example User\\.codex\\.tmp\\signet-codex-hook-0123456789abcdef.cmd" hook session-start -H codex --codex-json',
+		);
+		expect(command).not.toContain('set "');
 	});
 
 	test("idempotent: re-running install produces identical hooks.json", async () => {

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -552,6 +552,41 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(calls[1]).toBe("plugin add signet@signet-local");
 	});
 
+	test("invokes Windows Codex command shims through cmd.exe", async () => {
+		if (process.platform !== "win32") return;
+		for (const extension of [".cmd", ".bat"]) {
+			const logPath = join(tempHome, `codex commands${extension}.log`);
+			const fakeCodex = join(tempHome, `fake Codex${extension}`);
+			writeFileSync(
+				fakeCodex,
+				[
+					"@echo off",
+					`set "LOG=${logPath}"`,
+					'>> "%LOG%" echo %*',
+					'if /I "%1 %2 %3"=="plugin marketplace add" exit /b 0',
+					'if /I "%1 %2"=="plugin add" echo Installed plugin root: C:\\fake\\signet',
+					"exit /b 0",
+					"",
+				].join("\r\n"),
+				"utf-8",
+			);
+
+			const connector = nativePluginCommandConnector(fakeCodex);
+			const result = await connector.install(tempHome);
+			await connector.uninstall();
+
+			expect(result.message).toBe("Codex integration installed — native plugin bundle");
+			const calls = readFileSync(logPath, "utf-8")
+				.trim()
+				.split(/\r?\n/)
+				.map((call) => call.replaceAll('"', ""));
+			expect(calls.some((call) => call.startsWith("plugin marketplace add "))).toBe(true);
+			expect(calls).toContain("plugin add signet@signet-local");
+			expect(calls).toContain("plugin remove signet@signet-local");
+			expect(calls).toContain("plugin marketplace remove signet-local");
+		}
+	});
+
 	test("native plugin install removes stale compatibility Signet hooks", async () => {
 		await connector().install(tempHome);
 		expect(existsSync(hooksPath)).toBe(true);
@@ -1183,9 +1218,13 @@ describe("CodexConnector.install — hooks.json schema", () => {
 	test("discovers Windows Store package roots", () => {
 		const packagesRoot = join(tempHome, "Packages");
 		const codex = join(packagesRoot, "OpenAI.ChatGPT-Desktop_1.0.0", "resources", "codex.exe");
+		const unrelated = join(packagesRoot, "Acme.Codex_1.0.0", "resources", "codex.exe");
 		mkdirSync(join(codex, ".."), { recursive: true });
+		mkdirSync(join(unrelated, ".."), { recursive: true });
 		writeFileSync(codex, "codex fixture\n", "utf-8");
+		writeFileSync(unrelated, "unrelated fixture\n", "utf-8");
 
+		expect(resolveCodexCli([packagesRoot], (path) => path === unrelated, "win32")).toBeNull();
 		expect(resolveCodexCli([packagesRoot], (path) => path === codex, "win32")).toBe(codex);
 	});
 

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -1107,7 +1107,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 			if (process.platform === "win32") {
 				const wrapper = result.filesWritten.find((path) => path.toLowerCase().endsWith(".cmd"));
 				expect(wrapper).toBeDefined();
-				expect(readFileSync(wrapper as string, "utf-8")).toContain(`${runtime} ${signetEntry}`);
+				expect(readFileSync(wrapper as string, "utf-8").replaceAll('"', "")).toContain(`${runtime} ${signetEntry}`);
 			} else {
 				expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
 			}
@@ -1147,7 +1147,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 			if (process.platform === "win32") {
 				const wrapper = result.filesWritten.find((path) => path.toLowerCase().endsWith(".cmd"));
 				expect(wrapper).toBeDefined();
-				expect(readFileSync(wrapper as string, "utf-8")).toContain(`${runtime} ${signetEntry}`);
+				expect(readFileSync(wrapper as string, "utf-8").replaceAll('"', "")).toContain(`${runtime} ${signetEntry}`);
 			} else {
 				expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
 			}

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -9,7 +9,14 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CodexConnector, buildHooksFile, buildMcpBlock, resolveCodexCli, resolveCodexDesktopNode } from "./index.js";
+import {
+	CodexConnector,
+	buildHooksFile,
+	buildMcpBlock,
+	resolveCodexCli,
+	resolveCodexDesktopNode,
+	resolveWindowsAppxInstallRoots,
+} from "./index.js";
 
 class TempConnector extends CodexConnector {
 	constructor(private home: string) {
@@ -1225,7 +1232,20 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		writeFileSync(unrelated, "unrelated fixture\n", "utf-8");
 
 		expect(resolveCodexCli([packagesRoot], (path) => path === unrelated, "win32")).toBeNull();
+		expect(resolveCodexCli([`${packagesRoot}\\`], (path) => path === unrelated, "win32")).toBeNull();
 		expect(resolveCodexCli([packagesRoot], (path) => path === codex, "win32")).toBe(codex);
+	});
+
+	test("discovers the current ChatGPT Desktop AppX package from PowerShell output", () => {
+		const packageRoot = join(tempHome, "WindowsApps", "OpenAI.ChatGPT-Desktop_26.901.6511.0_x64__2p2nqsd0c76g0");
+		let query = "";
+		const roots = resolveWindowsAppxInstallRoots("win32", (command) => {
+			query = command;
+			return { status: 0, stdout: `${packageRoot}\r\n` };
+		});
+
+		expect(query).toContain("'OpenAI.ChatGPT-Desktop'");
+		expect(roots).toEqual([packageRoot]);
 	});
 
 	test("honors CODEX_HOME for the desktop connector", async () => {

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -27,11 +27,17 @@ class DesktopRuntimeTempConnector extends TempConnector {
 	constructor(
 		home: string,
 		private appPath: string,
+		private runtime?: string,
 	) {
 		super(home);
 	}
 	protected override getCodexDesktopAppPaths(): readonly string[] {
 		return [this.appPath];
+	}
+	protected override resolveCodexDesktopNode(): string | null {
+		return this.runtime
+			? resolveCodexDesktopNode([this.appPath], (path) => path === this.runtime)
+			: super.resolveCodexDesktopNode();
 	}
 }
 
@@ -57,6 +63,20 @@ class NativePluginTempConnector extends TempConnector {
 
 function readFileIfExists(path: string): string {
 	return existsSync(path) ? readFileSync(path, "utf-8").trimEnd() : "";
+}
+
+function tomlBasicString(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function hookStateHeader(event: string): string {
+	return `[hooks.state."${tomlBasicString(hooksPath)}:${event}:0:0"]`;
+}
+
+function selectedHookCommand(handler: Record<string, unknown>): string {
+	const command = process.platform === "win32" ? handler.commandWindows : handler.command;
+	if (typeof command !== "string") throw new Error("Expected a string Codex hook command");
+	return command;
 }
 
 class NativePluginFailingTempConnector extends TempConnector {
@@ -179,8 +199,8 @@ function connector(): TempConnector {
 	return new TempConnector(tempHome);
 }
 
-function desktopRuntimeConnector(appPath: string): TempConnector {
-	return new DesktopRuntimeTempConnector(tempHome, appPath);
+function desktopRuntimeConnector(appPath: string, runtime?: string): TempConnector {
+	return new DesktopRuntimeTempConnector(tempHome, appPath, runtime);
 }
 
 function nativePluginConnector(): TempConnector {
@@ -323,47 +343,31 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		await connector().install(tempHome);
 
 		const content = readFileSync(configPath, "utf-8");
-		const prefix = `[hooks.state."${hooksPath}:`;
+		const prefix = `[hooks.state."${tomlBasicString(hooksPath)}:`;
 		expect(content).toContain(`${prefix}session_start:0:0"]`);
-		expect(content).toContain(
-			"trusted_hash = 'sha256:d09f47a1bd6bc12137cf42650495399d38d20edb12f71913a9b5b046502475fa'",
-		);
+		expect(content).toMatch(/trusted_hash = 'sha256:[0-9a-f]{64}'/);
 		expect(content).toContain(`${prefix}user_prompt_submit:0:0"]`);
-		expect(content).toContain(
-			"trusted_hash = 'sha256:3e57921f72057cbaab62097b2aa09467d57332ea1a96b925b5695b423d6f0e43'",
-		);
 		expect(content).toContain(`${prefix}stop:0:0"]`);
-		expect(content).toContain(
-			"trusted_hash = 'sha256:8a71d58ff6a7d2c9c6b5587da1e3aba4e4ff020a198318e428ff71f7b4fab6af'",
-		);
 		expect(content).toContain(`${prefix}pre_tool_use:0:0"]`);
-		expect(content).toContain(
-			"trusted_hash = 'sha256:0ecfffe8a9fbb8efa06ba68f59ee00d653427a37009573a9da24ff698b371c3c'",
-		);
+		expect(content.match(/trusted_hash = 'sha256:[0-9a-f]{64}'/g)?.length).toBe(4);
 		expect(content.match(/enabled = true/g)?.length).toBe(4);
 	});
 
 	test("repairs disabled Signet hook state on reinstall", async () => {
 		await connector().install(tempHome);
+		const userPromptState = hookStateHeader("user_prompt_submit");
 		const disabled = readFileSync(configPath, "utf-8").replace(
-			`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]\nenabled = true`,
-			`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]\nenabled = false`,
+			`${userPromptState}\nenabled = true`,
+			`${userPromptState}\nenabled = false`,
 		);
 		writeFileSync(configPath, disabled);
 
 		await connector().install(tempHome);
 
 		const content = readFileSync(configPath, "utf-8");
-		expect(content).toContain(`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]\nenabled = true`);
-		expect(content).not.toContain(`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]\nenabled = false`);
-		expect(
-			content.match(
-				new RegExp(
-					`\\[hooks\\.state\\."${hooksPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:user_prompt_submit:0:0"\\]`,
-					"g",
-				),
-			)?.length,
-		).toBe(1);
+		expect(content).toContain(`${userPromptState}\nenabled = true`);
+		expect(content).not.toContain(`${userPromptState}\nenabled = false`);
+		expect(content.match(new RegExp(userPromptState.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))?.length).toBe(1);
 	});
 
 	test("uses remote HTTP MCP URL when SIGNET_DAEMON_URL is configured", async () => {
@@ -401,7 +405,7 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 	test("still writes Codex lifecycle hooks when remote HTTP MCP is configured", async () => {
 		process.env.SIGNET_DAEMON_URL = "http://192.168.0.60:3850/";
 
-		await connector().install(tempHome);
+		const result = await connector().install(tempHome);
 
 		const json = readHooksJson();
 		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
@@ -411,13 +415,30 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		)[0];
 		const stopHandler = ((hooks.Stop[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
 
-		expect(startHandler.command).toBe(
-			"SIGNET_DAEMON_URL='http://192.168.0.60:3850' signet hook session-start -H codex --codex-json",
-		);
-		expect(promptHandler.command).toBe(
-			"SIGNET_DAEMON_URL='http://192.168.0.60:3850' signet hook user-prompt-submit -H codex --codex-json",
-		);
-		expect(stopHandler.command).toBe("SIGNET_DAEMON_URL='http://192.168.0.60:3850' signet hook session-end -H codex");
+		if (process.platform === "win32") {
+			for (const [handler, subcommand] of [
+				[startHandler, "session-start"],
+				[promptHandler, "user-prompt-submit"],
+				[stopHandler, "session-end"],
+			] as const) {
+				expect(selectedHookCommand(handler)).toMatch(
+					new RegExp(`signet-codex-hook-[0-9a-f]{16}\\.cmd.*hook ${subcommand}`),
+				);
+			}
+			const wrapper = result.filesWritten.find((path) => path.toLowerCase().endsWith(".cmd"));
+			expect(wrapper).toBeDefined();
+			expect(readFileSync(wrapper as string, "utf-8")).toContain('set "SIGNET_DAEMON_URL=http://192.168.0.60:3850"');
+		} else {
+			expect(selectedHookCommand(startHandler)).toBe(
+				"SIGNET_DAEMON_URL='http://192.168.0.60:3850' signet hook session-start -H codex --codex-json",
+			);
+			expect(selectedHookCommand(promptHandler)).toBe(
+				"SIGNET_DAEMON_URL='http://192.168.0.60:3850' signet hook user-prompt-submit -H codex --codex-json",
+			);
+			expect(selectedHookCommand(stopHandler)).toBe(
+				"SIGNET_DAEMON_URL='http://192.168.0.60:3850' signet hook session-end -H codex",
+			);
+		}
 	});
 
 	test("remote lifecycle hooks remain idempotent across repeated installs", async () => {
@@ -534,14 +555,14 @@ describe("CodexConnector.install — native plugin bundle", () => {
 	test("native plugin install removes stale compatibility Signet hooks", async () => {
 		await connector().install(tempHome);
 		expect(existsSync(hooksPath)).toBe(true);
-		expect(readFileSync(configPath, "utf-8")).toContain(`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]`);
+		expect(readFileSync(configPath, "utf-8")).toContain(hookStateHeader("user_prompt_submit"));
 
 		await nativePluginConnector().install(tempHome);
 
 		const config = readFileSync(configPath, "utf-8");
 		expect(config).toContain('[plugins."signet@signet-local"]');
 		expect(config).not.toContain("[mcp_servers.signet]");
-		expect(config).not.toContain(`[hooks.state."${hooksPath}:`);
+		expect(config).not.toContain(`[hooks.state."${tomlBasicString(hooksPath)}:`);
 		expect(existsSync(hooksPath)).toBe(false);
 	});
 
@@ -554,7 +575,7 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(result.warnings).toContain(
 			"Codex plugin support detected, but lifecycle hooks still require the compatibility hooks.json path in this Codex version",
 		);
-		expect(config).toContain(`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]`);
+		expect(config).toContain(hookStateHeader("user_prompt_submit"));
 		expect(existsSync(hooksPath)).toBe(true);
 		expect(config).not.toContain("[mcp_servers.signet]");
 	});
@@ -1037,11 +1058,17 @@ describe("CodexConnector.install — hooks.json schema", () => {
 			"[mcp_servers.signet]\ncommand = '/old/Codex.app/Contents/Resources/node'\nargs = ['/old/mcp-stdio.js']\n",
 		);
 
-		const result = await desktopRuntimeConnector(appPath).install(tempHome);
+		const result = await desktopRuntimeConnector(appPath, runtime).install(tempHome);
 		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
 		for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
 			const handler = ((hooks[event]?.[0]?.hooks as Record<string, unknown>[]) ?? [])[0];
-			expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
+			if (process.platform === "win32") {
+				const wrapper = result.filesWritten.find((path) => path.toLowerCase().endsWith(".cmd"));
+				expect(wrapper).toBeDefined();
+				expect(readFileSync(wrapper as string, "utf-8")).toContain(`${runtime} ${signetEntry}`);
+			} else {
+				expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
+			}
 		}
 		expect(readFileSync(configPath, "utf-8")).toContain(`command = '${runtime}'`);
 		expect(readFileSync(configPath, "utf-8")).toContain(`args = ['${mcpEntry}']`);
@@ -1071,33 +1098,41 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		process.argv[1] = "/$bunfs/root/signet";
 		process.env.SIGNET_WRAPPER_DIR = packageRoot;
 
-		await desktopRuntimeConnector(appPath).install(tempHome);
+		const result = await desktopRuntimeConnector(appPath, runtime).install(tempHome);
 		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
 		for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
 			const handler = ((hooks[event]?.[0]?.hooks as Record<string, unknown>[]) ?? [])[0];
-			expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
+			if (process.platform === "win32") {
+				const wrapper = result.filesWritten.find((path) => path.toLowerCase().endsWith(".cmd"));
+				expect(wrapper).toBeDefined();
+				expect(readFileSync(wrapper as string, "utf-8")).toContain(`${runtime} ${signetEntry}`);
+			} else {
+				expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
+			}
 		}
 		const config = readFileSync(configPath, "utf-8");
 		expect(config).toContain(`command = '${runtime}'`);
 		expect(config).toContain(`args = ['${mcpEntry}']`);
 	});
 
-	test("discovers symlinked Codex Desktop runtimes", async () => {
+	test("discovers nested Codex Desktop runtimes", async () => {
 		const appPath = join(tempHome, "Applications", "Codex.app");
 		const resourcesDir = join(appPath, "Contents", "Resources");
-		const runtimeDir = join(tempHome, "node-runtime");
-		const versionedNode = join(runtimeDir, "node-v22.14.0");
-		const runtime = join(runtimeDir, "node");
-		mkdirSync(runtimeDir, { recursive: true });
-		writeFileSync(versionedNode, "#!/bin/sh\necho v22.14.0\n", "utf-8");
-		chmodSync(versionedNode, 0o755);
-		symlinkSync("node-v22.14.0", runtime);
-		mkdirSync(resourcesDir, { recursive: true });
-		symlinkSync(runtimeDir, join(resourcesDir, "runtime"));
+		const runtime = join(resourcesDir, "runtime", process.platform === "win32" ? "node.exe" : "node");
+		mkdirSync(join(runtime, ".."), { recursive: true });
+		if (process.platform === "win32") {
+			writeFileSync(runtime, "node fixture\n", "utf-8");
+		} else {
+			const runtimeDir = join(tempHome, "node-runtime");
+			const versionedNode = join(runtimeDir, "node-v22.14.0");
+			mkdirSync(runtimeDir, { recursive: true });
+			writeFileSync(versionedNode, "#!/bin/sh\necho v22.14.0\n", "utf-8");
+			chmodSync(versionedNode, 0o755);
+			rmSync(runtime, { force: true });
+			symlinkSync(versionedNode, runtime);
+		}
 
-		expect(resolveCodexDesktopNode([appPath], (path) => path === join(resourcesDir, "runtime", "node"))).toBe(
-			join(resourcesDir, "runtime", "node"),
-		);
+		expect(resolveCodexDesktopNode([appPath], (path) => path === runtime, process.platform)).toBe(runtime);
 	});
 
 	test("discovers the Codex executable bundled by ChatGPT.app", () => {
@@ -1111,7 +1146,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		);
 		chmodSync(codex, 0o755);
 
-		expect(resolveCodexCli([appPath])).toBe(codex);
+		expect(resolveCodexCli([appPath], (path) => path === codex, "darwin")).toBe(codex);
 	});
 
 	test("discovers Linux ChatGPT resource layouts", () => {
@@ -1134,6 +1169,15 @@ describe("CodexConnector.install — hooks.json schema", () => {
 
 		expect(resolveCodexCli([appPath], (path) => path === codex, "win32")).toBe(codex);
 		expect(resolveCodexDesktopNode([appPath], (path) => path === node, "win32")).toBe(node);
+	});
+
+	test("discovers versioned Windows Codex binaries without PATH", () => {
+		const appPath = join(tempHome, "OpenAI", "Codex");
+		const codex = join(appPath, "bin", "8e5b6932251c2c1c", "codex.exe");
+		mkdirSync(join(codex, ".."), { recursive: true });
+		writeFileSync(codex, "codex fixture\n", "utf-8");
+
+		expect(resolveCodexCli([appPath], (path) => path === codex, "win32")).toBe(codex);
 	});
 
 	test("discovers Windows Store package roots", () => {
@@ -1169,11 +1213,18 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		process.execPath = nativeBinary;
 		process.argv[1] = "/$bunfs/root/signet";
 
-		await connector().install(tempHome);
+		const result = await connector().install(tempHome);
 
 		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
 		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
-		expect(startHandler.command).toBe(`${nativeBinary} hook session-start -H codex --codex-json`);
+		if (process.platform === "win32") {
+			const wrapper = result.filesWritten.find((path) => path.toLowerCase().endsWith(".cmd"));
+			expect(wrapper).toBeDefined();
+			expect(readFileSync(wrapper as string, "utf-8")).toContain(nativeBinary);
+			expect(selectedHookCommand(startHandler)).toContain("hook session-start -H codex --codex-json");
+		} else {
+			expect(startHandler.command).toBe(`${nativeBinary} hook session-start -H codex --codex-json`);
+		}
 
 		const config = readFileSync(configPath, "utf-8");
 		expect(config).toContain(`command = '${nativeBinary}'`);

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -203,28 +203,35 @@ function readBoundedDirectoryEntries(root: string, limit: number): Dirent[] {
 
 let cachedWindowsAppxInstallRoots: string[] | undefined;
 
-function resolveWindowsAppxInstallRoots(): string[] {
-	if (process.platform !== "win32") return [];
-	if (cachedWindowsAppxInstallRoots !== undefined) return cachedWindowsAppxInstallRoots;
+interface WindowsAppxQueryResult {
+	readonly status: number | null;
+	readonly stdout: string;
+}
+
+type WindowsAppxQuery = (command: string) => WindowsAppxQueryResult;
+
+const WINDOWS_APPX_DISCOVERY_COMMAND =
+	"Get-AppxPackage | Where-Object { $_.Name -eq 'OpenAI.Codex' -or $_.Name -eq 'OpenAI.ChatGPT' -or $_.Name -eq 'OpenAI.ChatGPT-Desktop' } | ForEach-Object { $_.InstallLocation }";
+
+export function resolveWindowsAppxInstallRoots(
+	platform: NodeJS.Platform = process.platform,
+	query?: WindowsAppxQuery,
+): string[] {
+	if (platform !== "win32") return [];
+	if (!query && cachedWindowsAppxInstallRoots !== undefined) return cachedWindowsAppxInstallRoots;
 	try {
-		const result = spawnSync(
-			"powershell.exe",
-			[
-				"-NoLogo",
-				"-NoProfile",
-				"-NonInteractive",
-				"-Command",
-				"Get-AppxPackage | Where-Object { $_.Name -eq 'OpenAI.Codex' -or $_.Name -eq 'OpenAI.ChatGPT' } | ForEach-Object { $_.InstallLocation }",
-			],
-			{ encoding: "utf-8", timeout: 5_000 },
-		);
-		if (result.status !== 0) return (cachedWindowsAppxInstallRoots = []);
-		return (cachedWindowsAppxInstallRoots = uniquePaths(result.stdout.split(/\r?\n/).map((path) => path.trim())).slice(
-			0,
-			CODEX_APP_PATH_LIMIT,
-		));
+		const result = query
+			? query(WINDOWS_APPX_DISCOVERY_COMMAND)
+			: spawnSync(
+					"powershell.exe",
+					["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", WINDOWS_APPX_DISCOVERY_COMMAND],
+					{ encoding: "utf-8", timeout: 5_000 },
+				);
+		if (result.status !== 0) return query ? [] : (cachedWindowsAppxInstallRoots = []);
+		const roots = uniquePaths(result.stdout.split(/\r?\n/).map((path) => path.trim())).slice(0, CODEX_APP_PATH_LIMIT);
+		return query ? roots : (cachedWindowsAppxInstallRoots = roots);
 	} catch {
-		return (cachedWindowsAppxInstallRoots = []);
+		return query ? [] : (cachedWindowsAppxInstallRoots = []);
 	}
 }
 
@@ -236,7 +243,7 @@ function defaultCodexDesktopAppPaths(platform: NodeJS.Platform = process.platfor
 		const programFilesX86 = readTrimmedEnv("PROGRAMFILES(X86)");
 		return uniquePaths([
 			...overrides,
-			...resolveWindowsAppxInstallRoots(),
+			...resolveWindowsAppxInstallRoots(platform),
 			join(localAppData, "Programs", "OpenAI", "Codex"),
 			join(localAppData, "Programs", "OpenAI", "ChatGPT"),
 			join(localAppData, "OpenAI", "Codex"),
@@ -272,7 +279,7 @@ function defaultCodexDesktopAppPaths(platform: NodeJS.Platform = process.platfor
 }
 
 function codexDesktopResourceRoots(appPath: string, platform: NodeJS.Platform): string[] {
-	const isWindowsPackageParent = platform === "win32" && /[\\/]((?:windowsapps)|(?:packages))$/i.test(appPath);
+	const isWindowsPackageParent = platform === "win32" && /[\\/]((?:windowsapps)|(?:packages))[\\/]*$/i.test(appPath);
 	const roots =
 		platform === "darwin"
 			? [join(appPath, "Contents", "Resources")]

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -174,6 +174,30 @@ function uniquePaths(paths: readonly (string | undefined)[]): string[] {
 	return [...new Set(paths.filter((path): path is string => Boolean(path)))];
 }
 
+let cachedWindowsAppxInstallRoots: string[] | undefined;
+
+function resolveWindowsAppxInstallRoots(): string[] {
+	if (process.platform !== "win32") return [];
+	if (cachedWindowsAppxInstallRoots !== undefined) return cachedWindowsAppxInstallRoots;
+	try {
+		const result = spawnSync(
+			"powershell.exe",
+			[
+				"-NoLogo",
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
+				"Get-AppxPackage | Where-Object { $_.Name -eq 'OpenAI.Codex' -or $_.Name -eq 'OpenAI.ChatGPT' } | ForEach-Object { $_.InstallLocation }",
+			],
+			{ encoding: "utf-8", timeout: 5_000 },
+		);
+		if (result.status !== 0) return (cachedWindowsAppxInstallRoots = []);
+		return (cachedWindowsAppxInstallRoots = uniquePaths(result.stdout.split(/\r?\n/).map((path) => path.trim())));
+	} catch {
+		return (cachedWindowsAppxInstallRoots = []);
+	}
+}
+
 function defaultCodexDesktopAppPaths(platform: NodeJS.Platform = process.platform): readonly string[] {
 	const overrides = [readTrimmedEnv("CODEX_APP_PATH"), readTrimmedEnv("CHATGPT_APP_PATH")];
 	if (platform === "win32") {
@@ -182,6 +206,7 @@ function defaultCodexDesktopAppPaths(platform: NodeJS.Platform = process.platfor
 		const programFilesX86 = readTrimmedEnv("PROGRAMFILES(X86)");
 		return uniquePaths([
 			...overrides,
+			...resolveWindowsAppxInstallRoots(),
 			join(localAppData, "Programs", "OpenAI", "Codex"),
 			join(localAppData, "Programs", "OpenAI", "ChatGPT"),
 			join(localAppData, "OpenAI", "Codex"),
@@ -222,6 +247,7 @@ function codexDesktopResourceRoots(appPath: string, platform: NodeJS.Platform): 
 			? [join(appPath, "Contents", "Resources")]
 			: [
 					join(appPath, "resources"),
+					join(appPath, "app"),
 					join(appPath, "app", "resources"),
 					join(appPath, "Contents", "Resources"),
 					appPath,
@@ -246,7 +272,7 @@ function codexDesktopResourceRoots(appPath: string, platform: NodeJS.Platform): 
 	return uniquePaths(roots);
 }
 
-function codexDesktopNodeCandidates(root: string, depth = 0, platform: NodeJS.Platform = process.platform): string[] {
+function codexDesktopExecutableCandidates(root: string, executableNames: ReadonlySet<string>, depth = 0): string[] {
 	if (depth > CODEX_RUNTIME_SCAN_DEPTH || !existsSync(root)) return [];
 	const candidates: string[] = [];
 	let entries: Dirent[] = [];
@@ -255,18 +281,23 @@ function codexDesktopNodeCandidates(root: string, depth = 0, platform: NodeJS.Pl
 	} catch {
 		return [];
 	}
-	const nodeNames = platform === "win32" ? new Set(["node", "node.exe"]) : new Set(["node"]);
 	for (const entry of entries) {
 		const path = join(root, entry.name);
-		if ((entry.isFile() || entry.isSymbolicLink()) && nodeNames.has(entry.name.toLowerCase())) candidates.push(path);
+		if ((entry.isFile() || entry.isSymbolicLink()) && executableNames.has(entry.name.toLowerCase()))
+			candidates.push(path);
 		try {
 			if (!statSync(path).isDirectory()) continue;
-			candidates.push(...codexDesktopNodeCandidates(path, depth + 1, platform));
+			candidates.push(...codexDesktopExecutableCandidates(path, executableNames, depth + 1));
 		} catch {
 			// Ignore broken symlinks and files that disappear while scanning.
 		}
 	}
 	return candidates;
+}
+
+function codexDesktopNodeCandidates(root: string, depth = 0, platform: NodeJS.Platform = process.platform): string[] {
+	const nodeNames = platform === "win32" ? new Set(["node", "node.exe"]) : new Set(["node"]);
+	return codexDesktopExecutableCandidates(root, nodeNames, depth);
 }
 
 function isUsableNodeRuntime(path: string): boolean {
@@ -300,10 +331,12 @@ export function resolveCodexDesktopNode(
 
 function codexDesktopCliCandidates(appPath: string, platform: NodeJS.Platform = process.platform): string[] {
 	const executableNames = platform === "win32" ? ["codex.exe", "codex.cmd", "codex"] : ["codex"];
+	const names = new Set(executableNames);
 	return uniquePaths(
-		codexDesktopResourceRoots(appPath, platform).flatMap((root) =>
-			executableNames.flatMap((name) => [join(root, name), join(root, "bin", name)]),
-		),
+		codexDesktopResourceRoots(appPath, platform).flatMap((root) => [
+			...executableNames.flatMap((name) => [join(root, name), join(root, "bin", name)]),
+			...codexDesktopExecutableCandidates(root, names),
+		]),
 	);
 }
 
@@ -600,7 +633,7 @@ function shellCommandArg(value: string, platform: NodeJS.Platform = process.plat
 		const escaped = value.replace(/[%^&|<>!"]/g, (character) => {
 			if (character === "%") return "%%";
 			if (character === "!") return "^!";
-			if (character === '"') return '\\"';
+			if (character === '"') return '^"';
 			return `^${character}`;
 		});
 		return `"${escaped}"`;
@@ -659,7 +692,7 @@ function writeWindowsHookWrapper(
 
 	const apiKey = readAuthTokenEnv();
 	const wrapperRoot = join(codexHome, ".tmp", "signet-plugin-marketplace", "runtime");
-	const identity = JSON.stringify({ signetArgs, remoteDaemonUrl, apiKey });
+	const identity = JSON.stringify({ signetArgs, remoteDaemonUrl });
 	const digest = createHash("sha256").update(identity).digest("hex").slice(0, 16);
 	const wrapperPath = join(wrapperRoot, `signet-codex-hook-${digest}.cmd`);
 	mkdirSync(wrapperRoot, { recursive: true });

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
+	opendirSync,
 	readFileSync,
 	readdirSync,
 	rmSync,
@@ -169,9 +170,35 @@ function resolveSignetMcp(runtime: string | null = null): SignetMcpConfig {
 }
 
 const CODEX_RUNTIME_SCAN_DEPTH = 8;
+const CODEX_RUNTIME_SCAN_ENTRY_LIMIT = 4_096;
+const CODEX_PACKAGE_ROOT_SCAN_LIMIT = 4_096;
+const CODEX_APP_PATH_LIMIT = 32;
 
 function uniquePaths(paths: readonly (string | undefined)[]): string[] {
 	return [...new Set(paths.filter((path): path is string => Boolean(path)))];
+}
+
+function readBoundedDirectoryEntries(root: string, limit: number): Dirent[] {
+	if (limit <= 0) return [];
+	let directory: ReturnType<typeof opendirSync> | undefined;
+	const entries: Dirent[] = [];
+	try {
+		directory = opendirSync(root);
+		while (entries.length < limit) {
+			const entry = directory.readSync();
+			if (!entry) break;
+			entries.push(entry);
+		}
+	} catch {
+		return [];
+	} finally {
+		try {
+			directory?.closeSync();
+		} catch {
+			// Ignore directories that disappear or become inaccessible during the scan.
+		}
+	}
+	return entries;
 }
 
 let cachedWindowsAppxInstallRoots: string[] | undefined;
@@ -192,7 +219,10 @@ function resolveWindowsAppxInstallRoots(): string[] {
 			{ encoding: "utf-8", timeout: 5_000 },
 		);
 		if (result.status !== 0) return (cachedWindowsAppxInstallRoots = []);
-		return (cachedWindowsAppxInstallRoots = uniquePaths(result.stdout.split(/\r?\n/).map((path) => path.trim())));
+		return (cachedWindowsAppxInstallRoots = uniquePaths(result.stdout.split(/\r?\n/).map((path) => path.trim())).slice(
+			0,
+			CODEX_APP_PATH_LIMIT,
+		));
 	} catch {
 		return (cachedWindowsAppxInstallRoots = []);
 	}
@@ -242,52 +272,58 @@ function defaultCodexDesktopAppPaths(platform: NodeJS.Platform = process.platfor
 }
 
 function codexDesktopResourceRoots(appPath: string, platform: NodeJS.Platform): string[] {
+	const isWindowsPackageParent = platform === "win32" && /[\\/]((?:windowsapps)|(?:packages))$/i.test(appPath);
 	const roots =
 		platform === "darwin"
 			? [join(appPath, "Contents", "Resources")]
-			: [
-					join(appPath, "resources"),
-					join(appPath, "app"),
-					join(appPath, "app", "resources"),
-					join(appPath, "Contents", "Resources"),
-					appPath,
-				];
-	if (platform === "win32" && /[\\/]((?:windowsapps)|(?:packages))$/i.test(appPath)) {
-		try {
-			for (const entry of readdirSync(appPath, { withFileTypes: true })) {
-				if (entry.isDirectory() && /^OpenAI\.(?:Codex|ChatGPT)(?:[-_.]|$)/i.test(entry.name)) {
-					const packageRoot = join(appPath, entry.name);
-					roots.push(
-						packageRoot,
-						join(packageRoot, "resources"),
-						join(packageRoot, "app", "resources"),
-						join(packageRoot, "Contents", "Resources"),
-					);
-				}
+			: isWindowsPackageParent
+				? []
+				: [
+						join(appPath, "resources"),
+						join(appPath, "app"),
+						join(appPath, "app", "resources"),
+						join(appPath, "Contents", "Resources"),
+						appPath,
+					];
+	if (isWindowsPackageParent) {
+		for (const entry of readBoundedDirectoryEntries(appPath, CODEX_PACKAGE_ROOT_SCAN_LIMIT)) {
+			if (entry.isDirectory() && /^OpenAI\.(?:Codex|ChatGPT)(?:[-_.]|$)/i.test(entry.name)) {
+				const packageRoot = join(appPath, entry.name);
+				roots.push(
+					packageRoot,
+					join(packageRoot, "resources"),
+					join(packageRoot, "app"),
+					join(packageRoot, "app", "resources"),
+					join(packageRoot, "Contents", "Resources"),
+				);
 			}
-		} catch {
-			// WindowsApps is commonly access-restricted; PATH and explicit overrides remain available.
 		}
 	}
 	return uniquePaths(roots);
 }
 
-function codexDesktopExecutableCandidates(root: string, executableNames: ReadonlySet<string>, depth = 0): string[] {
-	if (depth > CODEX_RUNTIME_SCAN_DEPTH || !existsSync(root)) return [];
+interface RuntimeScanBudget {
+	remaining: number;
+}
+
+function codexDesktopExecutableCandidates(
+	root: string,
+	executableNames: ReadonlySet<string>,
+	depth = 0,
+	budget: RuntimeScanBudget = { remaining: CODEX_RUNTIME_SCAN_ENTRY_LIMIT },
+): string[] {
+	if (depth > CODEX_RUNTIME_SCAN_DEPTH || budget.remaining <= 0 || !existsSync(root)) return [];
 	const candidates: string[] = [];
-	let entries: Dirent[] = [];
-	try {
-		entries = readdirSync(root, { withFileTypes: true });
-	} catch {
-		return [];
-	}
+	const entries = readBoundedDirectoryEntries(root, budget.remaining);
 	for (const entry of entries) {
+		if (budget.remaining <= 0) break;
+		budget.remaining -= 1;
 		const path = join(root, entry.name);
 		if ((entry.isFile() || entry.isSymbolicLink()) && executableNames.has(entry.name.toLowerCase()))
 			candidates.push(path);
 		try {
 			if (!statSync(path).isDirectory()) continue;
-			candidates.push(...codexDesktopExecutableCandidates(path, executableNames, depth + 1));
+			candidates.push(...codexDesktopExecutableCandidates(path, executableNames, depth + 1, budget));
 		} catch {
 			// Ignore broken symlinks and files that disappear while scanning.
 		}
@@ -295,9 +331,14 @@ function codexDesktopExecutableCandidates(root: string, executableNames: Readonl
 	return candidates;
 }
 
-function codexDesktopNodeCandidates(root: string, depth = 0, platform: NodeJS.Platform = process.platform): string[] {
+function codexDesktopNodeCandidates(
+	root: string,
+	depth = 0,
+	platform: NodeJS.Platform = process.platform,
+	budget: RuntimeScanBudget = { remaining: CODEX_RUNTIME_SCAN_ENTRY_LIMIT },
+): string[] {
 	const nodeNames = platform === "win32" ? new Set(["node", "node.exe"]) : new Set(["node"]);
-	return codexDesktopExecutableCandidates(root, nodeNames, depth);
+	return codexDesktopExecutableCandidates(root, nodeNames, depth, budget);
 }
 
 function isUsableNodeRuntime(path: string): boolean {
@@ -317,8 +358,9 @@ export function resolveCodexDesktopNode(
 ): string | null {
 	const seen = new Set<string>();
 	for (const appPath of appPaths) {
+		const budget: RuntimeScanBudget = { remaining: CODEX_RUNTIME_SCAN_ENTRY_LIMIT };
 		const candidates = codexDesktopResourceRoots(appPath, platform).flatMap((root) =>
-			codexDesktopNodeCandidates(root, 0, platform),
+			codexDesktopNodeCandidates(root, 0, platform, budget),
 		);
 		for (const candidate of candidates) {
 			if (seen.has(candidate)) continue;
@@ -332,10 +374,11 @@ export function resolveCodexDesktopNode(
 function codexDesktopCliCandidates(appPath: string, platform: NodeJS.Platform = process.platform): string[] {
 	const executableNames = platform === "win32" ? ["codex.exe", "codex.cmd", "codex"] : ["codex"];
 	const names = new Set(executableNames);
+	const budget: RuntimeScanBudget = { remaining: CODEX_RUNTIME_SCAN_ENTRY_LIMIT };
 	return uniquePaths(
 		codexDesktopResourceRoots(appPath, platform).flatMap((root) => [
 			...executableNames.flatMap((name) => [join(root, name), join(root, "bin", name)]),
-			...codexDesktopExecutableCandidates(root, names),
+			...codexDesktopExecutableCandidates(root, names, 0, budget),
 		]),
 	);
 }
@@ -353,10 +396,11 @@ function pathExecutableCandidates(command: string, platform: NodeJS.Platform = p
 function isUsableCodexCli(path: string, platform: NodeJS.Platform = process.platform): boolean {
 	if (!isExistingFile(path)) return false;
 	try {
-		const result = spawnSync(path, ["plugin", "--help"], {
+		const invocation = codexCommandInvocation(path, ["plugin", "--help"], platform);
+		const result = spawnSync(invocation.command, invocation.args, {
 			encoding: "utf-8",
 			timeout: 5_000,
-			shell: platform === "win32" && /\.(?:cmd|bat)$/i.test(path),
+			env: invocation.env,
 		});
 		return result.status === 0 && `${result.stdout ?? ""}${result.stderr ?? ""}`.trim().length > 0;
 	} catch {
@@ -656,6 +700,47 @@ function windowsBatchArg(value: string): string {
 
 function windowsBatchEntrypoint(value: string): string {
 	return /\.(?:cmd|bat)$/i.test(value) ? "call " : "";
+}
+
+function windowsCmdEnvironmentValue(value: string): string {
+	if (value.includes('"')) throw new Error("Windows command arguments cannot contain double quotes");
+	return `"${value}"`;
+}
+
+interface CodexCommandInvocation {
+	readonly command: string;
+	readonly args: string[];
+	readonly env: NodeJS.ProcessEnv;
+}
+
+function codexCommandInvocation(
+	command: string,
+	args: readonly string[],
+	platform: NodeJS.Platform = process.platform,
+	environment: NodeJS.ProcessEnv = process.env,
+): CodexCommandInvocation {
+	if (platform === "win32" && /\.(?:cmd|bat)$/i.test(command)) {
+		// Keep user-controlled paths and arguments out of cmd.exe's command string.
+		// The quoted environment values survive cmd.exe expansion without Node's
+		// Windows argument quoting turning embedded quotes into backslashes.
+		const commandVariable = "SIGNET_CODEX_SHIM_COMMAND";
+		const env: NodeJS.ProcessEnv = {
+			...environment,
+			[commandVariable]: windowsCmdEnvironmentValue(command),
+		};
+		const invocationArgs = ["/d", "/v:off", "/s", "/c", `%SIGNET_CODEX_SHIM_COMMAND%`];
+		for (const [index, arg] of args.entries()) {
+			const argumentVariable = `SIGNET_CODEX_SHIM_ARG_${index}`;
+			env[argumentVariable] = windowsCmdEnvironmentValue(arg);
+			invocationArgs.push(`%${argumentVariable}%`);
+		}
+		return {
+			command: "cmd.exe",
+			args: invocationArgs,
+			env,
+		};
+	}
+	return { command, args: [...args], env: environment };
 }
 
 function readAuthTokenEnv(): string | undefined {
@@ -1259,11 +1344,12 @@ export class CodexConnector extends BaseConnector {
 		const codex = this.resolveCodexCli();
 		if (!codex) return false;
 		try {
-			const result = spawnSync(codex, ["plugin", "--help"], {
+			const env = { ...process.env, CODEX_HOME: this.getCodexHome() };
+			const invocation = codexCommandInvocation(codex, ["plugin", "--help"], process.platform, env);
+			const result = spawnSync(invocation.command, invocation.args, {
 				stdio: "ignore",
 				timeout: 15_000,
-				shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
-				env: { ...process.env, CODEX_HOME: this.getCodexHome() },
+				env: invocation.env,
 			});
 			return result.status === 0 && !result.error;
 		} catch {
@@ -1287,11 +1373,17 @@ export class CodexConnector extends BaseConnector {
 		let marketplaceResult: ReturnType<typeof spawnSync> | null = null;
 		let marketplaceError: unknown = null;
 		try {
-			marketplaceResult = spawnSync(codex, ["plugin", "marketplace", "add", marketplaceRoot], {
+			const env = { ...process.env, CODEX_HOME: codexHome };
+			const invocation = codexCommandInvocation(
+				codex,
+				["plugin", "marketplace", "add", marketplaceRoot],
+				process.platform,
+				env,
+			);
+			marketplaceResult = spawnSync(invocation.command, invocation.args, {
 				encoding: "utf-8",
 				timeout: 15_000,
-				shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
-				env: { ...process.env, CODEX_HOME: codexHome },
+				env: invocation.env,
 			});
 		} catch (error) {
 			marketplaceError = error;
@@ -1316,11 +1408,17 @@ export class CodexConnector extends BaseConnector {
 		let result: ReturnType<typeof spawnSync> | null = null;
 		let installError: unknown = null;
 		try {
-			result = spawnSync(codex, ["plugin", "add", CODEX_PLUGIN_CONFIG_NAME], {
+			const env = { ...process.env, CODEX_HOME: codexHome };
+			const invocation = codexCommandInvocation(
+				codex,
+				["plugin", "add", CODEX_PLUGIN_CONFIG_NAME],
+				process.platform,
+				env,
+			);
+			result = spawnSync(invocation.command, invocation.args, {
 				encoding: "utf-8",
 				timeout: 15_000,
-				shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
-				env: { ...process.env, CODEX_HOME: codexHome },
+				env: invocation.env,
 			});
 		} catch (error) {
 			installError = error;
@@ -1352,15 +1450,23 @@ export class CodexConnector extends BaseConnector {
 	protected removeNativePlugin(codexHome: string): void {
 		const codex = this.resolveCodexCli();
 		if (!codex) return;
-		const options = {
-			stdio: "ignore" as const,
-			timeout: 15_000,
-			shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
-			env: { ...process.env, CODEX_HOME: codexHome },
-		};
+		const env = { ...process.env, CODEX_HOME: codexHome };
+		const options = { stdio: "ignore" as const, timeout: 15_000 };
 		try {
-			spawnSync(codex, ["plugin", "remove", CODEX_PLUGIN_CONFIG_NAME], options);
-			spawnSync(codex, ["plugin", "marketplace", "remove", CODEX_PLUGIN_MARKETPLACE_NAME], options);
+			const removePlugin = codexCommandInvocation(
+				codex,
+				["plugin", "remove", CODEX_PLUGIN_CONFIG_NAME],
+				process.platform,
+				env,
+			);
+			spawnSync(removePlugin.command, removePlugin.args, { ...options, env: removePlugin.env });
+			const removeMarketplace = codexCommandInvocation(
+				codex,
+				["plugin", "marketplace", "remove", CODEX_PLUGIN_MARKETPLACE_NAME],
+				process.platform,
+				env,
+			);
+			spawnSync(removeMarketplace.command, removeMarketplace.args, { ...options, env: removeMarketplace.env });
 		} catch {
 			// Uninstall still removes Signet-owned compatibility state below.
 		}

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -225,7 +225,7 @@ export function resolveWindowsAppxInstallRoots(
 			: spawnSync(
 					"powershell.exe",
 					["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", WINDOWS_APPX_DISCOVERY_COMMAND],
-					{ encoding: "utf-8", timeout: 5_000 },
+					{ encoding: "utf-8", timeout: 1_000 },
 				);
 		if (result.status !== 0) return query ? [] : (cachedWindowsAppxInstallRoots = []);
 		const roots = uniquePaths(result.stdout.split(/\r?\n/).map((path) => path.trim())).slice(0, CODEX_APP_PATH_LIMIT);

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -1,8 +1,17 @@
 import { spawnSyncHidden as spawnSync } from "@signet/core";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+	type Dirent,
+} from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import {
 	BaseConnector,
 	type InstallResult,
@@ -17,7 +26,11 @@ import {
 import { expandHome, resolvePromptSubmitTimeoutMs, resolveSessionStartTimeoutMs } from "@signet/core";
 
 export type SignetMcpConfig =
-	| { readonly command: string; readonly args: readonly string[] }
+	| {
+			readonly command: string;
+			readonly args: readonly string[];
+			readonly env?: Readonly<Record<string, string>>;
+	  }
 	| {
 			readonly url: string;
 			readonly startupTimeoutSec: number;
@@ -28,6 +41,22 @@ export type SignetMcpConfig =
 const CODEX_PLUGIN_MARKETPLACE_NAME = "signet-local";
 const CODEX_PLUGIN_NAME = "signet";
 const CODEX_PLUGIN_CONFIG_NAME = `${CODEX_PLUGIN_NAME}@${CODEX_PLUGIN_MARKETPLACE_NAME}`;
+const CODEX_PLUGIN_VERSION = "0.1.0";
+const CODEX_PLUGIN_DESCRIPTION =
+	"Connect Codex to the local Signet substrate for source-backed recall, sessions, ontology, skills, and scoped note capture.";
+const CODEX_PLUGIN_INTERFACE = {
+	displayName: "Signet",
+	shortDescription: "Source-backed recall and continuity for Codex",
+	longDescription:
+		"Signet connects Codex to local source-backed memory, transcript search, ontology, and explicit note capture without replacing Codex native memory.",
+	developerName: "Signet",
+	category: "Coding",
+	capabilities: ["Read", "Write"],
+	websiteURL: "https://github.com/Signet-AI/signetai",
+	defaultPrompt: ["Recall prior Signet context for this repo"],
+	brandColor: "#2563EB",
+} as const;
+const CODEX_PLUGIN_KEYWORDS = ["signet", "recall", "sources", "sessions", "ontology", "codex"] as const;
 
 interface CodexPluginBundleFile {
 	readonly relativePath: string;
@@ -69,9 +98,48 @@ function resolveSignetEntry(): string | null {
 	return null;
 }
 
+function isExistingFile(path: string): boolean {
+	try {
+		return statSync(path).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function isScriptRuntime(path: string): boolean {
+	if (!isExistingFile(path)) return false;
+	return /^(?:node|bun)(?:\.exe)?$/i.test(basename(path));
+}
+
+function isNativeSignetBinary(path: string): boolean {
+	if (!isExistingFile(path)) return false;
+	return /^(?:signet|signet\.exe)$/i.test(basename(path));
+}
+
+function resolveSignetNativeBinary(): string | null {
+	const wrapperDir = readTrimmedEnv("SIGNET_WRAPPER_DIR");
+	const signetDir = readTrimmedEnv("SIGNET_DIR");
+	const binaryName = process.platform === "win32" ? "signet.exe" : "signet";
+	const roots = [...new Set([wrapperDir, signetDir].filter((root): root is string => Boolean(root)))];
+	const candidates = [
+		readTrimmedEnv("SIGNET_CLI_PATH"),
+		process.execPath,
+		...roots.flatMap((root) => [join(root, "native", binaryName), join(root, "bin", binaryName)]),
+	];
+	for (const candidate of candidates) {
+		if (candidate && isNativeSignetBinary(candidate)) return candidate;
+	}
+	return null;
+}
+
 function resolveSignetArgs(runtime: string | null = null): string[] {
+	const explicitCli = readTrimmedEnv("SIGNET_CLI_PATH");
+	if (explicitCli && isExistingFile(explicitCli)) return [explicitCli];
 	const entry = resolveSignetEntry();
-	if (runtime && entry) return [runtime, entry];
+	const scriptRuntime = runtime ?? (isScriptRuntime(process.execPath) ? process.execPath : null);
+	if (scriptRuntime && entry) return [scriptRuntime, entry];
+	const nativeBinary = resolveSignetNativeBinary();
+	if (nativeBinary) return [nativeBinary];
 	const resolved = resolveSignetCliCommand();
 	return [resolved.command, ...resolved.args];
 }
@@ -91,22 +159,109 @@ function resolveSignetMcp(runtime: string | null = null): SignetMcpConfig {
 	}
 	const entry = resolveSignetEntry();
 	const mcpEntry = entry ? join(dirname(entry), "..", "dist", "mcp-stdio.js") : null;
-	if (runtime && mcpEntry && existsSync(mcpEntry)) return { command: runtime, args: [mcpEntry] };
+	const scriptRuntime = runtime ?? (isScriptRuntime(process.execPath) ? process.execPath : null);
+	if (scriptRuntime && mcpEntry && existsSync(mcpEntry)) return { command: scriptRuntime, args: [mcpEntry] };
+	const nativeBinary = resolveSignetNativeBinary();
+	if (nativeBinary) {
+		return { command: nativeBinary, args: [], env: { SIGNET_MCP_STDIO_WORKER: "1" } };
+	}
 	return resolveSignetMcpCommand();
 }
 
-const CODEX_DESKTOP_APP_PATHS = [join(homedir(), "Applications", "Codex.app"), "/Applications/Codex.app"];
 const CODEX_RUNTIME_SCAN_DEPTH = 8;
 
-function codexDesktopNodeCandidates(root: string, depth = 0): string[] {
+function uniquePaths(paths: readonly (string | undefined)[]): string[] {
+	return [...new Set(paths.filter((path): path is string => Boolean(path)))];
+}
+
+function defaultCodexDesktopAppPaths(platform: NodeJS.Platform = process.platform): readonly string[] {
+	const overrides = [readTrimmedEnv("CODEX_APP_PATH"), readTrimmedEnv("CHATGPT_APP_PATH")];
+	if (platform === "win32") {
+		const localAppData = readTrimmedEnv("LOCALAPPDATA") ?? join(homedir(), "AppData", "Local");
+		const programFiles = readTrimmedEnv("PROGRAMFILES");
+		const programFilesX86 = readTrimmedEnv("PROGRAMFILES(X86)");
+		return uniquePaths([
+			...overrides,
+			join(localAppData, "Programs", "OpenAI", "Codex"),
+			join(localAppData, "Programs", "OpenAI", "ChatGPT"),
+			join(localAppData, "OpenAI", "Codex"),
+			join(localAppData, "OpenAI", "ChatGPT"),
+			programFiles ? join(programFiles, "OpenAI", "Codex") : undefined,
+			programFiles ? join(programFiles, "OpenAI", "ChatGPT") : undefined,
+			programFilesX86 ? join(programFilesX86, "OpenAI", "Codex") : undefined,
+			programFilesX86 ? join(programFilesX86, "OpenAI", "ChatGPT") : undefined,
+			programFiles ? join(programFiles, "WindowsApps") : undefined,
+			programFilesX86 ? join(programFilesX86, "WindowsApps") : undefined,
+			join(localAppData, "Packages"),
+		]);
+	}
+	if (platform === "linux") {
+		return uniquePaths([
+			...overrides,
+			"/usr/lib/chatgpt",
+			"/opt/chatgpt",
+			"/usr/local/lib/chatgpt",
+			join(homedir(), ".local", "share", "chatgpt"),
+			join(homedir(), ".local", "lib", "chatgpt"),
+			"/usr/lib/codex",
+			"/opt/codex",
+		]);
+	}
+	return uniquePaths([
+		...overrides,
+		join(homedir(), "Applications", "Codex.app"),
+		join(homedir(), "Applications", "ChatGPT.app"),
+		"/Applications/Codex.app",
+		"/Applications/ChatGPT.app",
+	]);
+}
+
+function codexDesktopResourceRoots(appPath: string, platform: NodeJS.Platform): string[] {
+	const roots =
+		platform === "darwin"
+			? [join(appPath, "Contents", "Resources")]
+			: [
+					join(appPath, "resources"),
+					join(appPath, "app", "resources"),
+					join(appPath, "Contents", "Resources"),
+					appPath,
+				];
+	if (platform === "win32" && /[\\/]((?:windowsapps)|(?:packages))$/i.test(appPath)) {
+		try {
+			for (const entry of readdirSync(appPath, { withFileTypes: true })) {
+				if (entry.isDirectory() && /^OpenAI\.(?:Codex|ChatGPT)(?:[-_.]|$)/i.test(entry.name)) {
+					const packageRoot = join(appPath, entry.name);
+					roots.push(
+						packageRoot,
+						join(packageRoot, "resources"),
+						join(packageRoot, "app", "resources"),
+						join(packageRoot, "Contents", "Resources"),
+					);
+				}
+			}
+		} catch {
+			// WindowsApps is commonly access-restricted; PATH and explicit overrides remain available.
+		}
+	}
+	return uniquePaths(roots);
+}
+
+function codexDesktopNodeCandidates(root: string, depth = 0, platform: NodeJS.Platform = process.platform): string[] {
 	if (depth > CODEX_RUNTIME_SCAN_DEPTH || !existsSync(root)) return [];
 	const candidates: string[] = [];
-	for (const entry of readdirSync(root, { withFileTypes: true })) {
+	let entries: Dirent[] = [];
+	try {
+		entries = readdirSync(root, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const nodeNames = platform === "win32" ? new Set(["node", "node.exe"]) : new Set(["node"]);
+	for (const entry of entries) {
 		const path = join(root, entry.name);
-		if ((entry.isFile() || entry.isSymbolicLink()) && entry.name === "node") candidates.push(path);
+		if ((entry.isFile() || entry.isSymbolicLink()) && nodeNames.has(entry.name.toLowerCase())) candidates.push(path);
 		try {
 			if (!statSync(path).isDirectory()) continue;
-			candidates.push(...codexDesktopNodeCandidates(path, depth + 1));
+			candidates.push(...codexDesktopNodeCandidates(path, depth + 1, platform));
 		} catch {
 			// Ignore broken symlinks and files that disappear while scanning.
 		}
@@ -125,14 +280,81 @@ function isUsableNodeRuntime(path: string): boolean {
 }
 
 export function resolveCodexDesktopNode(
-	appPaths: readonly string[] = CODEX_DESKTOP_APP_PATHS,
+	appPaths: readonly string[] = defaultCodexDesktopAppPaths(),
 	validate: (path: string) => boolean = isUsableNodeRuntime,
+	platform: NodeJS.Platform = process.platform,
 ): string | null {
+	const seen = new Set<string>();
 	for (const appPath of appPaths) {
-		const candidates = codexDesktopNodeCandidates(join(appPath, "Contents", "Resources"));
+		const candidates = codexDesktopResourceRoots(appPath, platform).flatMap((root) =>
+			codexDesktopNodeCandidates(root, 0, platform),
+		);
 		for (const candidate of candidates) {
+			if (seen.has(candidate)) continue;
+			seen.add(candidate);
 			if (validate(candidate)) return candidate;
 		}
+	}
+	return null;
+}
+
+function codexDesktopCliCandidates(appPath: string, platform: NodeJS.Platform = process.platform): string[] {
+	const executableNames = platform === "win32" ? ["codex.exe", "codex.cmd", "codex"] : ["codex"];
+	return uniquePaths(
+		codexDesktopResourceRoots(appPath, platform).flatMap((root) =>
+			executableNames.flatMap((name) => [join(root, name), join(root, "bin", name)]),
+		),
+	);
+}
+
+function pathExecutableCandidates(command: string, platform: NodeJS.Platform = process.platform): string[] {
+	const commandNames =
+		platform === "win32" ? [command, `${command}.exe`, `${command}.cmd`, `${command}.bat`] : [command];
+	const pathDelimiter = platform === "win32" ? ";" : delimiter;
+	return (process.env.PATH ?? "")
+		.split(pathDelimiter)
+		.filter((directory) => directory.length > 0)
+		.flatMap((directory) => commandNames.map((name) => join(directory, name)));
+}
+
+function isUsableCodexCli(path: string, platform: NodeJS.Platform = process.platform): boolean {
+	if (!isExistingFile(path)) return false;
+	try {
+		const result = spawnSync(path, ["plugin", "--help"], {
+			encoding: "utf-8",
+			timeout: 5_000,
+			shell: platform === "win32" && /\.(?:cmd|bat)$/i.test(path),
+		});
+		return result.status === 0 && `${result.stdout ?? ""}${result.stderr ?? ""}`.trim().length > 0;
+	} catch {
+		return false;
+	}
+}
+
+/** Resolve a plugin-capable Codex executable used for native plugin management.
+ *
+ * ChatGPT.app bundles the same Codex CLI used by the standalone Codex app,
+ * but it is not guaranteed to be exposed as a shell command in every desktop
+ * launch environment. Prefer an explicit override, then bundled app paths,
+ * then the user's PATH so Work/Codex mode and the standalone CLI share one
+ * install path.
+ */
+export function resolveCodexCli(
+	appPaths: readonly string[] = defaultCodexDesktopAppPaths(),
+	validate: (path: string) => boolean = isUsableCodexCli,
+	platform: NodeJS.Platform = process.platform,
+): string | null {
+	const explicit = readTrimmedEnv("CODEX_CLI_PATH");
+	const candidates = [
+		explicit,
+		...appPaths.flatMap((appPath) => codexDesktopCliCandidates(appPath, platform)),
+		...pathExecutableCandidates("codex", platform),
+	].filter((candidate): candidate is string => Boolean(candidate));
+	const seen = new Set<string>();
+	for (const candidate of candidates) {
+		if (seen.has(candidate)) continue;
+		seen.add(candidate);
+		if (validate(candidate)) return candidate;
 	}
 	return null;
 }
@@ -145,8 +367,9 @@ function codexPluginBundleFiles(
 	signetArgs: readonly string[],
 	mcp: SignetMcpConfig,
 	remoteDaemonUrl: string | null,
+	windowsHookCommand: string | null,
 ): CodexPluginBundleFile[] {
-	const hookFile = buildHooksFile([...signetArgs], remoteDaemonUrl);
+	const hookFile = buildHooksFile([...signetArgs], remoteDaemonUrl, windowsHookCommand);
 	const mcpServer =
 		"url" in mcp
 			? {
@@ -158,7 +381,18 @@ function codexPluginBundleFiles(
 			: {
 					command: mcp.command,
 					args: mcp.args,
+					...(mcp.env ? { env: mcp.env } : {}),
 				};
+	const pluginMetadata = {
+		name: CODEX_PLUGIN_NAME,
+		version: CODEX_PLUGIN_VERSION,
+		description: CODEX_PLUGIN_DESCRIPTION,
+		author: { name: "Signet" },
+		homepage: "https://github.com/Signet-AI/signetai",
+		repository: "https://github.com/Signet-AI/signetai",
+		license: "Apache-2.0",
+		keywords: CODEX_PLUGIN_KEYWORDS,
+	};
 	return [
 		{
 			relativePath: ".agents/plugins/marketplace.json",
@@ -170,7 +404,7 @@ function codexPluginBundleFiles(
 						{
 							name: CODEX_PLUGIN_NAME,
 							source: { source: "local", path: `./plugins/${CODEX_PLUGIN_NAME}` },
-							policy: { installation: "AVAILABLE" },
+							policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
 							category: "Coding",
 						},
 					],
@@ -183,30 +417,10 @@ function codexPluginBundleFiles(
 			relativePath: `plugins/${CODEX_PLUGIN_NAME}/.codex-plugin/plugin.json`,
 			content: `${JSON.stringify(
 				{
-					name: CODEX_PLUGIN_NAME,
-					version: "0.1.0",
-					description:
-						"Connect Codex to the local Signet substrate for source-backed recall, sessions, ontology, skills, and scoped note capture.",
-					author: { name: "Signet" },
-					homepage: "https://github.com/Signet-AI/signetai",
-					repository: "https://github.com/Signet-AI/signetai",
-					license: "Apache-2.0",
-					keywords: ["signet", "recall", "sources", "sessions", "ontology", "codex"],
+					...pluginMetadata,
 					skills: "./skills/",
 					mcpServers: "./.mcp.json",
-					hooks: "./hooks/hooks.json",
-					interface: {
-						displayName: "Signet",
-						shortDescription: "Source-backed recall and continuity for Codex",
-						longDescription:
-							"Signet connects Codex to local source-backed memory, transcript search, ontology, and explicit note capture without replacing Codex native memory.",
-						developerName: "Signet",
-						category: "Coding",
-						capabilities: ["Read", "Write"],
-						websiteURL: "https://github.com/Signet-AI/signetai",
-						defaultPrompt: ["Recall prior Signet context for this repo"],
-						brandColor: "#2563EB",
-					},
+					interface: CODEX_PLUGIN_INTERFACE,
 				},
 				null,
 				2,
@@ -286,20 +500,29 @@ export function writeCodexPluginBundle(input: {
 	readonly signetArgs?: readonly string[];
 	readonly mcp?: SignetMcpConfig;
 	readonly remoteDaemonUrl?: string | null;
+	readonly windowsHookCommand?: string | null;
 }): CodexPluginBundleResult {
 	const marketplaceRoot = join(input.codexHome, ".tmp", "signet-plugin-marketplace");
 	const pluginRoot = join(marketplaceRoot, "plugins", CODEX_PLUGIN_NAME);
 	const filesWritten: string[] = [];
+	const signetArgs = input.signetArgs ?? resolveSignetArgs();
+	const remoteDaemonUrl = input.remoteDaemonUrl ?? resolveRemoteDaemonUrl();
+	const windowsHookCommand =
+		input.windowsHookCommand === undefined
+			? writeWindowsHookWrapper(input.codexHome, signetArgs, remoteDaemonUrl)
+			: input.windowsHookCommand;
 	for (const file of codexPluginBundleFiles(
-		input.signetArgs ?? resolveSignetArgs(),
+		signetArgs,
 		input.mcp ?? resolveSignetMcp(),
-		input.remoteDaemonUrl ?? resolveRemoteDaemonUrl(),
+		remoteDaemonUrl,
+		windowsHookCommand,
 	)) {
 		const path = join(marketplaceRoot, file.relativePath);
 		mkdirSync(join(path, ".."), { recursive: true });
 		writeFileSync(path, file.content, "utf-8");
 		filesWritten.push(path);
 	}
+	if (windowsHookCommand && !filesWritten.includes(windowsHookCommand)) filesWritten.push(windowsHookCommand);
 	return { marketplaceRoot, pluginRoot, filesWritten };
 }
 
@@ -312,6 +535,7 @@ export function writeCodexPluginBundle(input: {
 //     "hooks": {
 //       "SessionStart": [{ "hooks": [{ "type": "command", "command": "...", "timeout": N }] }],
 //       "UserPromptSubmit": [...],
+//       "PreToolUse": [...],
 //       "Stop": [...]
 //     }
 //   }
@@ -334,6 +558,7 @@ interface MatcherGroup {
 interface HandlerConfig {
 	type: "command";
 	command: string;
+	commandWindows?: string;
 	timeout?: number;
 }
 
@@ -369,18 +594,49 @@ function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+function shellCommandArg(value: string, platform: NodeJS.Platform = process.platform): string {
+	if (/^[A-Za-z0-9_./\\:@+=,-]+$/.test(value)) return value;
+	if (platform === "win32") {
+		const escaped = value.replace(/[%^&|<>!"]/g, (character) => {
+			if (character === "%") return "%%";
+			if (character === "!") return "^!";
+			if (character === '"') return '\\"';
+			return `^${character}`;
+		});
+		return `"${escaped}"`;
+	}
+	return shellQuote(value);
+}
+
 function cmdEnvQuote(value: string): string {
-	return value.replace(/[\^"&|<>]/g, "^$&");
+	return value.replace(/[%^"&|<>!]/g, (character) => {
+		if (character === "%") return "%%";
+		if (character === "!") return "^!";
+		return `^${character}`;
+	});
+}
+
+function windowsBatchArg(value: string): string {
+	if (/^[A-Za-z0-9_./\\:@+=,-]+$/.test(value)) return value;
+	return `"${cmdEnvQuote(value)}"`;
+}
+
+function windowsBatchEntrypoint(value: string): string {
+	return /\.(?:cmd|bat)$/i.test(value) ? "call " : "";
 }
 
 function readAuthTokenEnv(): string | undefined {
 	return resolveSignetApiKey();
 }
 
-function withRemoteDaemonEnv(command: string, remoteDaemonUrl: string | null): string {
+function withRemoteDaemonEnv(
+	command: string,
+	remoteDaemonUrl: string | null,
+	platform: NodeJS.Platform = process.platform,
+): string {
 	const apiKey = readAuthTokenEnv();
 	if (!remoteDaemonUrl && !apiKey) return command;
-	if (process.platform === "win32") {
+	if (platform === "win32") {
 		const vars = [
 			...(remoteDaemonUrl ? [`set "SIGNET_DAEMON_URL=${cmdEnvQuote(remoteDaemonUrl)}"`] : []),
 			...(apiKey ? [`set "SIGNET_API_KEY=${cmdEnvQuote(apiKey)}"`] : []),
@@ -394,29 +650,77 @@ function withRemoteDaemonEnv(command: string, remoteDaemonUrl: string | null): s
 	].join(" ");
 }
 
+function writeWindowsHookWrapper(
+	codexHome: string,
+	signetArgs: readonly string[],
+	remoteDaemonUrl: string | null,
+): string | null {
+	if (process.platform !== "win32") return null;
+
+	const apiKey = readAuthTokenEnv();
+	const wrapperRoot = join(codexHome, ".tmp", "signet-plugin-marketplace", "runtime");
+	const identity = JSON.stringify({ signetArgs, remoteDaemonUrl, apiKey });
+	const digest = createHash("sha256").update(identity).digest("hex").slice(0, 16);
+	const wrapperPath = join(wrapperRoot, `signet-codex-hook-${digest}.cmd`);
+	mkdirSync(wrapperRoot, { recursive: true });
+	try {
+		for (const entry of readdirSync(wrapperRoot, { withFileTypes: true })) {
+			if (
+				entry.isFile() &&
+				/^signet-codex-hook-[0-9a-f]{16}\.cmd$/i.test(entry.name) &&
+				entry.name !== basename(wrapperPath)
+			) {
+				rmSync(join(wrapperRoot, entry.name), { force: true });
+			}
+		}
+	} catch {
+		// The current wrapper is still usable if an older generated wrapper cannot be removed.
+	}
+
+	const lines = ["@echo off", "setlocal"];
+	if (remoteDaemonUrl) lines.push(`set "SIGNET_DAEMON_URL=${cmdEnvQuote(remoteDaemonUrl)}"`);
+	if (apiKey) lines.push(`set "SIGNET_API_KEY=${cmdEnvQuote(apiKey)}"`);
+	const invocation = signetArgs.map(windowsBatchArg).join(" ");
+	lines.push(`${windowsBatchEntrypoint(signetArgs[0] ?? "")}${invocation} %*`);
+	lines.push("exit /b %ERRORLEVEL%", "");
+	writeFileSync(wrapperPath, `${lines.join("\r\n")}`, "utf-8");
+	return wrapperPath;
+}
+
 export function buildHooksFile(
 	signetArgs: string[],
 	remoteDaemonUrl: string | null = resolveRemoteDaemonUrl(),
+	windowsHookCommand: string | null = null,
+	platform: NodeJS.Platform = process.platform,
 ): HooksFile {
-	const cmd = (
-		subcommand: string,
-		secs: number,
-		codexJson = true,
-		extraArgs: readonly string[] = [],
-	): MatcherGroup => ({
-		hooks: [
-			{
-				type: "command",
-				command: withRemoteDaemonEnv(
-					[...signetArgs, "hook", subcommand, "-H", "codex", ...extraArgs, ...(codexJson ? ["--codex-json"] : [])].join(
-						" ",
-					),
-					remoteDaemonUrl,
-				),
-				timeout: secs,
-			},
-		],
-	});
+	const cmd = (subcommand: string, secs: number, codexJson = true, extraArgs: readonly string[] = []): MatcherGroup => {
+		const hookArgs = ["hook", subcommand, "-H", "codex", ...extraArgs, ...(codexJson ? ["--codex-json"] : [])];
+		const args = [...signetArgs, ...hookArgs];
+		const command = withRemoteDaemonEnv(
+			args.map((arg) => shellCommandArg(arg, platform)).join(" "),
+			remoteDaemonUrl,
+			platform,
+		);
+		const commandWindows =
+			platform === "win32"
+				? windowsHookCommand
+					? [
+							shellCommandArg(windowsHookCommand, "win32"),
+							...hookArgs.map((arg) => shellCommandArg(arg, "win32")),
+						].join(" ")
+					: withRemoteDaemonEnv(args.map((arg) => shellCommandArg(arg, "win32")).join(" "), remoteDaemonUrl, "win32")
+				: undefined;
+		return {
+			hooks: [
+				{
+					type: "command",
+					command,
+					...(commandWindows ? { commandWindows } : {}),
+					timeout: secs,
+				},
+			],
+		};
+	};
 	return {
 		hooks: {
 			SessionStart: [cmd("session-start", resolveCodexSessionStartTimeoutSeconds())],
@@ -448,7 +752,7 @@ function writeHooksFile(path: string, file: HooksFile): void {
 	atomicWriteJson(path, file);
 }
 
-const SIGNET_HOOK_SUBCOMMANDS = ["session-start", "user-prompt-submit", "session-end"] as const;
+const SIGNET_HOOK_SUBCOMMANDS = ["session-start", "user-prompt-submit", "notifications", "session-end"] as const;
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -468,6 +772,15 @@ function isSignetHookCommand(cmd: string): boolean {
 		const quotedBare = new RegExp(`^["'][^"']*[\\\\/]signet(?:\\.(?:cmd|ps1|bat|exe))?["']\\s+${hook}`, "i");
 		if (quotedBare.test(normalized)) return true;
 
+		const absoluteBinary = new RegExp(`^(?:[^\\s"']*[\\\\/]signet(?:\\.(?:cmd|ps1|bat|exe))?)\\s+${hook}`, "i");
+		if (absoluteBinary.test(normalized)) return true;
+
+		const windowsWrapper = new RegExp(
+			`^(?:"[^"]*[\\\\/]signet-codex-hook-[^"]+\\.cmd"|'[^']*[\\\\/]signet-codex-hook-[^']+\\.cmd'|\\S*[\\\\/]signet-codex-hook-[^\\s]+\\.cmd)\\s+${hook}`,
+			"i",
+		);
+		if (windowsWrapper.test(normalized)) return true;
+
 		const nodeShim = new RegExp(
 			`^(?:"[^"]*[\\\\/]?node(?:\\.exe)?"|'[^']*[\\\\/]?node(?:\\.exe)?'|\\S*[\\\\/]?node(?:\\.exe)?)\\s+(?:"[^"]*[\\\\/]signet\\.js"|'[^']*[\\\\/]signet\\.js'|\\S*[\\\\/]signet\\.js)\\s+${hook}`,
 			"i",
@@ -476,22 +789,40 @@ function isSignetHookCommand(cmd: string): boolean {
 	});
 }
 
+function isSignetHookHandler(handler: unknown): handler is HandlerConfig {
+	if (typeof handler !== "object" || handler === null) return false;
+	const record = handler as Record<string, unknown>;
+	return [record.command, record.commandWindows].some(
+		(command): command is string => typeof command === "string" && isSignetHookCommand(command),
+	);
+}
+
+function isLegacySignetHookHandler(handler: unknown): boolean {
+	if (typeof handler !== "object" || handler === null) return false;
+	const command = (handler as Record<string, unknown>).command;
+	return Array.isArray(command) && isSignetHookCommand(command.join(" "));
+}
+
 function isSignetMatcherGroup(group: unknown): boolean {
 	if (typeof group !== "object" || group === null) return false;
 	const hooksArr = (group as Record<string, unknown>).hooks;
 	if (!Array.isArray(hooksArr)) return false;
-	for (const handler of hooksArr) {
-		if (typeof handler !== "object" || handler === null) continue;
-		const cmd = (handler as Record<string, unknown>).command;
-		if (typeof cmd !== "string") continue;
-		if (isSignetHookCommand(cmd)) return true;
-	}
-	return false;
+	return hooksArr.some(isSignetHookHandler);
 }
 
-function hasMissingNodeRuntime(command: string): boolean {
-	const node = command.match(/(?:^|\s)(['"]?)([^'"\s]*[\\/]node(?:\.exe)?)(?:\1)(?=\s|$)/i)?.[2];
-	return Boolean(node && !existsSync(node));
+function commandExecutable(command: string): string | null {
+	let normalized = command.trim();
+	for (let i = 0; i < 2; i++) {
+		normalized = normalized.replace(/^(?:SIGNET_DAEMON_URL|SIGNET_API_KEY)=(?:'[^']*'|"[^"]*"|\S+)\s+/i, "");
+		normalized = normalized.replace(/^set "(?:SIGNET_DAEMON_URL|SIGNET_API_KEY)=[^"]*" && /i, "");
+	}
+	const match = normalized.match(/^(?:"([^"]+)"|'([^']+)'|(\S+))/);
+	return match?.[1] ?? match?.[2] ?? match?.[3] ?? null;
+}
+
+function hasMissingRuntime(command: string): boolean {
+	const executable = commandExecutable(command);
+	return Boolean(executable && /[\\/]/.test(executable) && !existsSync(executable));
 }
 
 function hasMissingSignetRuntime(file: HooksFile | null, configPath: string): boolean {
@@ -500,12 +831,10 @@ function hasMissingSignetRuntime(file: HooksFile | null, configPath: string): bo
 		for (const group of groups) {
 			if (typeof group !== "object" || group === null || !Array.isArray(group.hooks)) continue;
 			for (const handler of group.hooks) {
-				if (
-					typeof handler?.command === "string" &&
-					isSignetHookCommand(handler.command) &&
-					hasMissingNodeRuntime(handler.command)
-				) {
-					return true;
+				for (const command of [handler?.command, handler?.commandWindows]) {
+					if (typeof command === "string" && isSignetHookCommand(command) && hasMissingRuntime(command)) {
+						return true;
+					}
 				}
 			}
 		}
@@ -522,7 +851,7 @@ function hasMissingSignetRuntime(file: HooksFile | null, configPath: string): bo
 		if (inSignetMcpSection && trimmed.startsWith("[")) break;
 		if (!inSignetMcpSection) continue;
 		const command = trimmed.match(/^command\s*=\s*['"]([^'"]+)['"]/)?.[1];
-		if (typeof command === "string") return hasMissingNodeRuntime(command);
+		if (typeof command === "string") return hasMissingRuntime(command);
 	}
 	return false;
 }
@@ -531,15 +860,26 @@ function isLegacySignetMatcherGroup(group: unknown): boolean {
 	if (typeof group !== "object" || group === null) return false;
 	const handlers = (group as Record<string, unknown>).handlers;
 	if (!Array.isArray(handlers)) return false;
-	for (const handler of handlers) {
-		if (typeof handler !== "object" || handler === null) continue;
-		const cmd = (handler as Record<string, unknown>).command;
-		if (Array.isArray(cmd)) {
-			const joined = cmd.join(" ");
-			if (isSignetHookCommand(joined)) return true;
-		}
-	}
-	return false;
+	return handlers.some(isLegacySignetHookHandler);
+}
+
+function removeSignetHandlersFromGroup(group: unknown): unknown | null {
+	if (typeof group !== "object" || group === null) return group;
+	const record = group as Record<string, unknown>;
+	const hooks = Array.isArray(record.hooks) ? record.hooks : null;
+	const legacyHandlers = Array.isArray(record.handlers) ? record.handlers : null;
+	if (!hooks && !legacyHandlers && !Object.hasOwn(record, "_signet")) return group;
+
+	const remainingHooks = hooks ? hooks.filter((handler) => !isSignetHookHandler(handler)) : null;
+	const remainingLegacyHandlers = legacyHandlers
+		? legacyHandlers.filter((handler) => !isLegacySignetHookHandler(handler))
+		: null;
+	if ((remainingHooks?.length ?? 0) + (remainingLegacyHandlers?.length ?? 0) === 0) return null;
+
+	const { _signet: _legacyGroupMarker, ...withoutMarker } = record;
+	if (hooks) withoutMarker.hooks = remainingHooks;
+	if (legacyHandlers) withoutMarker.handlers = remainingLegacyHandlers;
+	return withoutMarker as unknown as MatcherGroup;
 }
 
 function removeSignetEntries(file: HooksFile): HooksFile {
@@ -551,13 +891,7 @@ function removeSignetEntries(file: HooksFile): HooksFile {
 	for (const key of Object.keys(events)) {
 		const groups = events[key];
 		if (!Array.isArray(groups)) continue;
-		const filtered = groups
-			.filter((g) => !isSignetMatcherGroup(g) && !isLegacySignetMatcherGroup(g))
-			.map((group) => {
-				if (typeof group !== "object" || group === null) return group;
-				const { _signet: _legacyGroupMarker, ...preserved } = group as MatcherGroup & Record<string, unknown>;
-				return preserved as MatcherGroup;
-			});
+		const filtered = groups.map(removeSignetHandlersFromGroup).filter((group): group is MatcherGroup => group !== null);
 		if (filtered.length === 0) {
 			delete events[key];
 		} else {
@@ -587,12 +921,13 @@ function canonicalJson(value: unknown): unknown {
 }
 
 function codexHookHash(eventName: (typeof HOOK_EVENT_KEYS)[number], handler: HandlerConfig): string {
+	const command = process.platform === "win32" ? (handler.commandWindows ?? handler.command) : handler.command;
 	const identity = {
 		event_name: CODEX_HOOK_EVENT_LABELS[eventName],
 		hooks: [
 			{
 				type: "command",
-				command: handler.command,
+				command,
 				timeout: Math.max(handler.timeout ?? 600, 1),
 				async: false,
 			},
@@ -613,6 +948,7 @@ function buildHookTrustEntries(hooksPath: string, file: HooksFile): HookTrustEnt
 		for (const [groupIndex, group] of groups.entries()) {
 			if (!isSignetMatcherGroup(group)) continue;
 			for (const [handlerIndex, handler] of group.hooks.entries()) {
+				if (!isSignetHookHandler(handler)) continue;
 				entries.push({
 					key: `${hooksPath}:${CODEX_HOOK_EVENT_LABELS[eventName]}:${groupIndex}:${handlerIndex}`,
 					trustedHash: codexHookHash(eventName, handler),
@@ -749,6 +1085,13 @@ export function buildMcpBlock(mcp: SignetMcpConfig): string {
 	if (mcp.args.length > 0) {
 		block += `args = ${tomlInlineArray(mcp.args)}\n`;
 	}
+	if (mcp.env && Object.keys(mcp.env).length > 0) {
+		block += `\n[mcp_servers.signet.env]\n`;
+		block += Object.entries(mcp.env)
+			.map(([key, value]) => `${key} = ${tomlQuote(value)}`)
+			.join("\n");
+		block += "\n";
+	}
 	return block;
 }
 
@@ -819,15 +1162,19 @@ function unpatchConfigToml(path: string): boolean {
 
 function removeTomlSection(content: string, header: string): string {
 	if (!content.includes(header)) return content;
+	const sectionName = header.slice(1, -1);
 	const lines = content.split("\n");
 	const filtered: string[] = [];
 	let inSection = false;
 	for (const line of lines) {
-		if (line.trim() === header) {
+		const trimmed = line.trim();
+		if (trimmed === header) {
 			inSection = true;
 			continue;
 		}
-		if (inSection && line.match(/^\s*\[/)) {
+		if (inSection && trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			const candidate = trimmed.slice(1, -1);
+			if (candidate === sectionName || candidate.startsWith(`${sectionName}.`)) continue;
 			inSection = false;
 		}
 		if (!inSection) filtered.push(line);
@@ -836,29 +1183,6 @@ function removeTomlSection(content: string, header: string): string {
 		.join("\n")
 		.replace(/\n{3,}/g, "\n\n")
 		.trimEnd()}\n`;
-}
-
-function patchNativePluginConfig(path: string, marketplaceRoot: string): boolean {
-	mkdirSync(join(path, ".."), { recursive: true });
-	const marketplaceHeader = `[marketplaces.${CODEX_PLUGIN_MARKETPLACE_NAME}]`;
-	const pluginHeader = `[plugins."${CODEX_PLUGIN_CONFIG_NAME}"]`;
-	const marketplaceBlock = [
-		marketplaceHeader,
-		'last_updated = "1970-01-01T00:00:00Z"',
-		'source_type = "local"',
-		`source = ${tomlQuote(marketplaceRoot)}`,
-		"",
-		pluginHeader,
-		"enabled = true",
-		"",
-	].join("\n");
-	const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
-	let cleaned = removeTomlSection(removeTomlSection(existing, marketplaceHeader), pluginHeader);
-	cleaned = cleaned.trimEnd();
-	const updated = `${cleaned.length > 0 ? `${cleaned}\n\n` : ""}${marketplaceBlock}`;
-	if (updated === existing) return false;
-	writeFileSync(path, updated);
-	return true;
 }
 
 function unpatchNativePluginConfig(path: string): boolean {
@@ -881,41 +1205,108 @@ export class CodexConnector extends BaseConnector {
 	readonly harnessId = "codex";
 
 	protected getCodexHome(): string {
-		return join(homedir(), ".codex");
+		const configured = readTrimmedEnv("CODEX_HOME");
+		return configured ? expandHome(configured) : join(homedir(), ".codex");
 	}
 
 	protected getCodexDesktopAppPaths(): readonly string[] {
-		return CODEX_DESKTOP_APP_PATHS;
+		return defaultCodexDesktopAppPaths();
 	}
 
 	protected resolveCodexDesktopNode(): string | null {
 		return resolveCodexDesktopNode(this.getCodexDesktopAppPaths());
 	}
 
+	protected resolveCodexCli(): string | null {
+		return resolveCodexCli(this.getCodexDesktopAppPaths());
+	}
+
 	protected supportsNativePluginInstall(): boolean {
 		if (readTrimmedEnv("SIGNET_CODEX_DISABLE_NATIVE_PLUGIN") === "1") return false;
-		const result = spawnSync("codex", ["plugin", "--help"], {
-			stdio: "ignore",
-			env: { ...process.env, CODEX_HOME: this.getCodexHome() },
-		});
-		return result.status === 0;
+		const codex = this.resolveCodexCli();
+		if (!codex) return false;
+		try {
+			const result = spawnSync(codex, ["plugin", "--help"], {
+				stdio: "ignore",
+				timeout: 15_000,
+				shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
+				env: { ...process.env, CODEX_HOME: this.getCodexHome() },
+			});
+			return result.status === 0 && !result.error;
+		} catch {
+			return false;
+		}
 	}
 
 	protected nativePluginProvidesHooks(): boolean {
 		return readTrimmedEnv("SIGNET_CODEX_FORCE_COMPAT_HOOKS") !== "1";
 	}
 
-	protected installNativePlugin(codexHome: string): NativePluginCommandResult {
-		const result = spawnSync("codex", ["plugin", "add", CODEX_PLUGIN_CONFIG_NAME], {
-			encoding: "utf-8",
-			env: { ...process.env, CODEX_HOME: codexHome },
-		});
-		const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-		if (result.status !== 0) {
+	protected installNativePlugin(codexHome: string, marketplaceRoot: string): NativePluginCommandResult {
+		const codex = this.resolveCodexCli();
+		if (!codex) {
 			return {
 				success: false,
 				filesWritten: [],
-				warning: `Codex native plugin install failed; falling back to compatibility hooks/MCP: ${output.trim()}`,
+				warning: "Codex native plugin install skipped because no usable Codex executable was found",
+			};
+		}
+		let marketplaceResult: ReturnType<typeof spawnSync> | null = null;
+		let marketplaceError: unknown = null;
+		try {
+			marketplaceResult = spawnSync(codex, ["plugin", "marketplace", "add", marketplaceRoot], {
+				encoding: "utf-8",
+				timeout: 15_000,
+				shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
+				env: { ...process.env, CODEX_HOME: codexHome },
+			});
+		} catch (error) {
+			marketplaceError = error;
+		}
+		if (marketplaceError || !marketplaceResult) {
+			return {
+				success: false,
+				filesWritten: [],
+				warning: `Codex native plugin marketplace registration failed; falling back to compatibility hooks/MCP: ${String(marketplaceError ?? "command did not return a result")}`,
+			};
+		}
+		const marketplaceOutput = `${marketplaceResult.stdout ?? ""}\n${marketplaceResult.stderr ?? ""}`;
+		if (marketplaceResult.status !== 0 || marketplaceResult.error) {
+			return {
+				success: false,
+				filesWritten: [],
+				warning: `Codex native plugin marketplace registration failed; falling back to compatibility hooks/MCP: ${
+					marketplaceResult.error?.message ?? (marketplaceOutput.trim() || "command timed out")
+				}`,
+			};
+		}
+		let result: ReturnType<typeof spawnSync> | null = null;
+		let installError: unknown = null;
+		try {
+			result = spawnSync(codex, ["plugin", "add", CODEX_PLUGIN_CONFIG_NAME], {
+				encoding: "utf-8",
+				timeout: 15_000,
+				shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
+				env: { ...process.env, CODEX_HOME: codexHome },
+			});
+		} catch (error) {
+			installError = error;
+		}
+		if (installError || !result) {
+			return {
+				success: false,
+				filesWritten: [],
+				warning: `Codex native plugin install failed; falling back to compatibility hooks/MCP: ${String(installError ?? "command did not return a result")}`,
+			};
+		}
+		const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+		if (result.status !== 0 || result.error) {
+			return {
+				success: false,
+				filesWritten: [],
+				warning: `Codex native plugin install failed; falling back to compatibility hooks/MCP: ${
+					result.error?.message ?? (output.trim() || "command timed out")
+				}`,
 			};
 		}
 		const installedRoot = output.match(/Installed plugin root:\s*(.+)/)?.[1]?.trim();
@@ -926,10 +1317,20 @@ export class CodexConnector extends BaseConnector {
 	}
 
 	protected removeNativePlugin(codexHome: string): void {
-		spawnSync("codex", ["plugin", "remove", CODEX_PLUGIN_CONFIG_NAME], {
-			stdio: "ignore",
+		const codex = this.resolveCodexCli();
+		if (!codex) return;
+		const options = {
+			stdio: "ignore" as const,
+			timeout: 15_000,
+			shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(codex),
 			env: { ...process.env, CODEX_HOME: codexHome },
-		});
+		};
+		try {
+			spawnSync(codex, ["plugin", "remove", CODEX_PLUGIN_CONFIG_NAME], options);
+			spawnSync(codex, ["plugin", "marketplace", "remove", CODEX_PLUGIN_MARKETPLACE_NAME], options);
+		} catch {
+			// Uninstall still removes Signet-owned compatibility state below.
+		}
 	}
 
 	private getHooksJsonPath(): string {
@@ -945,6 +1346,7 @@ export class CodexConnector extends BaseConnector {
 		filesWritten: string[],
 		configsPatched: string[],
 		warnings: string[],
+		windowsHookCommand: string | null = null,
 	): void {
 		const hooksPath = this.getHooksJsonPath();
 		const existing = readHooksFile(hooksPath);
@@ -954,7 +1356,7 @@ export class CodexConnector extends BaseConnector {
 			const cleaned = removeSignetEntries(migrated);
 			const hasHooks = cleaned.hooks && Object.keys(cleaned.hooks).length > 0;
 			if (hasHooks) {
-				const signet = buildHooksFile(signetArgs);
+				const signet = buildHooksFile(signetArgs, resolveRemoteDaemonUrl(), windowsHookCommand);
 				const merged: HooksFile = { ...cleaned };
 				merged.hooks = { ...(cleaned.hooks as Record<string, MatcherGroup[]>) };
 				for (const key of HOOK_EVENT_KEYS) {
@@ -965,11 +1367,11 @@ export class CodexConnector extends BaseConnector {
 				writeHooksFile(hooksPath, merged);
 				warnings.push("Merged Signet hooks into existing hooks.json — existing hooks preserved");
 			} else {
-				const signet = buildHooksFile(signetArgs);
+				const signet = buildHooksFile(signetArgs, resolveRemoteDaemonUrl(), windowsHookCommand);
 				writeHooksFile(hooksPath, { ...cleaned, hooks: signet.hooks });
 			}
 		} else {
-			writeHooksFile(hooksPath, buildHooksFile(signetArgs));
+			writeHooksFile(hooksPath, buildHooksFile(signetArgs, resolveRemoteDaemonUrl(), windowsHookCommand));
 		}
 		filesWritten.push(hooksPath);
 
@@ -1035,6 +1437,8 @@ export class CodexConnector extends BaseConnector {
 		const staleRuntime = hasMissingSignetRuntime(readHooksFile(this.getHooksJsonPath()), configPath);
 		const runtime = this.resolveCodexDesktopNode();
 		const signetArgs = resolveSignetArgs(runtime);
+		const remoteDaemonUrl = resolveRemoteDaemonUrl();
+		const windowsHookCommand = writeWindowsHookWrapper(codexHome, signetArgs, remoteDaemonUrl);
 		const mcp = resolveSignetMcp(runtime);
 		if (staleRuntime) {
 			warnings.push(
@@ -1050,26 +1454,28 @@ export class CodexConnector extends BaseConnector {
 				codexHome,
 				signetArgs,
 				mcp,
-				remoteDaemonUrl: resolveRemoteDaemonUrl(),
+				remoteDaemonUrl,
+				windowsHookCommand,
 			});
 			filesWritten.push(...bundle.filesWritten);
-			if (patchNativePluginConfig(this.getConfigPath(), bundle.marketplaceRoot)) {
-				configsPatched.push(this.getConfigPath());
-			}
 			if (unpatchConfigToml(this.getConfigPath()) && !configsPatched.includes(this.getConfigPath())) {
 				configsPatched.push(this.getConfigPath());
 			}
-			const pluginInstall = this.installNativePlugin(codexHome);
+			const pluginInstall = this.installNativePlugin(codexHome, bundle.marketplaceRoot);
 			filesWritten.push(...pluginInstall.filesWritten);
 			if (pluginInstall.warning) warnings.push(pluginInstall.warning);
 			if (pluginInstall.success) {
-				if (patchConfigToml(this.getConfigPath(), mcp) && !configsPatched.includes(this.getConfigPath())) {
+				if (
+					existsSync(this.getConfigPath()) &&
+					readFileSync(this.getConfigPath(), "utf-8").includes(`[plugins."${CODEX_PLUGIN_CONFIG_NAME}"]`) &&
+					!configsPatched.includes(this.getConfigPath())
+				) {
 					configsPatched.push(this.getConfigPath());
 				}
 				if (this.nativePluginProvidesHooks()) {
 					this.removeCompatibilityHooks(configsPatched);
 				} else {
-					this.installCompatibilityHooks(signetArgs, filesWritten, configsPatched, warnings);
+					this.installCompatibilityHooks(signetArgs, filesWritten, configsPatched, warnings, windowsHookCommand);
 					warnings.push(
 						"Codex plugin support detected, but lifecycle hooks still require the compatibility hooks.json path in this Codex version",
 					);
@@ -1077,19 +1483,24 @@ export class CodexConnector extends BaseConnector {
 
 				return {
 					success: true,
-					message: "Codex integration installed — native plugin bundle + compatibility MCP server",
+					message: this.nativePluginProvidesHooks()
+						? "Codex integration installed — native plugin bundle"
+						: "Codex integration installed — native plugin bundle + compatibility hooks",
 					filesWritten,
 					configsPatched,
 					warnings,
 				};
 			}
+			// The CLI may have partially registered the marketplace before failing.
+			// Remove only the Signet-owned sections before falling back.
 			if (unpatchNativePluginConfig(this.getConfigPath()) && !configsPatched.includes(this.getConfigPath())) {
 				configsPatched.push(this.getConfigPath());
 			}
 		}
 
 		// 1. Install hooks.json (native Codex hook system)
-		this.installCompatibilityHooks(signetArgs, filesWritten, configsPatched, warnings);
+		if (windowsHookCommand && !filesWritten.includes(windowsHookCommand)) filesWritten.push(windowsHookCommand);
+		this.installCompatibilityHooks(signetArgs, filesWritten, configsPatched, warnings, windowsHookCommand);
 
 		// 2. Symlink skills directory
 		const skillsResult = this.symlinkSkills(expandedBasePath, codexHome);

--- a/integrations/codex/plugin/.agents/plugins/marketplace.json
+++ b/integrations/codex/plugin/.agents/plugins/marketplace.json
@@ -11,7 +11,8 @@
 				"path": "./plugins/signet"
 			},
 			"policy": {
-				"installation": "AVAILABLE"
+				"installation": "AVAILABLE",
+				"authentication": "ON_INSTALL"
 			},
 			"category": "Coding"
 		}

--- a/integrations/codex/plugin/plugins/signet/.codex-plugin/plugin.json
+++ b/integrations/codex/plugin/plugins/signet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "signet",
-	"version": "0.1.0",
+	"version": "0.1.0+codex.20260908213746",
 	"description": "Connect Codex to the local Signet substrate for source-backed recall, sessions, ontology, skills, and scoped note capture.",
 	"author": {
 		"name": "Signet"
@@ -11,7 +11,6 @@
 	"keywords": ["signet", "recall", "sources", "sessions", "ontology", "codex"],
 	"skills": "./skills/",
 	"mcpServers": "./.mcp.json",
-	"hooks": "./hooks/hooks.json",
 	"interface": {
 		"displayName": "Signet",
 		"shortDescription": "Source-backed recall and continuity for Codex",

--- a/integrations/codex/plugin/plugins/signet/hooks/hooks.json
+++ b/integrations/codex/plugin/plugins/signet/hooks/hooks.json
@@ -6,6 +6,7 @@
 					{
 						"type": "command",
 						"command": "signet hook session-start -H codex --codex-json",
+						"commandWindows": "signet.exe hook session-start -H codex --codex-json",
 						"timeout": 20
 					}
 				]
@@ -17,7 +18,20 @@
 					{
 						"type": "command",
 						"command": "signet hook user-prompt-submit -H codex --codex-json",
+						"commandWindows": "signet.exe hook user-prompt-submit -H codex --codex-json",
 						"timeout": 7
+					}
+				]
+			}
+		],
+		"PreToolUse": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "signet hook notifications -H codex --hook PreToolUse --codex-json",
+						"commandWindows": "signet.exe hook notifications -H codex --hook PreToolUse --codex-json",
+						"timeout": 5
 					}
 				]
 			}
@@ -28,6 +42,7 @@
 					{
 						"type": "command",
 						"command": "signet hook session-end -H codex",
+						"commandWindows": "signet.exe hook session-end -H codex",
 						"timeout": 30
 					}
 				]

--- a/web/docs/src/content/docs/harnesses/codex.md
+++ b/web/docs/src/content/docs/harnesses/codex.md
@@ -5,21 +5,27 @@ description: "Connect Signet to Codex."
 
 ## Codex
 
-Codex is OpenAI's terminal coding agent (`codex-rs`). Signet integrates
-with Codex through a generated Codex plugin bundle when the installed Codex
-CLI supports plugin marketplaces. The plugin declares Signet metadata, skills,
-and MCP configuration. Until Codex exposes plugin lifecycle hooks, Signet also
-installs compatibility `hooks.json` entries for session start, prompt submit,
-and session end. Older Codex versions fall back to direct hook and MCP config
-patching.
+Codex is OpenAI's coding agent (`codex-rs`), available as a standalone CLI and
+as the runtime bundled by the ChatGPT desktop app for Work/Codex mode. Signet
+integrates with both through a generated Codex plugin bundle when the installed
+Codex executable supports plugin marketplaces. The bundle uses the
+`.codex-plugin`/`.mcp.json` compatibility layout that current Codex CLI and
+ChatGPT desktop Work/Codex runtimes load for local stdio servers. A separate
+portable root manifest is intentionally deferred until the local-stdio contract
+is stable across desktop versions. Older Codex versions fall back to direct
+`hooks.json` and MCP config patching.
+
+The connector talks to the local Codex executable directly, including the copy
+bundled by ChatGPT desktop; Codex app-server integration is not required for
+plugin installation.
 
 ### Files managed by Signet
 
 | File | Description |
 |------|-------------|
 | `~/.codex/.tmp/signet-plugin-marketplace` | Generated local marketplace containing the Signet plugin bundle |
-| `~/.codex/config.toml` | Plugin marketplace/config registration, or compatibility `[mcp_servers.signet]` on older Codex installs |
-| `~/.codex/hooks.json` | Compatibility lifecycle hooks — SessionStart, UserPromptSubmit, Stop |
+| `~/.codex/config.toml` | Native plugin marketplace/config registration, or compatibility `[mcp_servers.signet]` on older Codex installs |
+| `~/.codex/hooks.json` | Compatibility lifecycle hooks — SessionStart, UserPromptSubmit, PreToolUse, Stop |
 | `~/.codex/skills` | Compatibility symlink to `$SIGNET_WORKSPACE/skills` when plugin support is unavailable |
 
 Generated Codex hook manifests contain only fields from Codex's hook schema.
@@ -47,13 +53,14 @@ still uses daemon-side dedupe keyed by `session_key`, `agent_id`, and
 
 ### How it works
 
-1. `signet setup --harness codex` feature-detects `codex plugin` support.
-2. On supported Codex installs, Signet writes a local plugin marketplace bundle and registers `signet@signet-local` in `~/.codex/config.toml`.
-3. While plugin lifecycle hooks are not available, Codex also reads compatibility hooks from `~/.codex/hooks.json`.
+1. `signet setup --harness codex` resolves a usable Codex executable. It checks the platform's known Codex/ChatGPT desktop resource roots and then `PATH`; `CODEX_CLI_PATH` can override discovery.
+2. If that executable supports `codex plugin`, Signet writes a local plugin marketplace bundle and registers `signet@signet-local` in `~/.codex/config.toml`.
+3. Native plugin hooks are loaded by Codex after its one-time hook trust review. If native plugin hooks are unavailable, Codex also reads compatibility hooks from `~/.codex/hooks.json`.
 4. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex --codex-json` → Signet returns identity + memories as `hookSpecificOutput.additionalContext` with `suppressOutput: true`, injected into the model's context window without printing the hook payload to the user transcript.
 5. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex --codex-json` → Signet returns bounded entity current-view context only when the prompt mentions a known entity or active alias. Empty matches return no additional context. This is blocking — Codex waits for the hook before sending to the model.
-6. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
-7. The MCP server exposes `signet_recall`, `signet_source_search`, `signet_session_search`, `signet_save_note`, and compatibility `memory_*` tools that Codex can invoke directly during sessions.
+6. Before a tool call, Codex may fire `PreToolUse` → calls `signet hook notifications -H codex --hook PreToolUse --codex-json` so Signet can deliver pending cross-agent notifications.
+7. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
+8. The MCP server exposes `signet_recall`, `signet_source_search`, `signet_session_search`, `signet_save_note`, and compatibility `memory_*` tools that Codex can invoke directly during sessions.
 
 Codex `SessionStart` hook timeout defaults to 20 seconds: the Signet CLI
 waits up to `SIGNET_SESSION_START_TIMEOUT` (`15000` ms by default) for
@@ -94,7 +101,19 @@ path, query string, fragment, or embedded credentials.
 
 Codex matches the session-start, prompt-submit, and session-end path, but
 it does **not** currently expose the same compaction lifecycle fidelity as
-Claude Code or OpenCode.
+Claude Code or OpenCode. In ChatGPT desktop, approve the generated Signet
+hooks in the one-time trust prompt; continuing without trust leaves the plugin
+installed but prevents lifecycle hooks from running.
+
+`CODEX_HOME` selects the Codex state directory for the connector. On Windows,
+native ChatGPT and native Codex normally use `%USERPROFILE%\\.codex`; a Codex
+CLI running in WSL uses Linux `~/.codex` unless `CODEX_HOME` points to the
+Windows directory. The Linux ChatGPT desktop app is currently preview software;
+when its bundled executable is not on `PATH`, Signet checks the usual
+`/usr/lib/chatgpt`, `/opt/chatgpt`, and per-user resource roots. On Windows,
+Signet writes a hashed `.cmd` wrapper for generated hooks so paths containing
+spaces and remote-daemon environment variables do not depend on Codex's wrapped
+`cmd.exe /C` quoting.
 
 ### Supported hooks
 
@@ -102,6 +121,7 @@ Claude Code or OpenCode.
 |------|-----------|
 | session-start | yes — identity + memories via `hookSpecificOutput.additionalContext` |
 | user-prompt-submit | yes — entity current-view context via `hookSpecificOutput.additionalContext` when matched |
+| pre-tool-use | yes — pending notifications via the Codex hook payload |
 | session-end | yes — transcript extraction via `Stop` hook |
 
 ### MCP tools
@@ -128,7 +148,7 @@ than a local Ollama instance.
 
 ### Prerequisites
 
-- Codex (`codex-rs`) installed and in `PATH`
+- Codex CLI installed, or ChatGPT desktop installed with Work/Codex mode
 - Signet daemon running (`signet daemon start`)
 
 ---

--- a/web/docs/src/content/docs/harnesses/codex.md
+++ b/web/docs/src/content/docs/harnesses/codex.md
@@ -105,15 +105,18 @@ Claude Code or OpenCode. In ChatGPT desktop, approve the generated Signet
 hooks in the one-time trust prompt; continuing without trust leaves the plugin
 installed but prevents lifecycle hooks from running.
 
-`CODEX_HOME` selects the Codex state directory for the connector. On Windows,
-native ChatGPT and native Codex normally use `%USERPROFILE%\\.codex`; a Codex
-CLI running in WSL uses Linux `~/.codex` unless `CODEX_HOME` points to the
-Windows directory. The Linux ChatGPT desktop app is currently preview software;
-when its bundled executable is not on `PATH`, Signet checks the usual
-`/usr/lib/chatgpt`, `/opt/chatgpt`, and per-user resource roots. On Windows,
-Signet writes a hashed `.cmd` wrapper for generated hooks so paths containing
-spaces and remote-daemon environment variables do not depend on Codex's wrapped
-`cmd.exe /C` quoting.
+`CODEX_HOME` selects the Codex state directory for the connector. Native
+ChatGPT and Codex on Windows normally use `%USERPROFILE%\\.codex`, and
+standalone Codex clients on one OS may share that OS's state directory. Keep
+WSL/Linux and macOS installs on their native state directories instead of
+pointing them at a Windows `CODEX_HOME`: generated hook and MCP commands
+contain platform-specific absolute paths and Windows `.cmd` wrappers. Install
+the integration separately per OS. The Linux ChatGPT desktop app is currently
+preview software; when its bundled executable is not on `PATH`, Signet checks
+the usual `/usr/lib/chatgpt`, `/opt/chatgpt`, and per-user resource roots. On
+Windows, Signet writes a hashed `.cmd` wrapper for generated hooks so paths
+containing spaces and remote-daemon environment variables do not depend on
+Codex's wrapped `cmd.exe /C` quoting.
 
 ### Supported hooks
 


### PR DESCRIPTION
## Summary

- Integrate Signet as a native local Codex plugin for standalone Codex and ChatGPT desktop Work/Codex mode.
- Let the Codex CLI own marketplace/plugin state, with hooks and MCP retained as the compatibility fallback.
- Harden runtime discovery, CODEX_HOME/WSL handling, mixed-hook ownership, TOML cleanup, and Windows hook command execution.
- Document the Chat mode/OAuth boundary and keep the Codex app server out of the plugin path.

## Validation

- bun test integrations/codex (74 passed, 0 failed)
- bunx tsc -p integrations/codex/connector/tsconfig.json --noEmit
- bun run --cwd integrations/codex/connector build
- bun run --cwd web/docs validate:content (91 pages and routes)
- bun run --cwd integrations/codex/plugin test
- Biome checks on changed TypeScript and JSON
- git diff --check
- Real ChatGPT.app bundled-Codex install, reinstall, uninstall, and static marketplace smoke

## Notes

- No live Windows or Linux ChatGPT desktop runtime was available; platform resolver coverage is test-based.
- The bundled plugin validator could not run because PyYAML is not installed (ModuleNotFoundError: yaml).
- Commit includes the required Assisted-by disclosure per CONTRIBUTING.md.