### PR TITLE
fix(desktop): preserve source changes during sync

### DIFF
--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -354,6 +354,7 @@ export {
 	syncWorkspaceSourceRepo,
 } from "./workspace-source-repo";
 export type {
+	WorkspaceSourceRepoLocalChanges,
 	WorkspaceSourceRepoStatus,
 	WorkspaceSourceRepoSyncOptions,
 	WorkspaceSourceRepoSyncResult,

--- a/platform/core/src/workspace-source-repo.test.ts
+++ b/platform/core/src/workspace-source-repo.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	type WorkspaceSourceRepoSyncOptions,
 	type WorkspaceSourceRepoSyncResult,
 	resolveWorkspaceSourceRepoPath,
 	syncWorkspaceSourceRepo,
@@ -71,8 +72,12 @@ function pushRemoteChange(workDir: string, content: string, message: string): vo
 	runGit(["push", "origin", "main"], workDir);
 }
 
-function syncWorkspace(workspaceDir: string, remoteUrl: string): WorkspaceSourceRepoSyncResult {
-	return syncWorkspaceSourceRepo(workspaceDir, { remoteUrl, cloneIfMissing: true });
+function syncWorkspace(
+	workspaceDir: string,
+	remoteUrl: string,
+	options: Omit<WorkspaceSourceRepoSyncOptions, "remoteUrl" | "cloneIfMissing"> = {},
+): WorkspaceSourceRepoSyncResult {
+	return syncWorkspaceSourceRepo(workspaceDir, { remoteUrl, cloneIfMissing: true, ...options });
 }
 
 describe("syncWorkspaceSourceRepo", () => {
@@ -155,9 +160,11 @@ describe("syncWorkspaceSourceRepo", () => {
 		mkdirSync(join(repoPath, "surfaces", "desktop", "release"), { recursive: true });
 		mkdirSync(join(repoPath, "surfaces", "desktop", "resources", "daemon"), { recursive: true });
 		mkdirSync(join(repoPath, "dist", "signetai", "hermes-plugin"), { recursive: true });
+		mkdirSync(join(repoPath, "platform", "daemon"), { recursive: true });
 		writeFileSync(join(repoPath, "surfaces", "desktop", "release", "Signet-0.1.0-linux-x64.AppImage"), "app");
 		writeFileSync(join(repoPath, "surfaces", "desktop", "resources", "daemon", "daemon.js"), "daemon");
 		writeFileSync(join(repoPath, "dist", "signetai", "hermes-plugin", "plugin.py"), "plugin");
+		writeFileSync(join(repoPath, "platform", "daemon", "anydoc.win32-x64-msvc-gs7ezvas.node"), "native addon");
 		pushRemoteChange(workDir, "# signet\n\nremote build fix\n", "remote build fix");
 
 		const result = syncWorkspace(workspaceDir, remoteUrl);
@@ -167,6 +174,9 @@ describe("syncWorkspaceSourceRepo", () => {
 		expect(
 			readFileSync(join(repoPath, "surfaces", "desktop", "release", "Signet-0.1.0-linux-x64.AppImage"), "utf-8"),
 		).toBe("app");
+		expect(readFileSync(join(repoPath, "platform", "daemon", "anydoc.win32-x64-msvc-gs7ezvas.node"), "utf-8")).toBe(
+			"native addon",
+		);
 	});
 
 	it("fetches but does not pull over local workspace changes", () => {
@@ -185,6 +195,68 @@ describe("syncWorkspaceSourceRepo", () => {
 		expect(readFileSync(join(repoPath, "README.md"), "utf-8")).toBe("# local edits\n");
 	});
 
+	it("autostashes tracked and untracked changes before pulling when requested", () => {
+		const { remoteUrl, workDir } = seedRemote();
+		const workspaceDir = makeTempDir("signet-source-workspace-");
+
+		expect(syncWorkspace(workspaceDir, remoteUrl).status).toBe("cloned");
+		const repoPath = resolveWorkspaceSourceRepoPath(workspaceDir);
+		mkdirSync(join(repoPath, "platform", "daemon"), { recursive: true });
+		writeFileSync(join(repoPath, "platform", "daemon", "anydoc.win32-x64-msvc-gs7ezvas.node"), "generated addon\n");
+		writeFileSync(join(repoPath, "README.md"), "# local edits\n");
+		writeFileSync(join(repoPath, "local-notes.txt"), "keep this\n");
+		pushRemoteChange(workDir, "# signet\n\nremote change\n", "remote change");
+
+		const result = syncWorkspace(workspaceDir, remoteUrl, { localChanges: "stash" });
+
+		expect(result.status).toBe("pulled");
+		expect(result.localChanges).toBe("stashed");
+		expect(result.stashRef).toMatch(/^[0-9a-f]{40}$/);
+		expect(result.message).toContain(`local changes were preserved in stash ${result.stashRef}`);
+		expect(readFileSync(join(repoPath, "README.md"), "utf-8")).toContain("remote change");
+		expect(existsSync(join(repoPath, "local-notes.txt"))).toBe(false);
+		expect(existsSync(join(repoPath, "platform", "daemon", "anydoc.win32-x64-msvc-gs7ezvas.node"))).toBe(true);
+		expect(runGit(["stash", "list", "--format=%H %s"], repoPath)).toContain(
+			`${result.stashRef} On main: signet-source-autostash-`,
+		);
+	});
+
+	it("does not stash local changes when the checkout is already current", () => {
+		const { remoteUrl } = seedRemote();
+		const workspaceDir = makeTempDir("signet-source-workspace-");
+
+		expect(syncWorkspace(workspaceDir, remoteUrl).status).toBe("cloned");
+		const repoPath = resolveWorkspaceSourceRepoPath(workspaceDir);
+		writeFileSync(join(repoPath, "README.md"), "# local edits that stay put\n");
+
+		const result = syncWorkspace(workspaceDir, remoteUrl, { localChanges: "stash" });
+
+		expect(result.status).toBe("current");
+		expect(result.localChanges).toBe("left-in-place");
+		expect(result.stashRef).toBeUndefined();
+		expect(readFileSync(join(repoPath, "README.md"), "utf-8")).toBe("# local edits that stay put\n");
+		expect(runGit(["stash", "list"], repoPath)).toBe("");
+	});
+
+	it("autostashes local changes through the async sync path", async () => {
+		const { remoteUrl, workDir } = seedRemote();
+		const workspaceDir = makeTempDir("signet-source-workspace-");
+
+		expect((await syncWorkspaceSourceRepoAsync(workspaceDir, { remoteUrl, cloneIfMissing: true })).status).toBe(
+			"cloned",
+		);
+		const repoPath = resolveWorkspaceSourceRepoPath(workspaceDir);
+		writeFileSync(join(repoPath, "README.md"), "# async local edits\n");
+		pushRemoteChange(workDir, "# signet\n\nasync remote change\n", "async remote change");
+
+		const result = await syncWorkspaceSourceRepoAsync(workspaceDir, { remoteUrl, localChanges: "stash" });
+
+		expect(result.status).toBe("pulled");
+		expect(result.localChanges).toBe("stashed");
+		expect(result.stashRef).toMatch(/^[0-9a-f]{40}$/);
+		expect(readFileSync(join(repoPath, "README.md"), "utf-8")).toContain("async remote change");
+	});
+
 	it("rejects unsafe remote URLs before invoking git clone", () => {
 		const workspaceDir = makeTempDir("signet-source-workspace-");
 
@@ -199,19 +271,12 @@ describe("syncWorkspaceSourceRepo", () => {
 
 	it("surfaces sync lock acquisition errors instead of reporting a duplicate run", () => {
 		const workspaceDir = makeTempDir("signet-source-workspace-");
-		const daemonDir = join(workspaceDir, ".daemon");
-		mkdirSync(daemonDir, { recursive: true });
-		chmodSync(daemonDir, 0o500);
+		writeFileSync(join(workspaceDir, ".daemon"), "not a directory\n");
 
-		try {
-			const result = syncWorkspaceSourceRepo(workspaceDir, { cloneIfMissing: true });
+		const result = syncWorkspaceSourceRepo(workspaceDir, { cloneIfMissing: true });
 
-			expect(result.status).toBe("error");
-			expect(result.message).toContain("failed to acquire source checkout sync lock");
-			expect(result.message).toContain("EACCES");
-		} finally {
-			chmodSync(daemonDir, 0o700);
-		}
+		expect(result.status).toBe("error");
+		expect(result.message).toContain("failed to acquire source checkout sync lock");
 	});
 
 	it("returns a typed error when the workspace path cannot host the lock directory", () => {

--- a/platform/core/src/workspace-source-repo.ts
+++ b/platform/core/src/workspace-source-repo.ts
@@ -9,13 +9,17 @@ const DEFAULT_GIT_TIMEOUT_MS = 60_000;
 const SOURCE_REPO_SYNC_LOCK_FILENAME = "source-repo-sync.lock";
 const SOURCE_REPO_SYNC_LOCK_STALE_MS = 5 * 60_000;
 const SOURCE_REPO_SYNC_LOCK_WAIT_MS = 15_000;
+const SOURCE_REPO_AUTOSTASH_PREFIX = "signet-source-autostash";
 
 export type WorkspaceSourceRepoStatus = "cloned" | "pulled" | "fetched" | "current" | "skipped" | "error";
+export type WorkspaceSourceRepoLocalChanges = "none" | "generated-only" | "left-in-place" | "stashed";
 
 export interface WorkspaceSourceRepoSyncOptions {
 	/** Only explicit source builds may create a checkout; routine sync updates existing repositories. */
 	readonly cloneIfMissing?: boolean;
 	readonly gitTimeoutMs?: number;
+	/** Preserve user-owned local changes in a verified Git stash before updating. */
+	readonly localChanges?: "skip" | "stash";
 	readonly remoteUrl?: string;
 	readonly repoDirName?: string;
 }
@@ -26,6 +30,8 @@ export interface WorkspaceSourceRepoSyncResult {
 	readonly message: string;
 	readonly branch: string | null;
 	readonly defaultBranch: string | null;
+	readonly localChanges?: WorkspaceSourceRepoLocalChanges;
+	readonly stashRef?: string;
 }
 
 interface GitCommandResult {
@@ -57,6 +63,27 @@ type SyncLockAttempt =
 	| { readonly status: "error"; readonly message: string };
 
 type WorkspaceDirEnsureResult = { readonly ok: true } | { readonly ok: false; readonly message: string };
+
+interface WorkingTreeStatus {
+	readonly statusReadable: boolean;
+	readonly hasUserChanges: boolean;
+	readonly hasGeneratedChanges: boolean;
+	readonly hasUnmergedChanges: boolean;
+	readonly userPaths: readonly string[];
+}
+
+interface LocalChangesMetadata {
+	readonly localChanges: WorkspaceSourceRepoLocalChanges;
+	readonly stashRef?: string;
+}
+
+type AutoStashResult =
+	| { readonly ok: true; readonly stashRef: string }
+	| { readonly ok: false; readonly message: string; readonly stashRef?: string };
+
+type LocalChangesPreparation =
+	| { readonly ok: true; readonly metadata: LocalChangesMetadata }
+	| { readonly ok: false; readonly message: string; readonly metadata?: LocalChangesMetadata };
 
 type MaybePromise<T> = T | Promise<T>;
 type GitRunner = (
@@ -97,7 +124,15 @@ export function syncWorkspaceSourceRepo(
 	}
 
 	try {
-		return syncWorkspaceSourceRepoLocked(runGit, workspaceDir, repoPath, remoteUrl, timeoutMs, clone);
+		return syncWorkspaceSourceRepoLocked(
+			runGit,
+			workspaceDir,
+			repoPath,
+			remoteUrl,
+			timeoutMs,
+			clone,
+			options.localChanges ?? "skip",
+		);
 	} finally {
 		releaseSourceRepoSyncLock(lock.lock);
 	}
@@ -128,7 +163,15 @@ export async function syncWorkspaceSourceRepoAsync(
 	}
 
 	try {
-		return await syncWorkspaceSourceRepoLocked(runGitAsync, workspaceDir, repoPath, remoteUrl, timeoutMs, clone);
+		return await syncWorkspaceSourceRepoLocked(
+			runGitAsync,
+			workspaceDir,
+			repoPath,
+			remoteUrl,
+			timeoutMs,
+			clone,
+			options.localChanges ?? "skip",
+		);
 	} finally {
 		releaseSourceRepoSyncLock(lock.lock);
 	}
@@ -141,6 +184,7 @@ function syncWorkspaceSourceRepoLocked(
 	remoteUrl: string,
 	timeoutMs: number,
 	cloneIfMissing: boolean,
+	localChanges: "skip" | "stash",
 ): WorkspaceSourceRepoSyncResult;
 function syncWorkspaceSourceRepoLocked(
 	run: typeof runGitAsync,
@@ -149,6 +193,7 @@ function syncWorkspaceSourceRepoLocked(
 	remoteUrl: string,
 	timeoutMs: number,
 	cloneIfMissing: boolean,
+	localChanges: "skip" | "stash",
 ): Promise<WorkspaceSourceRepoSyncResult>;
 function syncWorkspaceSourceRepoLocked(
 	run: GitRunner,
@@ -157,6 +202,7 @@ function syncWorkspaceSourceRepoLocked(
 	remoteUrl: string,
 	timeoutMs: number,
 	cloneIfMissing: boolean,
+	localChanges: "skip" | "stash",
 ): MaybePromise<WorkspaceSourceRepoSyncResult> {
 	if (!existsSync(repoPath) || isEmptyDirectory(repoPath)) {
 		if (!cloneIfMissing) return missingCheckoutResult(repoPath);
@@ -204,7 +250,7 @@ function syncWorkspaceSourceRepoLocked(
 					);
 				}
 
-				return finalizeFetchedRepoWith(run, repoPath, state, timeoutMs);
+				return finalizeFetchedRepoWith(run, repoPath, state, timeoutMs, localChanges);
 			});
 		}),
 	);
@@ -215,6 +261,7 @@ function finalizeFetchedRepoWith(
 	repoPath: string,
 	state: RepoState,
 	timeoutMs: number,
+	localChangesMode: "skip" | "stash",
 ): MaybePromise<WorkspaceSourceRepoSyncResult> {
 	if (state.branch === null) {
 		return fetchedResult(
@@ -237,68 +284,168 @@ function finalizeFetchedRepoWith(
 			state,
 		);
 	}
-	return mapToSyncResult(isWorkingTreeDirtyWith(run, repoPath, timeoutMs), (dirty) => {
-		if (dirty) {
+	return flatMapMaybePromise(readWorkingTreeStatusWith(run, repoPath, timeoutMs), (workingTree) => {
+		const generatedOnlyMetadata: LocalChangesMetadata = {
+			localChanges: workingTree.hasGeneratedChanges ? "generated-only" : "none",
+		};
+		const localChangesMetadata: LocalChangesMetadata = {
+			localChanges: workingTree.hasUserChanges ? "left-in-place" : generatedOnlyMetadata.localChanges,
+		};
+
+		if (!workingTree.hasUserChanges) {
+			return continueFetchedRepoWith(run, repoPath, state, timeoutMs, generatedOnlyMetadata);
+		}
+
+		if (localChangesMode !== "stash") {
 			return fetchedResult(
 				repoPath,
 				"fetched latest Signet source checkout, skipped pull because the working tree has local changes",
 				state,
+				{ localChanges: "left-in-place" },
 			);
 		}
 
-		return mapToSyncResult(readUpstreamBranchWith(run, repoPath, timeoutMs), (upstream) => {
-			if (upstream !== `origin/${state.defaultBranch}`) {
+		if (workingTree.hasUnmergedChanges) {
+			return fetchedResult(
+				repoPath,
+				"fetched latest Signet source checkout, skipped pull because the working tree has unresolved merge conflicts",
+				state,
+				{ localChanges: "left-in-place" },
+			);
+		}
+
+		if (!workingTree.statusReadable) {
+			return errorResult(
+				repoPath,
+				"could not safely inspect the working tree before creating an automatic stash",
+				state,
+				localChangesMetadata,
+			);
+		}
+
+		return continueFetchedRepoWith(run, repoPath, state, timeoutMs, localChangesMetadata, () =>
+			prepareLocalChangesForUpdateWith(run, repoPath, timeoutMs, workingTree.userPaths),
+		);
+	});
+}
+
+function continueFetchedRepoWith(
+	run: GitRunner,
+	repoPath: string,
+	state: RepoState,
+	timeoutMs: number,
+	metadata: LocalChangesMetadata,
+	prepareForUpdate?: () => MaybePromise<LocalChangesPreparation>,
+): MaybePromise<WorkspaceSourceRepoSyncResult> {
+	const defaultBranch = state.defaultBranch;
+	if (defaultBranch === null) {
+		return fetchedResult(
+			repoPath,
+			"fetched latest Signet source checkout, skipped pull because origin HEAD is unavailable",
+			state,
+			metadata,
+		);
+	}
+
+	return flatMapMaybePromise(readUpstreamBranchWith(run, repoPath, timeoutMs), (upstream) => {
+		if (upstream !== `origin/${defaultBranch}`) {
+			return fetchedResult(
+				repoPath,
+				"fetched latest Signet source checkout, skipped pull because the current branch is not tracking origin",
+				state,
+				metadata,
+			);
+		}
+
+		return flatMapMaybePromise(readAheadBehindWith(run, repoPath, upstream, timeoutMs), (divergence) => {
+			if (divergence === null) {
 				return fetchedResult(
 					repoPath,
-					"fetched latest Signet source checkout, skipped pull because the current branch is not tracking origin",
+					"fetched latest Signet source checkout, skipped pull because branch divergence could not be determined",
 					state,
+					metadata,
 				);
 			}
+			if (divergence.ahead > 0) {
+				return fetchedResult(
+					repoPath,
+					"fetched latest Signet source checkout, skipped pull because the checkout has local commits",
+					state,
+					metadata,
+				);
+			}
+			if (divergence.behind === 0) {
+				return currentResult(repoPath, state, metadata);
+			}
 
-			return mapToSyncResult(readAheadBehindWith(run, repoPath, upstream, timeoutMs), (divergence) => {
-				if (divergence === null) {
+			return flatMapMaybePromise(isSafeBranchNameWith(run, defaultBranch, timeoutMs), (safeBranchName) => {
+				if (!safeBranchName) {
 					return fetchedResult(
 						repoPath,
-						"fetched latest Signet source checkout, skipped pull because branch divergence could not be determined",
+						"fetched latest Signet source checkout, skipped pull because origin HEAD resolved to an unsafe branch name",
 						state,
+						metadata,
 					);
 				}
-				if (divergence.ahead > 0) {
-					return fetchedResult(
-						repoPath,
-						"fetched latest Signet source checkout, skipped pull because the checkout has local commits",
-						state,
-					);
-				}
-				if (divergence.behind === 0) {
-					return currentResult(repoPath, state);
-				}
 
-				return mapToSyncResult(isSafeBranchNameWith(run, state.defaultBranch, timeoutMs), (safeBranchName) => {
-					if (!safeBranchName) {
-						return fetchedResult(
-							repoPath,
-							"fetched latest Signet source checkout, skipped pull because origin HEAD resolved to an unsafe branch name",
-							state,
-						);
-					}
-
-					return mapToSyncResult(
-						run(["merge", "--ff-only", "--no-edit", `refs/remotes/origin/${state.defaultBranch}`], repoPath, timeoutMs),
+				const fastForward = (preparedMetadata: LocalChangesMetadata): MaybePromise<WorkspaceSourceRepoSyncResult> =>
+					flatMapMaybePromise(
+						run(["merge", "--ff-only", "--no-edit", `refs/remotes/origin/${defaultBranch}`], repoPath, timeoutMs),
 						(pull) => {
 							if (!pull.ok) {
 								return errorResult(
 									repoPath,
 									`failed to fast-forward Signet source checkout: ${readGitError(pull, timeoutMs)}`,
 									state,
+									preparedMetadata,
 								);
 							}
 
-							return pulledResult(repoPath, state);
+							return pulledResult(repoPath, state, preparedMetadata);
 						},
 					);
+
+				if (!prepareForUpdate) return fastForward(metadata);
+				return flatMapMaybePromise(prepareForUpdate(), (preparation) => {
+					if (preparation.ok === false) {
+						return errorResult(repoPath, preparation.message, state, preparation.metadata ?? metadata);
+					}
+					return fastForward(preparation.metadata);
 				});
 			});
+		});
+	});
+}
+
+function prepareLocalChangesForUpdateWith(
+	run: GitRunner,
+	repoPath: string,
+	timeoutMs: number,
+	userPaths: readonly string[],
+): MaybePromise<LocalChangesPreparation> {
+	return flatMapMaybePromise(createAutoStashWith(run, repoPath, timeoutMs, userPaths), (stash) => {
+		if (stash.ok === false) {
+			return {
+				ok: false,
+				message: `failed to preserve local changes before updating Signet source checkout: ${stash.message}`,
+				...(stash.stashRef ? { metadata: { localChanges: "stashed", stashRef: stash.stashRef } } : {}),
+			};
+		}
+
+		const stashedMetadata: LocalChangesMetadata = {
+			localChanges: "stashed",
+			stashRef: stash.stashRef,
+		};
+		return flatMapMaybePromise(readWorkingTreeStatusWith(run, repoPath, timeoutMs), (afterStash) => {
+			if (!afterStash.statusReadable || afterStash.hasUserChanges) {
+				return {
+					ok: false,
+					message: `verified local-change stash ${stash.stashRef} did not leave the source checkout clean; the stash was kept`,
+					metadata: stashedMetadata,
+				};
+			}
+
+			return { ok: true, metadata: stashedMetadata };
 		});
 	});
 }
@@ -667,6 +814,8 @@ function readFsError(prefix: string, err: unknown): string {
 	return `${prefix}: ${err instanceof Error ? err.message : String(err)}`;
 }
 
+const NO_LOCAL_CHANGES: LocalChangesMetadata = { localChanges: "none" };
+
 function skippedResult(repoPath: string, message: string, state?: RepoState): WorkspaceSourceRepoSyncResult {
 	return {
 		status: "skipped",
@@ -677,23 +826,35 @@ function skippedResult(repoPath: string, message: string, state?: RepoState): Wo
 	};
 }
 
-function fetchedResult(repoPath: string, message: string, state: RepoState): WorkspaceSourceRepoSyncResult {
+function fetchedResult(
+	repoPath: string,
+	message: string,
+	state: RepoState,
+	metadata: LocalChangesMetadata = NO_LOCAL_CHANGES,
+): WorkspaceSourceRepoSyncResult {
 	return {
 		status: "fetched",
 		path: repoPath,
-		message,
+		message: addLocalChangesMessage(message, metadata),
 		branch: state.branch,
 		defaultBranch: state.defaultBranch,
+		...localChangesFields(metadata),
 	};
 }
 
-function errorResult(repoPath: string, message: string, state?: RepoState): WorkspaceSourceRepoSyncResult {
+function errorResult(
+	repoPath: string,
+	message: string,
+	state?: RepoState,
+	metadata: LocalChangesMetadata = NO_LOCAL_CHANGES,
+): WorkspaceSourceRepoSyncResult {
 	return {
 		status: "error",
 		path: repoPath,
-		message,
+		message: addLocalChangesMessage(message, metadata),
 		branch: state?.branch ?? null,
 		defaultBranch: state?.defaultBranch ?? null,
+		...localChangesFields(metadata),
 	};
 }
 
@@ -707,24 +868,58 @@ function clonedResult(repoPath: string, state: RepoState): WorkspaceSourceRepoSy
 	};
 }
 
-function pulledResult(repoPath: string, state: RepoState): WorkspaceSourceRepoSyncResult {
+function pulledResult(
+	repoPath: string,
+	state: RepoState,
+	metadata: LocalChangesMetadata = NO_LOCAL_CHANGES,
+): WorkspaceSourceRepoSyncResult {
 	return {
 		status: "pulled",
 		path: repoPath,
-		message: "pulled latest Signet source checkout",
+		message: addLocalChangesMessage("pulled latest Signet source checkout", metadata),
 		branch: state.branch,
 		defaultBranch: state.defaultBranch,
+		...localChangesFields(metadata),
 	};
 }
 
-function currentResult(repoPath: string, state: RepoState): WorkspaceSourceRepoSyncResult {
+function currentResult(
+	repoPath: string,
+	state: RepoState,
+	metadata: LocalChangesMetadata = NO_LOCAL_CHANGES,
+): WorkspaceSourceRepoSyncResult {
 	return {
 		status: "current",
 		path: repoPath,
-		message: "Signet source checkout is already current",
+		message: addLocalChangesMessage("Signet source checkout is already current", metadata),
 		branch: state.branch,
 		defaultBranch: state.defaultBranch,
+		...localChangesFields(metadata),
 	};
+}
+
+function localChangesFields(metadata: LocalChangesMetadata): {
+	readonly localChanges?: WorkspaceSourceRepoLocalChanges;
+	readonly stashRef?: string;
+} {
+	if (metadata.localChanges === "none") return {};
+	return {
+		localChanges: metadata.localChanges,
+		...(metadata.stashRef ? { stashRef: metadata.stashRef } : {}),
+	};
+}
+
+function addLocalChangesMessage(message: string, metadata: LocalChangesMetadata): string {
+	if (metadata.localChanges === "stashed" && metadata.stashRef) {
+		return `${message}; local changes were preserved in stash ${metadata.stashRef}`;
+	}
+	if (metadata.localChanges === "generated-only") {
+		return `${message}; generated build artifacts were left in place`;
+	}
+	if (metadata.localChanges === "left-in-place") {
+		return `${message}; local changes were left in place`;
+	}
+	return message;
 }
 
 function isPromiseLike<T>(value: MaybePromise<T>): value is Promise<T> {
@@ -732,6 +927,10 @@ function isPromiseLike<T>(value: MaybePromise<T>): value is Promise<T> {
 }
 
 function mapMaybePromise<T, U>(value: MaybePromise<T>, map: (value: T) => U): MaybePromise<U> {
+	return isPromiseLike(value) ? value.then(map) : map(value);
+}
+
+function flatMapMaybePromise<T, U>(value: MaybePromise<T>, map: (value: T) => MaybePromise<U>): MaybePromise<U> {
 	return isPromiseLike(value) ? value.then(map) : map(value);
 }
 
@@ -800,22 +999,63 @@ function readDefaultBranchWith(run: GitRunner, repoPath: string, timeoutMs: numb
 	);
 }
 
-function isWorkingTreeDirtyWith(run: typeof runGit, repoPath: string, timeoutMs: number): boolean;
-function isWorkingTreeDirtyWith(run: typeof runGitAsync, repoPath: string, timeoutMs: number): Promise<boolean>;
-function isWorkingTreeDirtyWith(run: GitRunner, repoPath: string, timeoutMs: number): MaybePromise<boolean>;
-function isWorkingTreeDirtyWith(run: GitRunner, repoPath: string, timeoutMs: number): MaybePromise<boolean> {
+function readWorkingTreeStatusWith(run: typeof runGit, repoPath: string, timeoutMs: number): WorkingTreeStatus;
+function readWorkingTreeStatusWith(
+	run: typeof runGitAsync,
+	repoPath: string,
+	timeoutMs: number,
+): Promise<WorkingTreeStatus>;
+function readWorkingTreeStatusWith(
+	run: GitRunner,
+	repoPath: string,
+	timeoutMs: number,
+): MaybePromise<WorkingTreeStatus>;
+function readWorkingTreeStatusWith(
+	run: GitRunner,
+	repoPath: string,
+	timeoutMs: number,
+): MaybePromise<WorkingTreeStatus> {
 	return mapMaybePromise(
 		run(["status", "--porcelain", "--untracked-files=all", "--ignore-submodules=all"], repoPath, timeoutMs),
 		(result) => {
 			if (!result.ok) {
-				return true;
+				return {
+					statusReadable: false,
+					hasUserChanges: true,
+					hasGeneratedChanges: false,
+					hasUnmergedChanges: false,
+					userPaths: [],
+				};
 			}
 
-			return result.stdout
+			let statusReadable = true;
+			let hasUserChanges = false;
+			let hasGeneratedChanges = false;
+			let hasUnmergedChanges = false;
+			const userPaths: string[] = [];
+			for (const line of result.stdout
 				.split("\n")
 				.map((line) => line.trimEnd())
-				.filter((line) => line.length > 0)
-				.some((line) => !isGeneratedSourceRepoStatusLine(line));
+				.filter((line) => line.length > 0)) {
+				if (isUnmergedStatusLine(line)) {
+					hasUnmergedChanges = true;
+					hasUserChanges = true;
+					continue;
+				}
+				if (isGeneratedSourceRepoStatusLine(line)) {
+					hasGeneratedChanges = true;
+					continue;
+				}
+				hasUserChanges = true;
+				const path = parsePorcelainStatusPath(line);
+				if (path) {
+					userPaths.push(path);
+				} else {
+					statusReadable = false;
+				}
+			}
+
+			return { statusReadable, hasUserChanges, hasGeneratedChanges, hasUnmergedChanges, userPaths };
 		},
 	);
 }
@@ -831,10 +1071,122 @@ const GENERATED_SOURCE_REPO_PATH_PREFIXES = [
 	"surfaces/desktop/resources/",
 ];
 
+const GENERATED_SOURCE_REPO_PATH_PATTERNS = [/^platform\/daemon\/anydoc\.[^/]+\.node$/];
+
 function isGeneratedSourceRepoStatusLine(line: string): boolean {
 	const path = parsePorcelainStatusPath(line);
 	if (!path) return false;
-	return GENERATED_SOURCE_REPO_PATH_PREFIXES.some((prefix) => path === prefix.slice(0, -1) || path.startsWith(prefix));
+	return (
+		GENERATED_SOURCE_REPO_PATH_PREFIXES.some((prefix) => path === prefix.slice(0, -1) || path.startsWith(prefix)) ||
+		GENERATED_SOURCE_REPO_PATH_PATTERNS.some((pattern) => pattern.test(path))
+	);
+}
+
+function isUnmergedStatusLine(line: string): boolean {
+	if (line.length < 2) return false;
+	const indexStatus = line[0];
+	const worktreeStatus = line[1];
+	return (
+		indexStatus === "U" ||
+		worktreeStatus === "U" ||
+		(indexStatus === "A" && worktreeStatus === "A") ||
+		(indexStatus === "D" && worktreeStatus === "D")
+	);
+}
+
+function createAutoStashWith(
+	run: typeof runGit,
+	repoPath: string,
+	timeoutMs: number,
+	userPaths: readonly string[],
+): AutoStashResult;
+function createAutoStashWith(
+	run: typeof runGitAsync,
+	repoPath: string,
+	timeoutMs: number,
+	userPaths: readonly string[],
+): Promise<AutoStashResult>;
+function createAutoStashWith(
+	run: GitRunner,
+	repoPath: string,
+	timeoutMs: number,
+	userPaths: readonly string[],
+): MaybePromise<AutoStashResult>;
+function createAutoStashWith(
+	run: GitRunner,
+	repoPath: string,
+	timeoutMs: number,
+	userPaths: readonly string[],
+): MaybePromise<AutoStashResult> {
+	const stashMessage = `${SOURCE_REPO_AUTOSTASH_PREFIX}-${new Date().toISOString().replace(/\D/g, "")}`;
+	const pathspecs = userPaths.map((path) => `:(literal)${path}`);
+	return flatMapMaybePromise(readStashHeadWith(run, repoPath, timeoutMs), (before) =>
+		flatMapMaybePromise(
+			run(["stash", "push", "--include-untracked", "--message", stashMessage, "--", ...pathspecs], repoPath, timeoutMs),
+			(stash) =>
+				flatMapMaybePromise(readStashHeadWith(run, repoPath, timeoutMs), (after) => {
+					const stashRef = after && after !== before ? after : undefined;
+					if (!stash.ok) {
+						return {
+							ok: false,
+							message: `git stash failed: ${readGitError(stash, timeoutMs)}`,
+							...(stashRef ? { stashRef } : {}),
+						};
+					}
+					if (!stashRef) {
+						return {
+							ok: false,
+							message: `git stash completed without creating a verifiable ${SOURCE_REPO_AUTOSTASH_PREFIX} entry`,
+						};
+					}
+
+					return flatMapMaybePromise(readStashSubjectWith(run, repoPath, stashRef, timeoutMs), (subject) => {
+						if (!subject?.includes(stashMessage)) {
+							return {
+								ok: false,
+								message: `new refs/stash entry ${stashRef} could not be verified as Signet's automatic stash`,
+								stashRef,
+							};
+						}
+
+						return { ok: true, stashRef };
+					});
+				}),
+		),
+	);
+}
+
+function readStashHeadWith(run: typeof runGit, repoPath: string, timeoutMs: number): string | null;
+function readStashHeadWith(run: typeof runGitAsync, repoPath: string, timeoutMs: number): Promise<string | null>;
+function readStashHeadWith(run: GitRunner, repoPath: string, timeoutMs: number): MaybePromise<string | null>;
+function readStashHeadWith(run: GitRunner, repoPath: string, timeoutMs: number): MaybePromise<string | null> {
+	return mapMaybePromise(run(["rev-parse", "--verify", "--quiet", "refs/stash"], repoPath, timeoutMs), (result) =>
+		readTrimmedValue(result),
+	);
+}
+
+function readStashSubjectWith(run: typeof runGit, repoPath: string, stashRef: string, timeoutMs: number): string | null;
+function readStashSubjectWith(
+	run: typeof runGitAsync,
+	repoPath: string,
+	stashRef: string,
+	timeoutMs: number,
+): Promise<string | null>;
+function readStashSubjectWith(
+	run: GitRunner,
+	repoPath: string,
+	stashRef: string,
+	timeoutMs: number,
+): MaybePromise<string | null>;
+function readStashSubjectWith(
+	run: GitRunner,
+	repoPath: string,
+	stashRef: string,
+	timeoutMs: number,
+): MaybePromise<string | null> {
+	return mapMaybePromise(run(["show", "-s", "--format=%s", stashRef], repoPath, timeoutMs), (result) =>
+		readTrimmedValue(result),
+	);
 }
 
 function parsePorcelainStatusPath(line: string): string | null {

--- a/platform/daemon/.gitignore
+++ b/platform/daemon/.gitignore
@@ -3,3 +3,6 @@
 /skills/
 
 /dist/
+
+# Bun emits this native addon next to the daemon bundle when building.
+/anydoc.*.node

--- a/platform/daemon/src/update-system.test.ts
+++ b/platform/daemon/src/update-system.test.ts
@@ -113,8 +113,8 @@ describe("Issue 322: verify installed version after update install", () => {
 				activeExecutablePath: "/home/test/.local/bin/signet",
 			},
 			{
-				syncWorkspaceSourceRepoAsync: async (dir) => {
-					calls.push(dir);
+				syncWorkspaceSourceRepoAsync: async (dir, options) => {
+					calls.push(`${dir}:${options?.localChanges ?? "skip"}`);
 					return {
 						status: "current",
 						path: join(dir, "signetai"),
@@ -130,7 +130,7 @@ describe("Issue 322: verify installed version after update install", () => {
 			},
 		);
 
-		expect(calls).toEqual([workspaceDir]);
+		expect(calls).toEqual([`${workspaceDir}:stash`]);
 		expect(result).toEqual({
 			success: true,
 			message: "Update installed. Restart daemon to apply.",
@@ -147,6 +147,39 @@ describe("Issue 322: verify installed version after update install", () => {
 			},
 		});
 		expect(getUpdateState().pendingRestartVersion).toBe("0.78.1");
+	});
+
+	it("reports the source stash restore command after a successful update", async () => {
+		const workspaceDir = join(tmpdir(), `signet-update-stash-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const repoPath = join(workspaceDir, "signetai");
+		const stashRef = "0123456789abcdef0123456789abcdef01234567";
+		initUpdateSystem("0.78.0", workspaceDir);
+
+		const result = await finalizeSuccessfulUpdateInstall(
+			"0.78.1",
+			"installed ok",
+			{
+				installMethod: "native",
+				activeExecutablePath: "/home/test/.local/bin/signet",
+			},
+			{
+				syncWorkspaceSourceRepoAsync: async () => ({
+					status: "pulled",
+					path: repoPath,
+					message: `pulled latest Signet source checkout; local changes were preserved in stash ${stashRef}`,
+					branch: "main",
+					defaultBranch: "main",
+					localChanges: "stashed",
+					stashRef,
+				}),
+				updateDesktopInstallAfterUpdate: async () => ({
+					status: "skipped",
+					message: "Signet desktop app is not installed",
+				}),
+			},
+		);
+
+		expect(result.message).toContain(`Restore with: git -C "${repoPath}" stash apply ${stashRef}`);
 	});
 
 	it("fires the onUpgraded lifecycle hook with (from, to) on success (issue #1026 Phase 2)", async () => {

--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -13,6 +13,7 @@ import {
 	type SignetInstallMethod,
 	type SignetInstallationReport,
 	type SignetUpdateTarget,
+	type WorkspaceSourceRepoSyncOptions,
 	type WorkspaceSourceRepoSyncResult,
 	detectSignetInstallations,
 	parseSimpleYaml,
@@ -541,7 +542,10 @@ export function normalizeTargetVersion(targetVersion: string | undefined): strin
 }
 
 interface FinalizeSuccessfulUpdateDeps {
-	syncWorkspaceSourceRepoAsync?: (workspaceDir: string) => Promise<WorkspaceSourceRepoSyncResult>;
+	syncWorkspaceSourceRepoAsync?: (
+		workspaceDir: string,
+		options?: WorkspaceSourceRepoSyncOptions,
+	) => Promise<WorkspaceSourceRepoSyncResult>;
 	updateDesktopInstallAfterUpdate?: (
 		repoSync: WorkspaceSourceRepoSyncResult,
 		installedVersion: string,
@@ -775,7 +779,7 @@ export async function finalizeSuccessfulUpdateInstall(
 	stdout: string,
 	metadata: SuccessfulUpdateMetadata,
 	deps: FinalizeSuccessfulUpdateDeps = {
-		syncWorkspaceSourceRepoAsync: (workspaceDir) => syncWorkspaceSourceRepoAsync(workspaceDir),
+		syncWorkspaceSourceRepoAsync: (workspaceDir, options) => syncWorkspaceSourceRepoAsync(workspaceDir, options),
 		updateDesktopInstallAfterUpdate: (repoSync, version, activeExecutablePath) =>
 			updateDesktopInstallAfterUpdate(repoSync, version, {
 				signetCliPath: activeExecutablePath,
@@ -789,8 +793,9 @@ export async function finalizeSuccessfulUpdateInstall(
 	let repoSync: WorkspaceSourceRepoSyncResult;
 	try {
 		repoSync = await (
-			deps.syncWorkspaceSourceRepoAsync ?? ((workspaceDir) => syncWorkspaceSourceRepoAsync(workspaceDir))
-		)(agentsDir);
+			deps.syncWorkspaceSourceRepoAsync ??
+			((workspaceDir, options) => syncWorkspaceSourceRepoAsync(workspaceDir, options))
+		)(agentsDir, { localChanges: "stash" });
 	} catch (error) {
 		repoSync = {
 			status: "error",
@@ -838,9 +843,10 @@ export async function finalizeSuccessfulUpdateInstall(
 
 	updateLogger.info("system", "Update installed successfully");
 	deps.onUpgraded?.(currentVersion, installedVersion);
+	const sourceChangesRecovery = repoSync.stashRef ? sourceChangesRecoveryMessage(repoSync) : "";
 	return {
 		success: true,
-		message: "Update installed. Restart daemon to apply.",
+		message: `Update installed. Restart daemon to apply.${sourceChangesRecovery}`,
 		output: stdout,
 		installedVersion,
 		restartRequired: true,
@@ -850,6 +856,11 @@ export async function finalizeSuccessfulUpdateInstall(
 		observedVersion: installedVersion,
 		desktopUpdate,
 	};
+}
+
+function sourceChangesRecoveryMessage(repoSync: WorkspaceSourceRepoSyncResult): string {
+	if (!repoSync.stashRef) return "";
+	return `\nLocal source changes were preserved in stash ${repoSync.stashRef}. Restore with: git -C "${repoSync.path}" stash apply ${repoSync.stashRef}`;
 }
 
 export async function runUpdate(targetVersion?: string, deps: RunUpdateDeps = {}): Promise<UpdateRunResult> {

--- a/surfaces/cli/src/commands/desktop.ts
+++ b/surfaces/cli/src/commands/desktop.ts
@@ -27,6 +27,7 @@ export function registerDesktopCommands(program: Command, deps: DesktopDeps): vo
 				console.log(chalk.green("✓ Signet desktop build complete"));
 				console.log(chalk.dim(`  Source:   ${result.repo}`));
 				console.log(chalk.dim(`  Artifacts: ${result.releaseDir}`));
+				printLocalChangeStatus(result);
 			} catch (err) {
 				console.error(chalk.red("Signet desktop build failed"));
 				console.error(chalk.red(err instanceof Error ? err.message : String(err)));
@@ -68,10 +69,26 @@ export function registerDesktopCommands(program: Command, deps: DesktopDeps): vo
 					console.log(chalk.dim(`  Workspace: ${result.workspace}`));
 					console.log(chalk.cyan("\n  Run: launch the Signet Desktop executable above"));
 				}
+				printLocalChangeStatus(result);
 			} catch (err) {
 				console.error(chalk.red("Signet desktop install failed"));
 				console.error(chalk.red(err instanceof Error ? err.message : String(err)));
 				process.exit(1);
 			}
 		});
+}
+
+function printLocalChangeStatus(result: DesktopBuildResult): void {
+	if (result.localChanges === "generated-only") {
+		console.log(chalk.dim("  Generated build artifacts were left in place during source sync."));
+		return;
+	}
+	if (result.localChanges === "left-in-place") {
+		console.log(chalk.yellow("  Local source changes were left in place during source sync."));
+		return;
+	}
+	if (result.localChanges !== "stashed" || !result.stashRef) return;
+
+	console.log(chalk.yellow(`  Local source changes were preserved in stash ${result.stashRef}.`));
+	console.log(chalk.dim(`  Restore: git -C "${result.repo}" stash apply ${result.stashRef}`));
 }

--- a/surfaces/cli/src/features/desktop.test.ts
+++ b/surfaces/cli/src/features/desktop.test.ts
@@ -166,7 +166,7 @@ describe("desktop source build", () => {
 					cwd: home,
 					env: { SIGNET_PATH: workspace },
 					syncWorkspaceSourceRepo: (workspaceDir, options) => {
-						expect(options).toEqual({ cloneIfMissing: true });
+						expect(options).toEqual({ cloneIfMissing: true, localChanges: "stash" });
 						calls.push(`sync ${workspaceDir}`);
 						return {
 							status: "pulled",
@@ -209,6 +209,66 @@ describe("desktop source build", () => {
 			expect(calls).toEqual([`bun install @ ${root}`, `bun run build:desktop @ ${root}`]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns the exact source stash when desktop build parks local changes", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		const stashRef = "0123456789abcdef0123456789abcdef01234567";
+		try {
+			const result = buildDesktopFromSource(
+				{},
+				{
+					cwd: home,
+					env: { SIGNET_PATH: join(home, "workspace") },
+					syncWorkspaceSourceRepo: () => ({
+						status: "pulled",
+						path: root,
+						message: `pulled latest Signet source checkout; local changes were preserved in stash ${stashRef}`,
+						branch: "main",
+						defaultBranch: "main",
+						localChanges: "stashed",
+						stashRef,
+					}),
+					runner: () => ({ status: 0 }),
+				},
+			);
+
+			expect(result).toMatchObject({ repo: root, localChanges: "stashed", stashRef });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps source stash recovery details when desktop build fails", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		const stashRef = "0123456789abcdef0123456789abcdef01234567";
+		try {
+			expect(() =>
+				buildDesktopFromSource(
+					{},
+					{
+						cwd: home,
+						env: { SIGNET_PATH: join(home, "workspace") },
+						syncWorkspaceSourceRepo: () => ({
+							status: "pulled",
+							path: root,
+							message: "pulled latest Signet source checkout",
+							branch: "main",
+							defaultBranch: "main",
+							localChanges: "stashed",
+							stashRef,
+						}),
+						runner: (_cmd, args) => ({ status: args.includes("build:desktop") ? 1 : 0 }),
+					},
+				),
+			).toThrow(`Local source changes were preserved in stash ${stashRef}`);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
 		}
 	});
 });
@@ -367,7 +427,7 @@ describe("linux desktop install", () => {
 					env: { SIGNET_PATH: workspace },
 					platform: "linux",
 					syncWorkspaceSourceRepo: (workspaceDir, options) => {
-						expect(options).toEqual({ cloneIfMissing: true });
+						expect(options).toEqual({ cloneIfMissing: true, localChanges: "stash" });
 						calls.push(`sync ${workspaceDir}`);
 						return {
 							status: "pulled",

--- a/surfaces/cli/src/features/desktop.ts
+++ b/surfaces/cli/src/features/desktop.ts
@@ -20,7 +20,11 @@ import {
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveWorkspaceSourceRepoPath, syncWorkspaceSourceRepo } from "@signet/core";
+import {
+	resolveWorkspaceSourceRepoPath,
+	syncWorkspaceSourceRepo,
+	type WorkspaceSourceRepoSyncResult,
+} from "@signet/core";
 import { resolveAgentsDir } from "../lib/workspace.js";
 
 export interface DesktopCommandOptions {
@@ -35,6 +39,8 @@ export interface DesktopInstallOptions extends DesktopCommandOptions {
 export interface DesktopBuildResult {
 	readonly repo: string;
 	readonly releaseDir: string;
+	readonly localChanges?: "none" | "generated-only" | "left-in-place" | "stashed";
+	readonly stashRef?: string;
 }
 
 export interface DesktopLinuxInstallResult extends DesktopBuildResult {
@@ -81,6 +87,11 @@ type CommandRunner = (
 	opts: { readonly cwd: string; readonly env: NodeJS.ProcessEnv },
 ) => CommandResult;
 
+interface PreparedDesktopSourceCheckout {
+	readonly repo: string;
+	readonly sourceSync?: WorkspaceSourceRepoSyncResult;
+}
+
 const defaultRunner: CommandRunner = (cmd, args, opts) =>
 	spawnSync(cmd, [...args], {
 		cwd: opts.cwd,
@@ -124,61 +135,115 @@ function desktopSourceCheckoutCandidates(ctx: Pick<DesktopCommandContext, "cwd" 
 	});
 }
 
-function prepareDesktopSourceCheckout(options: DesktopCommandOptions, ctx: DesktopCommandContext): string {
+function prepareDesktopSourceCheckout(
+	options: DesktopCommandOptions,
+	ctx: DesktopCommandContext,
+): PreparedDesktopSourceCheckout {
 	const env = ctx.env ?? process.env;
 	const explicit = options.repo?.trim() || env.SIGNET_SOURCE_DIR?.trim();
-	if (explicit || options.skipSourceSync) return resolveDesktopSourceCheckout(options.repo, ctx);
+	if (explicit || options.skipSourceSync) {
+		return { repo: resolveDesktopSourceCheckout(options.repo, ctx) };
+	}
 
 	const workspace = resolveAgentsDir(env).path;
-	const sync = (ctx.syncWorkspaceSourceRepo ?? syncWorkspaceSourceRepo)(workspace, { cloneIfMissing: true });
+	const sync = (ctx.syncWorkspaceSourceRepo ?? syncWorkspaceSourceRepo)(workspace, {
+		cloneIfMissing: true,
+		localChanges: "stash",
+	});
 	if (!["cloned", "pulled", "current"].includes(sync.status)) {
-		throw new Error(`Could not update Signet source checkout before desktop build: ${sync.message}`);
+		throw new Error(sourceSyncFailureMessage(sync));
 	}
-	return sync.path;
+	return { repo: sync.path, sourceSync: sync };
 }
 
 export function buildDesktopFromSource(
 	options: DesktopCommandOptions = {},
 	ctx: DesktopCommandContext = {},
 ): DesktopBuildResult {
-	const repo = prepareDesktopSourceCheckout(options, ctx);
+	const prepared = prepareDesktopSourceCheckout(options, ctx);
+	try {
+		buildDesktopAtRepo(prepared.repo, ctx);
+	} catch (error) {
+		throw sourceSyncFailure(error, prepared);
+	}
+
+	return withSourceSyncMetadata(
+		{ repo: prepared.repo, releaseDir: desktopReleaseDir(prepared.repo) },
+		prepared.sourceSync,
+	);
+}
+
+function buildDesktopAtRepo(repo: string, ctx: DesktopCommandContext): void {
 	const runner = ctx.runner ?? defaultRunner;
 	const env = ctx.env ?? process.env;
 
 	runChecked(runner, "bun", ["install"], repo, env);
 	runChecked(runner, "bun", ["run", "build:desktop"], repo, env);
-
-	return { repo, releaseDir: desktopReleaseDir(repo) };
 }
 
 export function installDesktopFromSource(
 	options: DesktopInstallOptions = {},
 	ctx: DesktopCommandContext = {},
 ): DesktopInstallResult {
-	const repo = options.skipBuild
-		? resolveDesktopSourceCheckout(options.repo, ctx)
+	const prepared = options.skipBuild
+		? { repo: resolveDesktopSourceCheckout(options.repo, ctx) }
 		: prepareDesktopSourceCheckout(options, ctx);
 	const workspace = resolveAgentsDir(ctx.env ?? process.env).path;
-	if (!options.skipBuild) {
-		buildDesktopFromSource({ repo, skipSourceSync: true }, ctx);
-	}
+	try {
+		if (!options.skipBuild) {
+			buildDesktopAtRepo(prepared.repo, ctx);
+		}
 
-	const platform = ctx.platform ?? process.platform;
-	const home = ctx.home ?? homedir();
-	if (platform === "darwin") {
-		return installMacDesktopApp(repo, home, workspace);
-	}
-	if (platform === "win32") {
-		const localAppData = ctx.env?.LOCALAPPDATA?.trim() || join(home, "AppData", "Local");
-		return installWindowsDesktopApp(repo, home, workspace, localAppData);
-	}
-	if (platform !== "linux") {
-		throw new Error(
-			`signet desktop install supports macOS, Windows, and Linux installs. Build artifacts are in ${desktopReleaseDir(repo)}.`,
-		);
-	}
+		const platform = ctx.platform ?? process.platform;
+		const home = ctx.home ?? homedir();
+		if (platform === "darwin") {
+			return withSourceSyncMetadata(installMacDesktopApp(prepared.repo, home, workspace), prepared.sourceSync);
+		}
+		if (platform === "win32") {
+			const localAppData = ctx.env?.LOCALAPPDATA?.trim() || join(home, "AppData", "Local");
+			return withSourceSyncMetadata(
+				installWindowsDesktopApp(prepared.repo, home, workspace, localAppData),
+				prepared.sourceSync,
+			);
+		}
+		if (platform !== "linux") {
+			throw new Error(
+				`signet desktop install supports macOS, Windows, and Linux installs. Build artifacts are in ${desktopReleaseDir(prepared.repo)}.`,
+			);
+		}
 
-	return installLinuxDesktopApp(repo, home, workspace);
+		return withSourceSyncMetadata(installLinuxDesktopApp(prepared.repo, home, workspace), prepared.sourceSync);
+	} catch (error) {
+		throw sourceSyncFailure(error, prepared);
+	}
+}
+
+function withSourceSyncMetadata<T extends DesktopBuildResult>(
+	result: T,
+	sourceSync: WorkspaceSourceRepoSyncResult | undefined,
+): T {
+	if (!sourceSync?.localChanges || sourceSync.localChanges === "none") return result;
+	return {
+		...result,
+		localChanges: sourceSync.localChanges,
+		...(sourceSync.stashRef ? { stashRef: sourceSync.stashRef } : {}),
+	};
+}
+
+function sourceSyncFailureMessage(sync: WorkspaceSourceRepoSyncResult): string {
+	const recovery = sync.stashRef ? `\n${sourceChangesRecoveryMessage(sync.path, sync.stashRef)}` : "";
+	return `Could not update Signet source checkout before desktop build: ${sync.message}${recovery}`;
+}
+
+function sourceSyncFailure(error: unknown, prepared: PreparedDesktopSourceCheckout): Error {
+	const original = error instanceof Error ? error : new Error(String(error));
+	const stashRef = prepared.sourceSync?.stashRef;
+	if (!stashRef) return original;
+	return new Error(`${original.message}\n${sourceChangesRecoveryMessage(prepared.repo, stashRef)}`);
+}
+
+function sourceChangesRecoveryMessage(repo: string, stashRef: string): string {
+	return `Local source changes were preserved in stash ${stashRef}. Restore with: git -C "${repo}" stash apply ${stashRef}`;
 }
 
 const MAC_APP_MARKER = "ai.signet.app";

--- a/web/docs/src/content/docs/getting-started/setup.md
+++ b/web/docs/src/content/docs/getting-started/setup.md
@@ -59,10 +59,15 @@ updates maintain an existing workspace checkout but do not create one.
 
 `signet desktop build` or `signet desktop install` explicitly creates the managed
 checkout when needed for a source build. Contributors can also clone the repository
-and pass `--repo` to the desktop command. Existing checkouts, local edits, and
-branches are preserved; this change does not delete or relocate them. If a managed
-desktop checkout was removed, rerun `signet desktop install` to restore its source
-build path before the next automatic desktop update.
+and pass `--repo` to the desktop command. Generated build output does not block
+managed default-branch checkout updates. Real local source changes on that checkout
+are preserved in a named Git stash when an update is needed, remain parked after
+success, and the command prints the exact stash and restore command. If the
+checkout is already current, local changes remain in place. Explicit
+`--repo` builds use that checkout without managed source synchronization. Other
+branches and unresolved merge conflicts remain untouched and stop the managed
+update. If a managed desktop checkout was removed, rerun `signet desktop install`
+to restore its source build path before the next automatic desktop update.
 
 The source-built desktop app installs to `~/Applications/Signet.app` on macOS and
 `%LOCALAPPDATA%\Programs\Signet Desktop` on Windows. These locations remain


### PR DESCRIPTION
## Summary

Make managed Signet source-checkout updates safe when the checkout contains local build output or user edits. During `signet desktop build`, `signet desktop install`, and automatic desktop updates, generated artifacts no longer block a fast-forward; tracked and untracked user changes are preserved when it is safe to update, while ambiguous checkouts are left untouched.

## Changes

- Classify working-tree state as clean, generated-only, user-modified, or unmerged, including generated native addons matching `platform/daemon/anydoc.*.node`.
- Keep generated desktop and native artifacts from blocking source updates.
- Have managed desktop build/install paths opt into preserving local changes. Callers that do not opt in retain the conservative behavior of leaving user changes in place.
- When a managed default-branch checkout tracks `origin` and is behind it:
  - create a named stash containing tracked and untracked user changes;
  - verify that Git created a new stash ref with the expected subject;
  - verify that the checkout is clean; and
  - fast-forward with `git merge --ff-only --no-edit`.
- Leave the verified stash parked instead of applying it automatically, and print the exact recovery command with its stash SHA.
- Leave branches, divergent commits, unmerged changes, unreadable status, and explicit `--repo` checkouts untouched rather than guessing how to reconcile them.
- Add regression coverage for sync, daemon update, and desktop build/install paths, plus setup documentation for the recovery behavior.

## Flow

![Desktop source sync behavior flowchart](https://github.com/user-attachments/assets/d449edb7-206c-446d-bd4d-370df6a1acb7)

## Type

- [x] `fix`: bug fix

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli`
- [x] Other: `@signet/docs`

## Screenshots

N/A: this changes CLI and source-update behavior; it does not change the dashboard, web, extension, or desktop application UI.

## Testing

### Automated validation

- `bun test platform/core/src/workspace-source-repo.test.ts`: 14 passed.
- `bun run --filter '@signet/core' typecheck`: passed.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/daemon' typecheck`: passed.
- `bun run --filter '@signet/cli' build:cli`: passed.
- `bun test platform/daemon/src/update-system.test.ts`: 37 passed; 3 existing Windows/path fixture failures.
- `bun test surfaces/cli/src/features/desktop.test.ts`: 23 passed; 4 existing Windows/POSIX fixture failures.
- Targeted Biome lint at error level and staged whitespace checks: passed.

The final `build:cli` stage succeeds, but the full CLI build wrapper remains blocked before that stage by the existing Windows `cp -r` prebuild script. The staged Biome hook also reports CRLF formatting in current Windows checkout files and four pre-existing `noTemplateCurlyInString` warnings in `update-system.test.ts`.

### Manual verification

Use a disposable managed checkout on the default branch:

1. Add one tracked edit, one untracked file, and a generated native addon such as `platform/daemon/anydoc.<platform>.node`.
2. Advance the remote default branch from a second checkout.
3. Run `signet desktop build` or `signet desktop install`.
4. Confirm that the update fast-forwards, the generated addon does not block it, and the tracked and untracked user changes are no longer in the worktree.
5. Copy the printed recovery command and run it. It should have this form:

   ```bash
   git -C "<managed checkout>" stash apply <stash-sha>
   ```

6. Confirm that the tracked edit and untracked file are restored.
7. Repeat with a non-default branch, a divergent checkout, unmerged changes, and an explicit `--repo`; confirm that each checkout is left unchanged.

## CI

The latest GitHub Actions run is not fully green. The [Enforce async DB accessor boundary check](https://github.com/Signet-AI/signetai/actions/runs/34353371146/job/102471845006) reports 23 passing tests and 1 failure because the committed event-loop ledger still contains older line numbers for `platform/daemon/src/update-system.ts`. The log shows that the source inventory and legacy marker count are unchanged; the mismatch is limited to shifted line numbers.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by: OpenAI Codex` in the commit)

## Notes

Stashes are intentionally parked and never auto-applied: a later build/install failure or merge conflict must not risk user data. Users receive the exact `git stash apply <sha>` command so recovery is explicit. No database migrations are included.
