### PR TITLE
fix: bound connector rows and clarify health status

### DIFF
--- a/integrations/forge/connector/dist/index.js
+++ b/integrations/forge/connector/dist/index.js
@@ -18397,7 +18397,7 @@ ${content}`);
   async inspectHealth() {
     try {
       if (this.isInstalled()) {
-        return { status: "degraded", message: "Integration detected; runtime health has not been verified." };
+        return { status: "unknown", message: "Integration detected; runtime health has not been verified." };
       }
       if (this.isDetected()) {
         return { status: "degraded", message: "Harness detected; Signet integration is not configured." };

--- a/libs/connector-base/src/index.ts
+++ b/libs/connector-base/src/index.ts
@@ -62,7 +62,7 @@ export interface UninstallResult {
 	configsPatched?: string[];
 }
 
-export type ConnectorHealthStatus = "healthy" | "degraded" | "unhealthy" | "needs-auth";
+export type ConnectorHealthStatus = "healthy" | "degraded" | "unhealthy" | "needs-auth" | "unknown";
 
 export interface ConnectorHealth {
 	status: ConnectorHealthStatus;
@@ -259,12 +259,12 @@ export abstract class BaseConnector {
 	/**
 	 * Inspect the connector's runtime health. Connectors with richer signals
 	 * may override this; the shared default only detects installation markers. It cannot verify
-	 * enabled configuration, runtime artifacts, or connectivity.
+	 * enabled configuration, runtime artifacts, or connectivity, so it reports an unknown state.
 	 */
 	async inspectHealth(): Promise<ConnectorHealth> {
 		try {
 			if (this.isInstalled()) {
-				return { status: "degraded", message: "Integration detected; runtime health has not been verified." };
+				return { status: "unknown", message: "Integration detected; runtime health has not been verified." };
 			}
 			if (this.isDetected()) {
 				return { status: "degraded", message: "Harness detected; Signet integration is not configured." };

--- a/platform/daemon/src/harness-registry.test.ts
+++ b/platform/daemon/src/harness-registry.test.ts
@@ -95,7 +95,7 @@ test("enumeration follows the supplied registry and isolates connector failures"
 		icon: "alpha.svg",
 		installed: true,
 		relevant: true,
-		health: { status: "degraded", checkedAt: "2026-09-09T12:01:00.000Z" },
+		health: { status: "unknown", checkedAt: "2026-09-09T12:01:00.000Z" },
 	});
 	expect(statuses.find((status) => status.id === "bravo")).toMatchObject({
 		configured: true,
@@ -158,7 +158,7 @@ test("installation markers do not report disabled or missing Codex runtime as he
 				new Date().toISOString(),
 			);
 			expect(result.installed).toBe(true);
-			expect(result.health.status).toBe("degraded");
+			expect(result.health.status).toBe("unknown");
 			expect(result.health.message).toContain("not been verified");
 		}
 	} finally {

--- a/platform/daemon/src/harness-registry.ts
+++ b/platform/daemon/src/harness-registry.ts
@@ -53,7 +53,7 @@ export interface HarnessConnectorStatus {
 
 export type HarnessRegistry = Readonly<Record<string, HarnessConnectorLoader>>;
 
-const HEALTH_STATUSES: readonly ConnectorHealthStatus[] = ["healthy", "degraded", "unhealthy", "needs-auth"];
+const HEALTH_STATUSES: readonly ConnectorHealthStatus[] = ["healthy", "degraded", "unhealthy", "needs-auth", "unknown"];
 
 function isHealthStatus(value: unknown): value is ConnectorHealthStatus {
 	return typeof value === "string" && HEALTH_STATUSES.some((status) => status === value);
@@ -79,7 +79,7 @@ function unavailableCapabilities(): ConnectorRecoveryCapabilities {
 
 function defaultHealth(installed: boolean, detected: boolean, checkedAt: string): HarnessConnectorHealth {
 	if (installed)
-		return { status: "degraded", message: "Integration detected; runtime health has not been verified.", checkedAt };
+		return { status: "unknown", message: "Integration detected; runtime health has not been verified.", checkedAt };
 	if (detected) {
 		return {
 			status: "degraded",

--- a/surfaces/dashboard/src/components/home/connectors.test.tsx
+++ b/surfaces/dashboard/src/components/home/connectors.test.tsx
@@ -114,6 +114,15 @@ describe("HomeConnectorsPanel", () => {
 						health: { status: "needs-auth", message: "Credentials expired.", checkedAt: new Date().toISOString() },
 					}),
 					connector({
+						id: "echo",
+						displayName: "Echo Harness",
+						health: {
+							status: "unknown",
+							message: "Integration detected; runtime health has not been verified.",
+							checkedAt: new Date().toISOString(),
+						},
+					}),
+					connector({
 						id: "ignored",
 						displayName: "Ignored Harness",
 						relevant: false,
@@ -127,13 +136,28 @@ describe("HomeConnectorsPanel", () => {
 			/>,
 		);
 
-		expect(mounted.container.querySelector('[data-testid="connector-count"]')?.textContent).toBe("4");
+		expect(mounted.container.querySelector('[data-testid="connector-count"]')?.textContent).toBe("5");
 		expect(mounted.container.textContent).toContain("Alpha Harness");
 		expect(mounted.container.textContent).toContain("Bravo Harness");
 		expect(mounted.container.textContent).toContain("Needs auth");
+		expect(mounted.container.textContent).toContain("Not verified");
 		expect(mounted.container.textContent).not.toContain("Ignored Harness");
 		expect(mounted.container.querySelector('[aria-label="Reinitialize Alpha Harness"]')).not.toBeNull();
 		expect(mounted.container.querySelector('img[src="/logos/alpha.svg"]')).not.toBeNull();
+
+		await act(async () => mounted.root.unmount());
+	});
+
+	test("bounds the connector rows in an inner scroll region", async () => {
+		const mounted = await mount(
+			<HomeConnectorsPanel result={response([connector()])} loading={false} onRefresh={() => undefined} />,
+		);
+
+		const rows = mounted.container.querySelector('[data-testid="connector-rows"]');
+		expect(rows).not.toBeNull();
+		expect(rows?.classList.contains("overflow-y-auto")).toBe(true);
+		expect(rows?.classList.contains("scrollbar-none")).toBe(true);
+		expect(rows?.getAttribute("aria-label")).toBe("Installed connector health");
 
 		await act(async () => mounted.root.unmount());
 	});

--- a/surfaces/dashboard/src/components/home/connectors.tsx
+++ b/surfaces/dashboard/src/components/home/connectors.tsx
@@ -27,6 +27,7 @@ const STATUS_LABELS: Record<HarnessConnectorHealthStatus, string> = {
 	degraded: "Degraded",
 	unhealthy: "Unhealthy",
 	"needs-auth": "Needs auth",
+	unknown: "Not verified",
 };
 
 const STATUS_CLASSES: Record<HarnessConnectorHealthStatus, string> = {
@@ -34,6 +35,7 @@ const STATUS_CLASSES: Record<HarnessConnectorHealthStatus, string> = {
 	degraded: "home-health-degraded",
 	unhealthy: "home-health-unhealthy",
 	"needs-auth": "home-health-needs-auth",
+	unknown: "home-health-unknown",
 };
 
 function actionLabel(action: RecoveryAction): string {
@@ -117,17 +119,41 @@ export function HomeConnectorsPanel({
 					No harness connectors installed.
 				</div>
 			) : (
-				<ul className="home-connectors-rows mt-1.5 list-none divide-y divide-border">
-					{connectors.map((connector) => (
-						<HomeConnectorRow
-							key={connector.id}
-							connector={connector}
-							globallyBusy={activeConnectorId !== null && activeConnectorId !== connector.id}
-							onRunning={(running) => setActiveConnectorId(running ? connector.id : null)}
-						/>
-					))}
-				</ul>
+				<HomeConnectorRows
+					connectors={connectors}
+					activeConnectorId={activeConnectorId}
+					onRunning={(id) => setActiveConnectorId(id)}
+				/>
 			)}
+		</section>
+	);
+}
+
+function HomeConnectorRows({
+	connectors,
+	activeConnectorId,
+	onRunning,
+}: {
+	connectors: readonly HarnessConnector[];
+	activeConnectorId: string | null;
+	onRunning: (id: string | null) => void;
+}) {
+	return (
+		<section
+			data-testid="connector-rows"
+			aria-label="Installed connector health"
+			className="home-connectors-rows mt-1.5 overflow-y-auto scrollbar-none"
+		>
+			<ul className="list-none divide-y divide-border">
+				{connectors.map((connector) => (
+					<HomeConnectorRow
+						key={connector.id}
+						connector={connector}
+						globallyBusy={activeConnectorId !== null && activeConnectorId !== connector.id}
+						onRunning={(running) => onRunning(running ? connector.id : null)}
+					/>
+				))}
+			</ul>
 		</section>
 	);
 }
@@ -208,7 +234,7 @@ function HomeConnectorRow({
 	return (
 		<>
 			<li
-				className="home-connector-row flex min-w-0 items-center gap-2.5 py-2.5"
+				className="home-connector-row flex min-w-0 items-center gap-2.5 px-0.5 py-2.5"
 				data-health={health.status}
 				aria-busy={running !== null}
 			>

--- a/surfaces/dashboard/src/index.css
+++ b/surfaces/dashboard/src/index.css
@@ -344,6 +344,7 @@
 	.home-health-degraded { color: var(--home-health-degraded); }
 	.home-health-unhealthy { color: var(--home-health-unhealthy); }
 	.home-health-needs-auth { color: var(--home-health-unhealthy); }
+	.home-health-unknown { color: var(--home-secondary, var(--muted-foreground)); }
 	.home-health-empty { color: var(--home-secondary); }
 	.home-status-healthy { background: var(--home-health-healthy); box-shadow: 0 0 6px color-mix(in srgb, var(--home-health-healthy) 45%, transparent); }
 	.home-status-warning { background: var(--home-health-degraded); box-shadow: 0 0 6px color-mix(in srgb, var(--home-health-degraded) 35%, transparent); }
@@ -367,6 +368,9 @@
 	.home-connector-row[data-health="unhealthy"] .home-connector-icon,
 	.home-connector-row[data-health="needs-auth"] .home-connector-icon { color: color-mix(in srgb, var(--home-health-unhealthy) 62%, var(--home-body)); }
 	.home-connector-row[data-health="degraded"] .home-connector-icon { color: color-mix(in srgb, var(--home-health-degraded) 68%, var(--home-body)); }
+	.home-connector-row[data-health="unknown"] .home-connector-icon { color: var(--home-secondary, var(--muted-foreground)); }
+	.home-connectors { min-height: 0; }
+	.home-connectors-rows { max-block-size: clamp(160px, 40dvh, 320px); overflow-x: hidden; overscroll-behavior: contain; }
 	.home-connector-action { display: inline-flex; min-height: 28px; align-items: center; gap: 5px; border: 1px solid var(--border); border-top-color: var(--home-edge, var(--border)); border-radius: 6px; padding-inline: 8px; background: var(--home-interactive, transparent); color: var(--home-meta, var(--muted-foreground)); font-size: 10.5px; font-weight: 400; white-space: nowrap; }
 	.home-connector-action:disabled { cursor: not-allowed; opacity: .45; }
 	.home-connector-actions { margin-inline-start: 6px; }

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -500,7 +500,7 @@ export interface SourcesResponse {
 	sources: SignetSource[];
 }
 
-export type HarnessConnectorHealthStatus = "healthy" | "degraded" | "unhealthy" | "needs-auth";
+export type HarnessConnectorHealthStatus = "healthy" | "degraded" | "unhealthy" | "needs-auth" | "unknown";
 
 export interface HarnessConnectorHealth {
 	status: HarnessConnectorHealthStatus;

--- a/web/docs/src/content/docs/remote-connectors.md
+++ b/web/docs/src/content/docs/remote-connectors.md
@@ -249,9 +249,11 @@ so merely supporting a harness does not add an unused row to the home page.
 The legacy `harnesses` and `configuredHarnesses` fields remain available to
 setup flows.
 
-Installation markers alone do not prove runtime health: the default inspection
-reports Degraded with an explicit unverified-health diagnostic. Healthy requires
-a connector-specific probe that validates its runtime. Inspection runs outside
+Installation markers alone do not prove runtime health: the shared default
+inspection reports Not verified with an explicit unverified-health diagnostic. A
+connector-specific probe may report Healthy, Degraded, or Needs auth when it can
+validate the corresponding runtime condition; registry-derived states such as a
+detected but unconfigured harness remain Degraded. Inspection runs outside
 the HTTP process in a child process, with a five-second deadline per connector. A timed
 out or failed inspection stays visible without suppressing other connectors.
 Requests cancel their child processes on disconnect; daemon shutdown waits for cleanup.


### PR DESCRIPTION
## Summary

Follow-up to #1900 for the two dashboard review notes: keep a large dynamic connector set inside the System rail, and avoid labeling an installed connector as degraded when no runtime probe has failed.

## Changes

- Bound the registry-driven connector rows in an inner, scrollbar-free scroll region so the rest of the System rail remains usable with 8+ connectors.
- Keep the connector count and row contents dynamic; the dashboard still has no independent harness list.
- Add an explicit `unknown` / `Not verified` health state for the shared installation-marker fallback.
- Preserve real connector-specific `Healthy`, `Degraded`, `Unhealthy`, and `Needs auth` results, including useful diagnostics.
- Update focused regression coverage and the connector health documentation.

## Testing

- `bun test src/harness-registry.test.ts src/harness-health.test.ts src/routes/harnesses-route.test.ts src/routes/harness-install.test.ts` — 7 passed.
- `bun test src/components/home/connectors.test.tsx src/views/home.test.tsx src/views/sources.test.tsx` — 23 passed.
- Full workspace typecheck passed via the repository pre-commit hook.
- Dashboard production build passed.
- Targeted Biome validation and `git diff --check` passed.
- Live headless browser verification at 1,558×1,314: 9 rows rendered in a 320px inner region; `scrollHeight` was 492px and `scrollTop` moved from 0 to 172px.

## Notes

- The current local daemon is an older compiled build, so the open browser still displays its previous degraded fallback until that daemon is rebuilt or restarted. The source path and tests now render installed-but-unprobed connectors as `Not verified`.
- No connector-specific health probes are currently implemented beyond the shared fallback; the normalized model remains ready for plugins to provide stronger signals.
